### PR TITLE
Update mobility prune UI and seed CBG styling

### DIFF
--- a/src/app/cz-generation/page.tsx
+++ b/src/app/cz-generation/page.tsx
@@ -5,15 +5,15 @@ import { useRouter } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useSession } from '@/lib/auth-client';
 import {
-  mergeGeoJsonFeatures,
-  normalizeCbgId,
-  getFeatureCbgId,
-  getBoundsForGeoJson,
   type GeoJSONData,
-  type LatLng
+  getBoundsForGeoJson,
+  getFeatureCbgId,
+  type LatLng,
+  mergeGeoJsonFeatures,
+  normalizeCbgId
 } from '@/lib/cz-geo';
-import type { ConvenienceZone } from '@/stores/simsettings';
 import { getStateFromCBG } from '@/lib/simulation-zone';
+import type { ConvenienceZone } from '@/stores/simsettings';
 import '@/styles/cz-generation.css';
 
 const InteractiveMap = dynamic(() => import('@/components/interactive-map'), {
@@ -27,7 +27,8 @@ const CLUSTER_ALGORITHM_OPTIONS = [
     label: 'Guided Connected Cities'
   },
   { value: 'greedy_fast', label: 'Greedy Fast' },
-  { value: 'greedy_weight_seed_guard', label: 'Greedy Weight + Seed Guard' }
+  { value: 'greedy_weight_seed_guard', label: 'Greedy Weight + Seed Guard' },
+  { value: 'mobility_prune', label: 'Mobility Prune' }
 ] as const;
 
 type ClusterAlgorithm = (typeof CLUSTER_ALGORITHM_OPTIONS)[number]['value'];
@@ -42,6 +43,8 @@ type TraceCandidate = {
   movement_to_outside?: number;
   movement_contributes_after_selection?: boolean;
   seed_distance_km?: number;
+  seed_movement_loss?: number;
+  seed_capture_after?: number;
   czi_after?: number;
   [key: string]: unknown;
 };
@@ -57,7 +60,7 @@ type TraceStep = {
 
 type TracePayload = {
   algorithm?: string;
-  algorithm_metadata?: HierarchicalAlgorithmMetadata | null;
+  algorithm_metadata?: ClusterAlgorithmMetadata | null;
   supports_stepwise?: boolean;
   steps?: TraceStep[];
   note?: string;
@@ -134,6 +137,40 @@ type HierarchicalAlgorithmMetadata = {
   population_target_met?: boolean;
 };
 
+type MobilityPruneAlgorithmMetadata = {
+  seed_cbgs?: string[];
+  missing_seed_cbgs?: string[];
+  seed_population?: number;
+  bounded_envelope?: boolean;
+  envelope_population_target?: number;
+  envelope_population_multiplier?: number;
+  envelope_population_floor?: number;
+  envelope_max_cbgs?: number;
+  min_seed_capture?: number;
+  envelope_growth_iterations?: number;
+  envelope_limited_by_cbg_cap?: boolean;
+  stopped_by_seed_capture_floor?: boolean;
+  initial_cbg_count?: number;
+  initial_population?: number;
+  initial_movement_inside?: number;
+  initial_movement_boundary?: number;
+  initial_czi?: number;
+  seed_movement_total?: number;
+  initial_seed_movement_captured?: number;
+  initial_seed_capture_share?: number;
+  final_seed_movement_captured?: number;
+  final_seed_capture_share?: number;
+  final_movement_inside?: number;
+  final_movement_boundary?: number;
+  final_czi?: number;
+  population_target_met?: boolean;
+  population_reduced?: number;
+  removed_cbg_count?: number;
+};
+
+type ClusterAlgorithmMetadata = HierarchicalAlgorithmMetadata &
+  MobilityPruneAlgorithmMetadata;
+
 type GuidedLinkedCbgDetail = {
   cbg?: string;
   population?: number;
@@ -208,11 +245,12 @@ type ClusteringPreviewResponse = {
   center?: [number, number] | null;
   size?: number | string;
   use_test_data?: boolean;
-  algorithm_metadata?: HierarchicalAlgorithmMetadata | null;
+  algorithm_metadata?: ClusterAlgorithmMetadata | null;
   trace?: TracePayload | null;
   algorithm?: string;
   clustering_params?: {
     seed_guard_distance_km?: number | string;
+    min_seed_capture?: number | string;
   } | null;
   geojson?: GeoJSONData | null;
   trace_geojson?: GeoJSONData | null;
@@ -545,6 +583,8 @@ export default function CZGeneration() {
   );
   const [showAdvancedClustering, setShowAdvancedClustering] = useState(false);
   const [seedGuardDistanceKm, setSeedGuardDistanceKm] = useState(20);
+  const [mobilityPruneMinSeedCapturePct, setMobilityPruneMinSeedCapturePct] =
+    useState(80);
   const [setupSeedCbg, setSetupSeedCbg] = useState('');
   const [setupSeedLabel, setSetupSeedLabel] = useState('');
   const [setupSeedCount, setSetupSeedCount] = useState(0);
@@ -567,13 +607,13 @@ export default function CZGeneration() {
   const [cbgGeoJSON, setCbgGeoJSON] = useState<GeoJSONData | null>(null);
   const [selectedCBGs, setSelectedCBGs] = useState<string[]>([]);
   const [seedCBG, setSeedCBG] = useState('');
-  const [, setTotalPopulation] = useState(0);
+  const [totalPopulation, setTotalPopulation] = useState(0);
   const [useTestData, setUseTestData] = useState(false);
   const [mapCenter, setMapCenter] = useState<[number, number] | null>(null);
   const [cityName, setCityName] = useState('');
   const [growthTrace, setGrowthTrace] = useState<TracePayload | null>(null);
   const [algorithmMetadata, setAlgorithmMetadata] =
-    useState<HierarchicalAlgorithmMetadata | null>(null);
+    useState<ClusterAlgorithmMetadata | null>(null);
   const [guidedMetadata, setGuidedMetadata] =
     useState<GuidedSecondOrderMetadata | null>(null);
   const [guidedDestinations, setGuidedDestinations] = useState<
@@ -614,12 +654,31 @@ export default function CZGeneration() {
   const isFinalizing = phase === 'finalizing';
   const isGuidedSecondOrderAlgorithm =
     clusterAlgorithm === 'guided_second_order_regions';
+  const isMobilityPruneAlgorithm = clusterAlgorithm === 'mobility_prune';
   const guidedSelectionMode = hasGenerated && isGuidedSecondOrderAlgorithm;
   const isTestLocationInput =
     String(location ?? '')
       .trim()
       .toUpperCase() === 'TEST';
   const traceSteps = growthTrace?.steps ?? [];
+  const mobilityPruneMetadata =
+    hasGenerated &&
+    isMobilityPruneAlgorithm &&
+    algorithmMetadata?.bounded_envelope
+      ? algorithmMetadata
+      : null;
+  const mapSeedCbgIds = useMemo(() => {
+    const source = algorithmMetadata?.seed_cbgs?.length
+      ? algorithmMetadata.seed_cbgs
+      : guidedSeedCbgs.length
+        ? guidedSeedCbgs
+        : seedCBG
+          ? [seedCBG]
+          : [];
+    return Array.from(
+      new Set(source.map((cbg) => normalizeCbgId(cbg)).filter(Boolean))
+    );
+  }, [algorithmMetadata, guidedSeedCbgs, seedCBG]);
   const maxTraceStep = traceSteps.length > 0 ? traceSteps.length - 1 : 0;
   const activeTraceStep =
     traceSteps[clampIndex(traceStepIndex, 0, maxTraceStep)] ?? null;
@@ -1289,6 +1348,15 @@ export default function CZGeneration() {
         req.seed_guard_distance_km = Number(seedGuardDistanceKm);
       }
     }
+    if (clusterAlgorithm === 'mobility_prune') {
+      const minSeedCapture = Number(mobilityPruneMinSeedCapturePct) / 100;
+      if (Number.isFinite(minSeedCapture)) {
+        req.mobility_prune_min_seed_capture = Math.min(
+          1,
+          Math.max(0, minSeedCapture)
+        );
+      }
+    }
 
     fetch(algUrl('frontier-candidates'), {
       method: 'POST',
@@ -1355,6 +1423,7 @@ export default function CZGeneration() {
     guidedSelectionMode,
     manualEditPanelsActive,
     minPop,
+    mobilityPruneMinSeedCapturePct,
     seedCBG,
     seedGuardDistanceKm,
     selectedCBGs,
@@ -1950,6 +2019,15 @@ export default function CZGeneration() {
           clusterReq.seed_guard_distance_km = Number(seedGuardDistanceKm);
         }
       }
+      if (clusterAlgorithm === 'mobility_prune') {
+        const minSeedCapture = Number(mobilityPruneMinSeedCapturePct) / 100;
+        if (Number.isFinite(minSeedCapture)) {
+          clusterReq.mobility_prune_min_seed_capture = Math.min(
+            1,
+            Math.max(0, minSeedCapture)
+          );
+        }
+      }
 
       if (coreCbg) {
         clusterReq.cbg = coreCbg;
@@ -2005,8 +2083,11 @@ export default function CZGeneration() {
       setAlgorithmMetadata(
         data.algorithm_metadata || data.trace?.algorithm_metadata || null
       );
+      const responseAlgorithm = isClusterAlgorithm(data.algorithm)
+        ? data.algorithm
+        : clusterAlgorithm;
       if (isClusterAlgorithm(data.algorithm)) {
-        setClusterAlgorithm(data.algorithm);
+        setClusterAlgorithm(responseAlgorithm);
       }
 
       if (
@@ -2020,10 +2101,23 @@ export default function CZGeneration() {
           setSeedGuardDistanceKm(rawThreshold);
         }
       }
+      if (data.clustering_params && data.algorithm === 'mobility_prune') {
+        const rawMinSeedCapture = Number(
+          data.clustering_params.min_seed_capture
+        );
+        if (Number.isFinite(rawMinSeedCapture)) {
+          setMobilityPruneMinSeedCapturePct(
+            Math.round(Math.min(1, Math.max(0, rawMinSeedCapture)) * 100)
+          );
+        }
+      }
 
       setGrowthTrace(data.trace || null);
       setTraceStepIndex(0);
-      setTraceEnabled(Boolean(data.trace?.steps?.length));
+      setTraceEnabled(
+        Boolean(data.trace?.steps?.length) &&
+          responseAlgorithm !== 'mobility_prune'
+      );
       setZoneEditMode(false);
       setManualFrontierCandidates([]);
       setManualFrontierError('');
@@ -2117,9 +2211,13 @@ export default function CZGeneration() {
         `Location: ${cityName || location || 'N/A'}`,
         `Seed CBG: ${seedCBG || 'N/A'}`,
         `Algorithm: ${algorithmLabel}`,
-        isGuidedSecondOrderAlgorithm
-          ? 'Minimum population filter: not used in guided connected cities mode'
-          : `Minimum population: ${Number(minPop || 0).toLocaleString()}`,
+        clusterAlgorithm === 'mobility_prune'
+          ? `Minimum seed movement captured: ${Number(
+              mobilityPruneMinSeedCapturePct || 0
+            ).toFixed(0)}%`
+          : isGuidedSecondOrderAlgorithm
+            ? 'Minimum population filter: not used in guided connected cities mode'
+            : `Minimum population: ${Number(minPop || 0).toLocaleString()}`,
         `Date range: ${startDate} to ${endDate}`,
         `CBGs in zone: ${selectedCBGs.length}`,
         `Test data mode: ${useTestData ? 'Yes' : 'No'}`
@@ -2171,7 +2269,6 @@ export default function CZGeneration() {
           `Seed guard distance (km): ${seedGuardDistanceKm}`
         );
       }
-
       const descriptionToSave =
         trimmedDescription || generatedDescription.join('\n');
       if (!trimmedDescription) {
@@ -2508,6 +2605,7 @@ coupling =
                     }
                     selectedCBGs={selectedCBGs}
                     seedCbgId={seedCBG}
+                    seedCbgIds={mapSeedCbgIds}
                     seedGuardRadiusKm={seedGuardDistanceKm}
                     showSeedGuardCircle={
                       clusterAlgorithm === 'greedy_weight_seed_guard'
@@ -2996,10 +3094,38 @@ coupling =
                               : 'No'}
                           </div>
                         )}
+                        {selectedAnalysisCandidate.seed_movement_loss !==
+                          undefined && (
+                          <div>
+                            <span className="font-semibold">
+                              Seed Movement Lost:
+                            </span>{' '}
+                            {Number(
+                              selectedAnalysisCandidate.seed_movement_loss ?? 0
+                            ).toLocaleString(undefined, {
+                              maximumFractionDigits: 1
+                            })}
+                          </div>
+                        )}
+                        {selectedAnalysisCandidate.seed_capture_after !==
+                          undefined && (
+                          <div>
+                            <span className="font-semibold">
+                              Seed Capture After Selection:
+                            </span>{' '}
+                            {(
+                              Number(
+                                selectedAnalysisCandidate.seed_capture_after ??
+                                  0
+                              ) * 100
+                            ).toFixed(1)}
+                            %
+                          </div>
+                        )}
                         {selectedAnalysisCandidate.czi_after !== undefined && (
                           <div>
                             <span className="font-semibold">
-                              CZI After Add:
+                              Zone CZI After Selection:
                             </span>{' '}
                             {Number(
                               selectedAnalysisCandidate.czi_after ?? 0
@@ -3115,7 +3241,130 @@ coupling =
               ) : (
                 <>
                   <div>
-                    {showTraceControls ? (
+                    {mobilityPruneMetadata ? (
+                      <>
+                        <div className="text-sm font-semibold mb-2">
+                          Mobility Prune Summary
+                        </div>
+                        <div className="flex flex-wrap gap-2 text-xs text-gray-700">
+                          <div className="rounded-full border border-[#dbeafe] bg-white px-3 py-1">
+                            <span className="font-semibold text-[#1f2937]">
+                              Final Zone:
+                            </span>{' '}
+                            {selectedCBGs.length} CBGs, pop{' '}
+                            {Number(totalPopulation || 0).toLocaleString()}
+                          </div>
+                          <div className="rounded-full border border-[#dbeafe] bg-white px-3 py-1">
+                            <span className="font-semibold text-[#1f2937]">
+                              Seed Pop:
+                            </span>{' '}
+                            {Number(
+                              mobilityPruneMetadata.seed_population ?? 0
+                            ).toLocaleString()}
+                          </div>
+                          <div className="rounded-full border border-[#dbeafe] bg-white px-3 py-1">
+                            <span className="font-semibold text-[#1f2937]">
+                              Envelope:
+                            </span>{' '}
+                            {Number(
+                              mobilityPruneMetadata.initial_cbg_count ?? 0
+                            ).toLocaleString()}{' '}
+                            CBGs, pop{' '}
+                            {Number(
+                              mobilityPruneMetadata.initial_population ?? 0
+                            ).toLocaleString()}
+                          </div>
+                          <div className="rounded-full border border-[#dbeafe] bg-white px-3 py-1">
+                            <span className="font-semibold text-[#1f2937]">
+                              Envelope Target:
+                            </span>{' '}
+                            {Number(
+                              mobilityPruneMetadata.envelope_population_target ??
+                                0
+                            ).toLocaleString()}
+                          </div>
+                          <div className="rounded-full border border-[#dbeafe] bg-white px-3 py-1">
+                            <span className="font-semibold text-[#1f2937]">
+                              Pruned:
+                            </span>{' '}
+                            {Number(
+                              mobilityPruneMetadata.removed_cbg_count ?? 0
+                            ).toLocaleString()}{' '}
+                            CBGs, pop{' '}
+                            {Number(
+                              mobilityPruneMetadata.population_reduced ?? 0
+                            ).toLocaleString()}
+                          </div>
+                          <div className="rounded-full border border-[#dbeafe] bg-white px-3 py-1">
+                            <span className="font-semibold text-[#1f2937]">
+                              Minimum Seed Capture:
+                            </span>{' '}
+                            {Number(
+                              (mobilityPruneMetadata.min_seed_capture ?? 0) *
+                                100
+                            ).toFixed(0)}
+                            %
+                          </div>
+                          <div className="rounded-full border border-[#dbeafe] bg-white px-3 py-1">
+                            <span className="font-semibold text-[#1f2937]">
+                              Seed Capture:
+                            </span>{' '}
+                            {Number(
+                              (mobilityPruneMetadata.final_seed_capture_share ??
+                                0) * 100
+                            ).toFixed(1)}
+                            %
+                          </div>
+                        </div>
+                        {showTraceControls &&
+                          growthTrace?.supports_stepwise &&
+                          traceSteps.length > 0 && (
+                            <div className="mt-3 border-t border-[#dbeafe] pt-3">
+                              <label className="flex items-center gap-2 text-xs">
+                                <input
+                                  type="checkbox"
+                                  checked={traceEnabled}
+                                  onChange={(e) =>
+                                    setTraceEnabled(e.target.checked)
+                                  }
+                                />
+                                Show pruning trace heat map
+                              </label>
+                              {traceEnabled && (
+                                <>
+                                  <div className="mt-2 text-xs text-gray-600">
+                                    Step{' '}
+                                    {Math.min(traceStepIndex, maxTraceStep) + 1}{' '}
+                                    of {traceSteps.length}
+                                  </div>
+                                  <div className="mt-2 flex gap-2">
+                                    <button
+                                      type="button"
+                                      className="px-2 py-1 text-xs rounded border border-[#70B4D4] disabled:opacity-40"
+                                      disabled={traceStepIndex <= 0}
+                                      onClick={() =>
+                                        jumpToTraceStep(traceStepIndex - 1)
+                                      }
+                                    >
+                                      Previous Step
+                                    </button>
+                                    <button
+                                      type="button"
+                                      className="px-2 py-1 text-xs rounded border border-[#70B4D4] disabled:opacity-40"
+                                      disabled={traceStepIndex >= maxTraceStep}
+                                      onClick={() =>
+                                        jumpToTraceStep(traceStepIndex + 1)
+                                      }
+                                    >
+                                      Next Step
+                                    </button>
+                                  </div>
+                                </>
+                              )}
+                            </div>
+                          )}
+                      </>
+                    ) : showTraceControls ? (
                       <>
                         <div className="text-sm font-semibold mb-2">
                           Trace Controls
@@ -3264,7 +3513,7 @@ coupling =
                       </div>
                     )}
 
-                  {algorithmMetadata && (
+                  {algorithmMetadata && !algorithmMetadata.bounded_envelope && (
                     <div className="min-w-[16rem] max-w-[22rem] flex flex-col gap-1 text-xs text-gray-700">
                       <div className="text-sm font-semibold text-[#1f2937]">
                         Hierarchy Summary
@@ -3440,7 +3689,28 @@ coupling =
                 </div>
 
                 <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-                  {!isGuidedSecondOrderAlgorithm && (
+                  {clusterAlgorithm === 'mobility_prune' ? (
+                    <div className="w-full">
+                      <FormField
+                        label="Minimum Seed Movement Captured (%)"
+                        name="mobility_prune_min_seed_capture"
+                        type="number"
+                        value={mobilityPruneMinSeedCapturePct}
+                        min={0}
+                        max={100}
+                        onChange={(e) =>
+                          setMobilityPruneMinSeedCapturePct(
+                            Number(e.target.value)
+                          )
+                        }
+                        disabled={loading}
+                      />
+                      <div className="mt-1 text-xs text-gray-600">
+                        Pruning stops before a removal would drop captured seed
+                        movement below this threshold.
+                      </div>
+                    </div>
+                  ) : !isGuidedSecondOrderAlgorithm ? (
                     <div className="w-full">
                       <FormField
                         label="Minimum Population"
@@ -3453,7 +3723,7 @@ coupling =
                         disabled={loading}
                       />
                     </div>
-                  )}
+                  ) : null}
                   <div className="w-full sm:col-span-2">
                     <FormField
                       label="Clustering Algorithm"
@@ -3594,6 +3864,14 @@ coupling =
                     connected cities by how much travel they share with it, and
                     asks you which connected cities should contribute linked
                     CBGs to the explicit simulation.
+                  </div>
+                )}
+
+                {clusterAlgorithm === 'mobility_prune' && (
+                  <div className="rounded-lg border border-[#70B4D4] bg-[#eff6ff] px-3 py-2 text-xs text-[#1e3a8a]">
+                    This mode grows a large mobility envelope, then prunes low
+                    seed-capture CBGs while preserving the seed CBGs' movement
+                    field.
                   </div>
                 )}
 

--- a/src/components/cbg-map.tsx
+++ b/src/components/cbg-map.tsx
@@ -1,18 +1,18 @@
 'use client';
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Layer, Map as MapLibreMap, Source } from 'react-map-gl/maplibre';
 import type { MapRef } from 'react-map-gl/maplibre';
+import { Layer, Map as MapLibreMap, Source } from 'react-map-gl/maplibre';
 import 'maplibre-gl/dist/maplibre-gl.css';
 import {
   createCircleGeoJson,
+  type GeoJSONData,
+  type GeoJSONFeature,
   getBoundsForGeoJson,
   getFeatureCbgId,
   getFeatureCenterFromGeoJson,
-  normalizeCbgId,
-  type GeoJSONFeature,
-  type GeoJSONData,
-  type LatLng
+  type LatLng,
+  normalizeCbgId
 } from '@/lib/cz-geo';
 
 const TRACE_LOW_COLOR = '#fde68a';
@@ -32,6 +32,11 @@ type TraceLayerData = {
   selectedCbg?: string;
   minScore: number;
   maxScore: number;
+};
+
+type SelectionStyle = {
+  fillColor: string;
+  lineColor: string;
 };
 
 function clamp(value: number, min: number, max: number) {
@@ -56,8 +61,7 @@ function hexToRgb(hex: string) {
 }
 
 function rgbToHex({ r, g, b }: { r: number; g: number; b: number }) {
-  const toHex = (component: number) =>
-    component.toString(16).padStart(2, '0');
+  const toHex = (component: number) => component.toString(16).padStart(2, '0');
   return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
 }
 
@@ -73,11 +77,6 @@ function interpolateHexColor(startHex: string, endHex: string, t: number) {
   });
 }
 
-type SelectionStyle = {
-  fillColor: string;
-  lineColor: string;
-};
-
 export default function CBGMap({
   cbgData,
   center = null,
@@ -86,6 +85,7 @@ export default function CBGMap({
   onTraceCbgInspect = null,
   selectedCBGs,
   seedCbgId = '',
+  seedCbgIds = [],
   seedGuardRadiusKm = 0,
   showSeedGuardCircle = false,
   traceLayer = null,
@@ -98,9 +98,12 @@ export default function CBGMap({
   center?: [number, number] | null;
   onCBGClick: (cbgId: string, properties: Record<string, unknown>) => void;
   onMapBackgroundClick: (latlng: LatLng) => void;
-  onTraceCbgInspect?: ((cbgId: string, properties: Record<string, unknown>) => void) | null;
+  onTraceCbgInspect?:
+    | ((cbgId: string, properties: Record<string, unknown>) => void)
+    | null;
   selectedCBGs: string[];
   seedCbgId?: string;
+  seedCbgIds?: string[];
   seedGuardRadiusKm?: number;
   showSeedGuardCircle?: boolean;
   traceLayer?: TraceLayerData | null;
@@ -113,6 +116,22 @@ export default function CBGMap({
   const hasFittedRef = useRef(false);
   const lastFocusedTargetRef = useRef('');
   const [hoverCbgId, setHoverCbgId] = useState<string | null>(null);
+  const selectedCbgSet = useMemo(
+    () =>
+      new Set(
+        selectedCBGs.map((cbgId) => normalizeCbgId(cbgId)).filter(Boolean)
+      ),
+    [selectedCBGs]
+  );
+  const seedCbgSet = useMemo(
+    () =>
+      new Set(
+        [...seedCbgIds, seedCbgId]
+          .map((cbgId) => normalizeCbgId(cbgId))
+          .filter(Boolean)
+      ),
+    [seedCbgId, seedCbgIds]
+  );
 
   const seedCircleCenter = useMemo(
     () =>
@@ -135,16 +154,12 @@ export default function CBGMap({
       return null;
     }
 
-    const selectedSet = new Set(
-      selectedCBGs.map((cbgId) => normalizeCbgId(cbgId)).filter(Boolean)
-    );
-
-    if (!selectedSet.size) {
+    if (!selectedCbgSet.size) {
       return cbgData;
     }
 
     const selectedFeatures = cbgData.features.filter((feature) =>
-      selectedSet.has(getFeatureCbgId(feature))
+      selectedCbgSet.has(getFeatureCbgId(feature))
     );
 
     if (!selectedFeatures.length) {
@@ -155,7 +170,7 @@ export default function CBGMap({
       type: 'FeatureCollection',
       features: selectedFeatures
     };
-  }, [cbgData, selectedCBGs]);
+  }, [cbgData, selectedCbgSet]);
 
   const bounds = useMemo(
     () => getBoundsForGeoJson(initialFitGeoJson),
@@ -195,15 +210,22 @@ export default function CBGMap({
           ...(() => {
             const cbgId = getFeatureCbgId(f);
             const isFocused = cbgId === focusedCbgId;
-            const candidate = cbgId ? traceLayer?.candidateByCbg.get(cbgId) : null;
+            const isSeed = seedCbgSet.has(cbgId);
+            const candidate = cbgId
+              ? traceLayer?.candidateByCbg.get(cbgId)
+              : null;
 
             if (traceLayer) {
               if (traceLayer.clusterSet.has(cbgId)) {
                 return {
-                  _fill_color: '#1d4ed8',
-                  _fill_opacity: 0.74,
-                  _line_color: isFocused ? '#0f172a' : '#1e3a8a',
-                  _line_width: isFocused ? 4 : 2.25
+                  _fill_color: isSeed ? '#10b981' : '#1d4ed8',
+                  _fill_opacity: isSeed ? 0.86 : 0.74,
+                  _line_color: isFocused
+                    ? '#0f172a'
+                    : isSeed
+                      ? '#065f46'
+                      : '#1e3a8a',
+                  _line_width: isFocused ? 4 : isSeed ? 3 : 2.25
                 };
               }
 
@@ -218,7 +240,9 @@ export default function CBGMap({
 
               if (candidate) {
                 return {
-                  _fill_color: getCandidateHeatColor(Number(candidate.score ?? 0)),
+                  _fill_color: getCandidateHeatColor(
+                    Number(candidate.score ?? 0)
+                  ),
                   _fill_opacity: 0.75,
                   _line_color: isFocused ? '#0f172a' : '#7c2d12',
                   _line_width: isFocused ? 4 : 2
@@ -233,31 +257,47 @@ export default function CBGMap({
               };
             }
 
-            const customStyle = selectionStyleByCbg?.get(cbgId);
-            if (customStyle) {
+            const selectionStyle = cbgId
+              ? selectionStyleByCbg?.get(cbgId)
+              : null;
+            if (selectionStyle && !selectedCbgSet.has(cbgId)) {
               return {
-                _fill_color: customStyle.fillColor,
+                _fill_color: selectionStyle.fillColor,
                 _fill_opacity: 0.6,
-                _line_color: isFocused ? '#0f172a' : customStyle.lineColor,
+                _line_color: isFocused ? '#0f172a' : selectionStyle.lineColor,
                 _line_width: isFocused ? 4 : 2
               };
             }
-            const isSelected = selectedCBGs.includes(cbgId);
+            const isSelected = selectedCbgSet.has(cbgId);
             return {
-              _fill_color: isSelected ? '#70B4D4' : '#BDBDBD',
-              _fill_opacity: isSelected ? 0.6 : 0.2,
+              _fill_color: isSelected
+                ? isSeed
+                  ? '#10b981'
+                  : selectionStyle?.fillColor || '#70B4D4'
+                : '#BDBDBD',
+              _fill_opacity: isSelected ? (isSeed ? 0.82 : 0.6) : 0.2,
               _line_color: isFocused
                 ? '#0f172a'
                 : isSelected
-                  ? '#1f2937'
+                  ? isSeed
+                    ? '#065f46'
+                    : selectionStyle?.lineColor || '#1f2937'
                   : '#6b7280',
-              _line_width: isFocused ? 4 : isSelected ? 2 : 1.25
+              _line_width: isFocused ? 4 : isSelected ? (isSeed ? 3 : 2) : 1.25
             };
           })()
         }
       }))
     };
-  }, [cbgData, focusedCbgId, getCandidateHeatColor, selectedCBGs, selectionStyleByCbg, traceLayer]);
+  }, [
+    cbgData,
+    focusedCbgId,
+    getCandidateHeatColor,
+    selectedCbgSet,
+    seedCbgSet,
+    selectionStyleByCbg,
+    traceLayer
+  ]);
 
   const focusedFeature = useMemo<GeoJSONFeature | null>(
     () =>
@@ -287,7 +327,10 @@ export default function CBGMap({
   }, [fitBoundsToData]);
 
   const handleClick = useCallback(
-    (e: { lngLat: { lat: number; lng: number }; features?: { properties?: Record<string, unknown> }[] }) => {
+    (e: {
+      lngLat: { lat: number; lng: number };
+      features?: { properties?: Record<string, unknown> }[];
+    }) => {
       const feature = e.features?.[0];
       if (feature?.properties) {
         const cbgId = (feature.properties._cbg_id as string) || '';
@@ -307,7 +350,13 @@ export default function CBGMap({
         onMapBackgroundClick({ lat: e.lngLat.lat, lng: e.lngLat.lng });
       }
     },
-    [editingEnabled, onCBGClick, onMapBackgroundClick, onTraceCbgInspect, traceLayer]
+    [
+      editingEnabled,
+      onCBGClick,
+      onMapBackgroundClick,
+      onTraceCbgInspect,
+      traceLayer
+    ]
   );
 
   const handleMouseLeave = useCallback(() => {
@@ -325,9 +374,18 @@ export default function CBGMap({
 
   // Hover highlight filter
   const hoverFilter = useMemo(
-    () => hoverCbgId
-      ? ['==', ['get', '_cbg_id'], hoverCbgId] as unknown as maplibregl.ExpressionSpecification
-      : ['==', ['get', '_cbg_id'], ''] as unknown as maplibregl.ExpressionSpecification,
+    () =>
+      hoverCbgId
+        ? ([
+            '==',
+            ['get', '_cbg_id'],
+            hoverCbgId
+          ] as unknown as maplibregl.ExpressionSpecification)
+        : ([
+            '==',
+            ['get', '_cbg_id'],
+            ''
+          ] as unknown as maplibregl.ExpressionSpecification),
     [hoverCbgId]
   );
 
@@ -365,83 +423,101 @@ export default function CBGMap({
   }, [focusTarget, focusedFeature]);
 
   return (
-    <MapLibreMap
-      ref={mapRef}
-      initialViewState={{
-        latitude: center?.[0] ?? 39.3291,
-        longitude: center?.[1] ?? -76.6220,
-        zoom: 12
-      }}
-      style={{ width: '100%', height: '100%' }}
-      mapStyle="https://basemaps.cartocdn.com/gl/positron-gl-style/style.json"
-      interactiveLayerIds={['cbg-fill']}
-      onLoad={handleMapLoad}
-      onClick={handleClick}
-      onMouseMove={handleMapMouseMove}
-      onMouseLeave={handleMouseLeave}
-      cursor={hoverCbgId ? 'pointer' : ''}
-    >
-      {seedCircleGeoJSON && (
+    <div className="relative h-full w-full">
+      <MapLibreMap
+        ref={mapRef}
+        initialViewState={{
+          latitude: center?.[0] ?? 39.3291,
+          longitude: center?.[1] ?? -76.622,
+          zoom: 12
+        }}
+        style={{ width: '100%', height: '100%' }}
+        mapStyle="https://basemaps.cartocdn.com/gl/positron-gl-style/style.json"
+        interactiveLayerIds={['cbg-fill']}
+        onLoad={handleMapLoad}
+        onClick={handleClick}
+        onMouseMove={handleMapMouseMove}
+        onMouseLeave={handleMouseLeave}
+        cursor={hoverCbgId ? 'pointer' : ''}
+      >
+        {seedCircleGeoJSON && (
+          <Source
+            id="seed-guard-circle"
+            type="geojson"
+            data={seedCircleGeoJSON as GeoJSON.FeatureCollection}
+          >
+            <Layer
+              id="seed-guard-circle-fill"
+              type="fill"
+              paint={{
+                'fill-color': '#60a5fa',
+                'fill-opacity': 0.06
+              }}
+            />
+            <Layer
+              id="seed-guard-circle-line"
+              type="line"
+              paint={{
+                'line-color': '#2563eb',
+                'line-width': 2,
+                'line-dasharray': [3, 2]
+              }}
+            />
+          </Source>
+        )}
         <Source
-          id="seed-guard-circle"
+          id="cbg-data"
           type="geojson"
-          data={seedCircleGeoJSON as GeoJSON.FeatureCollection}
+          data={taggedData as GeoJSON.FeatureCollection}
         >
           <Layer
-            id="seed-guard-circle-fill"
+            id="cbg-fill"
             type="fill"
             paint={{
-              'fill-color': '#60a5fa',
-              'fill-opacity': 0.06
+              'fill-color': ['get', '_fill_color'],
+              'fill-opacity': ['get', '_fill_opacity']
             }}
           />
           <Layer
-            id="seed-guard-circle-line"
+            id="cbg-outline"
             type="line"
             paint={{
-              'line-color': '#2563eb',
-              'line-width': 2,
-              'line-dasharray': [3, 2]
+              'line-color': ['get', '_line_color'],
+              'line-width': ['get', '_line_width']
+            }}
+          />
+          <Layer
+            id="cbg-hover"
+            type="fill"
+            filter={hoverFilter}
+            paint={{
+              'fill-color': '#70B4D4',
+              'fill-opacity': 0.9
+            }}
+          />
+          <Layer
+            id="cbg-hover-outline"
+            type="line"
+            filter={hoverFilter}
+            paint={{
+              'line-color': '#1f2937',
+              'line-width': 3
             }}
           />
         </Source>
+      </MapLibreMap>
+      {selectedCbgSet.size > 0 && seedCbgSet.size > 0 && (
+        <div className="pointer-events-none absolute bottom-3 left-3 rounded-md border border-gray-200 bg-white/95 px-3 py-2 text-xs font-medium text-gray-700 shadow-sm">
+          <div className="flex items-center gap-2">
+            <span className="h-3 w-3 rounded-sm border border-[#065f46] bg-[#10b981]" />
+            <span>Seed CBGs</span>
+          </div>
+          <div className="mt-1 flex items-center gap-2">
+            <span className="h-3 w-3 rounded-sm border border-[#1f2937] bg-[#70B4D4]" />
+            <span>Zone CBGs</span>
+          </div>
+        </div>
       )}
-      <Source id="cbg-data" type="geojson" data={taggedData as GeoJSON.FeatureCollection}>
-        <Layer
-          id="cbg-fill"
-          type="fill"
-          paint={{
-            'fill-color': ['get', '_fill_color'],
-            'fill-opacity': ['get', '_fill_opacity']
-          }}
-        />
-        <Layer
-          id="cbg-outline"
-          type="line"
-          paint={{
-            'line-color': ['get', '_line_color'],
-            'line-width': ['get', '_line_width']
-          }}
-        />
-        <Layer
-          id="cbg-hover"
-          type="fill"
-          filter={hoverFilter}
-          paint={{
-            'fill-color': '#70B4D4',
-            'fill-opacity': 0.9
-          }}
-        />
-        <Layer
-          id="cbg-hover-outline"
-          type="line"
-          filter={hoverFilter}
-          paint={{
-            'line-color': '#1f2937',
-            'line-width': 3
-          }}
-        />
-      </Source>
-    </MapLibreMap>
+    </div>
   );
 }


### PR DESCRIPTION
Updates the CZ generation UI for the seed-capture mobility prune workflow. Summary: shows the minimum seed movement captured control for Mobility Prune; sends mobility_prune_min_seed_capture to the backend; displays mobility-prune stats without defaulting to trace view; styles seed CBGs separately from final zone CBGs with a map legend. Verification: biome check src/components/cbg-map.tsx src/app/cz-generation/page.tsx; pnpm exec tsc --noEmit --pretty false.