### PR TITLE
Fix intervention timeline defaults and validation

### DIFF
--- a/src/components/intervention-timeline.tsx
+++ b/src/components/intervention-timeline.tsx
@@ -1,10 +1,45 @@
 'use client';
 
 import { useEffect, useMemo, useRef, useState } from 'react';
-import useSimSettings from '@/stores/simsettings';
+import useSimSettings, {
+  DEFAULT_INTERVENTIONS,
+  type Interventions as InterventionSettings
+} from '@/stores/simsettings';
 
 import '@/styles/intervention-timeline.css';
 import Interventions from './interventions';
+
+const INTERVENTION_VALUE_KEYS = [
+  'mask',
+  'vaccine',
+  'capacity',
+  'lockdown',
+  'selfiso'
+] as const satisfies readonly (keyof Omit<InterventionSettings, 'time'>)[];
+
+function interventionSettingsMatch(
+  a: InterventionSettings,
+  b: InterventionSettings
+) {
+  return INTERVENTION_VALUE_KEYS.every((key) => a[key] === b[key]);
+}
+
+function getEffectiveInterventionAt(
+  time: number,
+  interventions: InterventionSettings[]
+) {
+  const sorted = [...interventions].sort((a, b) => a.time - b.time);
+  const first = sorted[0];
+  if (!first) return null;
+
+  let active = first;
+  for (const intervention of sorted) {
+    if (intervention.time > time) break;
+    active = intervention;
+  }
+
+  return active;
+}
 
 export default function InterventionTimeline() {
   const hours = useSimSettings((state) => state.hours);
@@ -18,6 +53,7 @@ export default function InterventionTimeline() {
   );
 
   const [curtime, setCurtime] = useState(0);
+  const [timelineError, setTimelineError] = useState<string | null>(null);
   const values = useMemo(
     () =>
       Array.from(new Set(interventions.map((intervention) => intervention.time))).sort(
@@ -25,7 +61,6 @@ export default function InterventionTimeline() {
       ),
     [interventions]
   );
-  const timelineValues = values.filter((value) => value > 0);
   const dragTimeRef = useRef<number | null>(null);
   const pointerDragRef = useRef(false);
   const valuesRef = useRef(values);
@@ -35,16 +70,34 @@ export default function InterventionTimeline() {
     valuesRef.current = values;
   }, [values]);
 
+  const addInterventionAt = (time: number) => {
+    const activeIntervention = getEffectiveInterventionAt(time, interventions);
+
+    if (
+      activeIntervention &&
+      interventionSettingsMatch(activeIntervention, DEFAULT_INTERVENTIONS)
+    ) {
+      setTimelineError(
+        'That intervention would not change any settings. Adjust an existing intervention before adding another one.'
+      );
+      return;
+    }
+
+    addInterventions(time, activeIntervention ?? DEFAULT_INTERVENTIONS);
+    setCurtime(time);
+    setTimelineError(null);
+  };
+
   const getTrackTime = (clientX: number, track: HTMLElement) => {
     const rect = track.getBoundingClientRect();
     if (rect.width <= 0) return curtime;
     const ratio = Math.min(1, Math.max(0, (clientX - rect.left) / rect.width));
-    return Math.min(hours, Math.max(1, Math.round(ratio * hours)));
+    return Math.min(hours, Math.max(0, Math.round(ratio * hours)));
   };
 
   const moveIntervention = (fromTime: number, toTime: number) => {
-    const nextTime = Math.min(hours, Math.max(1, toTime));
-    if (fromTime === 0 || fromTime === nextTime) return;
+    const nextTime = Math.min(hours, Math.max(0, toTime));
+    if (fromTime === nextTime) return;
     if (values.includes(nextTime)) {
       setCurtime(nextTime);
       return;
@@ -52,11 +105,12 @@ export default function InterventionTimeline() {
 
     setInterventions(fromTime, { time: nextTime });
     setCurtime(nextTime);
+    setTimelineError(null);
   };
 
   const moveDraggedIntervention = (fromTime: number, toTime: number) => {
-    const nextTime = Math.min(hours, Math.max(1, toTime));
-    if (fromTime === 0 || fromTime === nextTime) return fromTime;
+    const nextTime = Math.min(hours, Math.max(0, toTime));
+    if (fromTime === nextTime) return fromTime;
     if (valuesRef.current.includes(nextTime)) return fromTime;
 
     setInterventions(fromTime, { time: nextTime });
@@ -64,6 +118,7 @@ export default function InterventionTimeline() {
       .map((value) => (value === fromTime ? nextTime : value))
       .sort((a, b) => a - b);
     setCurtime(nextTime);
+    setTimelineError(null);
     return nextTime;
   };
 
@@ -94,6 +149,7 @@ export default function InterventionTimeline() {
 
     if (thumbValue !== null) {
       setCurtime(thumbValue);
+      setTimelineError(null);
       dragTimeRef.current = thumbValue;
       return;
     }
@@ -102,12 +158,12 @@ export default function InterventionTimeline() {
 
     if (values.includes(nextTime)) {
       setCurtime(nextTime);
+      setTimelineError(null);
       dragTimeRef.current = nextTime;
-    } else if (curtime === 0 && values.length < 10) {
-      addInterventions(nextTime);
-      valuesRef.current = [...valuesRef.current, nextTime].sort((a, b) => a - b);
-      setCurtime(nextTime);
-      dragTimeRef.current = nextTime;
+    } else {
+      const fromTime = values.includes(curtime) ? curtime : values[0];
+      if (fromTime === undefined) return;
+      dragTimeRef.current = moveDraggedIntervention(fromTime, nextTime);
     }
   };
 
@@ -162,11 +218,12 @@ export default function InterventionTimeline() {
   };
 
   const deleteThumb = (time: number) => {
-    if (time === 0 || values.length === 1) return;
+    if (values.length === 1) return;
     const index = values.indexOf(time);
     const next = values.filter((value) => value !== time);
     deleteInterventions(time);
     setCurtime(next[Math.min(index, next.length - 1)] ?? 0);
+    setTimelineError(null);
   };
 
   const moveLeft = () => {
@@ -215,7 +272,7 @@ export default function InterventionTimeline() {
 
     if (e.key === 'Home') {
       e.preventDefault();
-      moveIntervention(value, 1);
+      moveIntervention(value, 0);
       return;
     }
 
@@ -254,35 +311,23 @@ export default function InterventionTimeline() {
       >
         <legend className="iv_timeline_legend">Intervention timeline</legend>
         <div className="iv_timeline_track_line" />
-        <button
-          type="button"
-          className={`iv_timeline_thumb iv_timeline_thumb--baseline${curtime === 0 ? ' current' : ''}`}
-          style={{ left: '0%' }}
-          aria-label="Baseline intervention hour 0"
-          onClick={() => setCurtime(0)}
-          onPointerDown={(e) => {
-            e.stopPropagation();
-            setCurtime(0);
-          }}
-          onMouseDown={(e) => {
-            e.stopPropagation();
-            setCurtime(0);
-          }}
-        />
-        {timelineValues.map((value) => (
+        {values.map((value) => (
           <button
             key={value}
             type="button"
             role="slider"
             className={`iv_timeline_thumb${curtime === value ? ' current' : ''}`}
-            style={{ left: `${(value / hours) * 100}%` }}
-            aria-valuemin={1}
+            style={{ left: `${hours > 0 ? (value / hours) * 100 : 0}%` }}
+            aria-valuemin={0}
             aria-valuemax={hours}
             aria-valuenow={value}
             aria-label={`Intervention ${values.indexOf(value) + 1} hour`}
             onPointerDown={() => { thumbPointerValueRef.current = value; }}
             onMouseDown={() => { thumbPointerValueRef.current = value; }}
-            onFocus={() => setCurtime(value)}
+            onFocus={() => {
+              setCurtime(value);
+              setTimelineError(null);
+            }}
             onKeyDown={(e) => handleThumbKeyDown(e, value)}
             onContextMenu={(e) => {
               e.preventDefault();
@@ -307,7 +352,7 @@ export default function InterventionTimeline() {
             type="button"
             className="iv_control_btn iv_control_btn--danger"
             onClick={() => deleteThumb(curtime)}
-            disabled={values.length <= 1 || values.indexOf(curtime) === 0}
+            disabled={values.length <= 1}
           >
             Delete
           </button>
@@ -316,8 +361,7 @@ export default function InterventionTimeline() {
             className="iv_control_btn iv_control_btn--add"
             onClick={() => {
               if (nextAddTime === undefined) return;
-              addInterventions(nextAddTime);
-              setCurtime(nextAddTime);
+              addInterventionAt(nextAddTime);
             }}
             disabled={values.length >= 10 || nextAddTime === undefined}
           >
@@ -334,10 +378,15 @@ export default function InterventionTimeline() {
           </button>
         </div>
       </div>
+      {timelineError && (
+        <div className="iv_timeline_error" role="alert">
+          {timelineError}
+        </div>
+      )}
 
       <div className="iv_intervention_label">
         <span className="iv_intervention_index">
-          {curtime === 0 ? 'Baseline Intervention' : `Intervention #${values.indexOf(curtime) + 1}`}
+          Intervention #{values.indexOf(curtime) + 1}
         </span>
         <span className="iv_intervention_hour">
           Hour {curtime.toString().padStart(3, '0')}
@@ -358,7 +407,7 @@ export default function InterventionTimeline() {
         )}
       </div>
 
-      <Interventions time={curtime} />
+      <Interventions time={curtime} onChange={() => setTimelineError(null)} />
     </div>
   );
 }

--- a/src/components/interventions.tsx
+++ b/src/components/interventions.tsx
@@ -22,7 +22,12 @@ function easeOutCubic(t: number) {
   return 1 - (1 - t) ** 3;
 }
 
-export default function Interventions({ time }: { time: number }) {
+type InterventionsProps = {
+  time: number;
+  onChange?: () => void;
+};
+
+export default function Interventions({ time, onChange }: InterventionsProps) {
   const allInterventions = useSimSettings((state) => state.interventions);
   const setInterventions = useSimSettings((state) => state.setInterventions);
 
@@ -90,32 +95,47 @@ export default function Interventions({ time }: { time: number }) {
       <SimParameter
         label={'Percent Masking'}
         value={display.mask}
-        callback={(mask) => setInterventions(time, { mask })}
+        callback={(mask) => {
+          setInterventions(time, { mask });
+          onChange?.();
+        }}
         info={'Proportion of people who wear masks, reducing the probability of disease transmission between individuals.'}
       />
       <SimParameter
         label={'Percent Vaccinated'}
         value={display.vaccine}
-        callback={(vaccine) => setInterventions(time, { vaccine })}
+        callback={(vaccine) => {
+          setInterventions(time, { vaccine });
+          onChange?.();
+        }}
         info={'Proportion of the population that is vaccinated, reducing individual susceptibility to infection.'}
       />
       <SimParameter
         label={'Maximum Facility Capacity'}
         value={display.capacity}
-        callback={(capacity) => setInterventions(time, { capacity })}
+        callback={(capacity) => {
+          setInterventions(time, { capacity });
+          onChange?.();
+        }}
         info={'Scales the maximum occupancy of every facility. At 50%, a venue that holds 100 people caps at 50, and anyone over the limit is sent home.'}
         disabled
       />
       <SimParameter
         label={'Lockdown Probability'}
         value={display.lockdown}
-        callback={(lockdown) => setInterventions(time, { lockdown })}
+        callback={(lockdown) => {
+          setInterventions(time, { lockdown });
+          onChange?.();
+        }}
         info={'Chance that any person stays home instead of travelling to a facility during a movement event. Applies regardless of health status.'}
       />
       <SimParameter
         label={'Self-Isolation Percent'}
         value={display.selfiso}
-        callback={(selfiso) => setInterventions(time, { selfiso })}
+        callback={(selfiso) => {
+          setInterventions(time, { selfiso });
+          onChange?.();
+        }}
         info={'Chance that a symptomatic (visibly ill) person stays home instead of going to a facility, modelling voluntary quarantine behaviour.'}
       />
     </div>

--- a/src/stores/simsettings.ts
+++ b/src/stores/simsettings.ts
@@ -26,6 +26,8 @@ export type Interventions = {
   selfiso: number;
 };
 
+type InterventionValues = Omit<Interventions, 'time'>;
+
 export type DmpMode = 'auto' | 'required' | 'off';
 
 export type SimSettings = {
@@ -45,7 +47,10 @@ export type SimSettings = {
 
 interface SimSettingsActions {
   setSettings: (new_settings: Partial<SimSettings>) => void;
-  addInterventions: (time: number) => void;
+  addInterventions: (
+    time: number,
+    values?: InterventionValues
+  ) => void;
   setInterventions: (
     time: number,
     new_interventions: Partial<Interventions>
@@ -55,13 +60,17 @@ interface SimSettingsActions {
 
 type SimSettingsStore = SimSettings & SimSettingsActions;
 
-const default_interventions: Interventions = {
-  time: 0,
-  mask: 0.4,
-  vaccine: 0.2,
+const DEFAULT_INTERVENTION_VALUES: InterventionValues = {
+  mask: 0.0,
+  vaccine: 0.0,
   capacity: 1.0,
   lockdown: 0.0,
-  selfiso: 0.5
+  selfiso: 0.0
+};
+
+export const DEFAULT_INTERVENTIONS: Interventions = {
+  time: 0,
+  ...DEFAULT_INTERVENTION_VALUES
 };
 
 const default_settings: SimSettings = {
@@ -78,7 +87,7 @@ const default_settings: SimSettings = {
     Delta: 'variant.Delta.general'
   },
   matrix_by_variant: {},
-  interventions: [{ ...default_interventions }]
+  interventions: [{ ...DEFAULT_INTERVENTIONS }]
 };
 
 const useSimSettings = create<SimSettingsStore>((set) => ({
@@ -88,10 +97,10 @@ const useSimSettings = create<SimSettingsStore>((set) => ({
     set((state) => ({ ...state, ...new_settings }));
   },
 
-  addInterventions: (time) => {
+  addInterventions: (time, values = DEFAULT_INTERVENTION_VALUES) => {
     set((state) => ({
       interventions: state.interventions.concat({
-        ...default_interventions,
+        ...values,
         time
       })
     }));

--- a/src/styles/intervention-timeline.css
+++ b/src/styles/intervention-timeline.css
@@ -70,14 +70,22 @@ button.iv_timeline_thumb:focus-visible {
   outline-offset: 3px;
 }
 
-button.iv_timeline_thumb--baseline {
-  cursor: default;
-}
-
 button.iv_timeline_thumb.current {
   background: var(--color-bg-dark);
   border-color: var(--color-primary-blue-soft);
   width: 14px;
   height: 26px;
   box-shadow: 0 1px 2px rgba(15, 23, 42, 0.18), 0 6px 14px rgba(15, 23, 42, 0.20);
+}
+
+.iv_timeline_error {
+  align-self: center;
+  max-width: 520px;
+  padding: 9px 14px;
+  border: 1px solid rgba(232, 72, 90, 0.20);
+  border-radius: 8px;
+  background: rgba(232, 72, 90, 0.08);
+  color: var(--color-accent-red);
+  font-size: 13px;
+  text-align: center;
 }


### PR DESCRIPTION
Summary: Makes the initial intervention movable from hour 0, defaults user-facing intervention levels to 0%, prevents no-op intervention additions with an inline error, and preserves active settings when adding a new intervention. Verification: focused Biome lint passed; git diff --check passed; /simulator returned 200 on the local dev server. Full tsc still fails on existing unrelated DMP Prisma dmpMatrix errors.