### PR TITLE
Hide private zones from logged-out users

### DIFF
--- a/src/app/api/convenience-zones/[czone_id]/route.ts
+++ b/src/app/api/convenience-zones/[czone_id]/route.ts
@@ -1,7 +1,7 @@
 import type { NextRequest } from 'next/server';
 import { jsonMessage, serviceResult } from '@/server/api/responses';
 import { parseNonNegativeRouteNumber } from '@/server/api/route-params';
-import { requireSessionUserId } from '@/server/api/session';
+import { getSessionUserId, requireSessionUserId } from '@/server/api/session';
 import {
   deleteConvenienceZone,
   getConvenienceZone,
@@ -10,7 +10,7 @@ import {
 } from '@/server/services/convenience-zones';
 
 export async function GET(
-  _request: NextRequest,
+  request: NextRequest,
   { params }: { params: Promise<{ czone_id: string }> }
 ) {
   const { czone_id } = await params;
@@ -19,7 +19,8 @@ export async function GET(
     return jsonMessage(id.message, id.status);
   }
 
-  const result = await getConvenienceZone(id.value);
+  const userId = await getSessionUserId(request.headers);
+  const result = await getConvenienceZone(id.value, userId);
   return serviceResult(result);
 }
 

--- a/src/app/api/simdata/cache/[czone_id]/route.ts
+++ b/src/app/api/simdata/cache/[czone_id]/route.ts
@@ -1,10 +1,11 @@
 import type { NextRequest } from 'next/server';
 import { jsonMessage, serviceResult } from '@/server/api/responses';
 import { parseNonNegativeRouteNumber } from '@/server/api/route-params';
+import { getSessionUserId } from '@/server/api/session';
 import { listSimDataCacheForZone } from '@/server/services/simdata-cache';
 
 export async function GET(
-  _request: NextRequest,
+  request: NextRequest,
   { params }: { params: Promise<{ czone_id: string }> }
 ) {
   const { czone_id: czone_id_raw } = await params;
@@ -13,6 +14,7 @@ export async function GET(
     return jsonMessage(czoneId.message, czoneId.status);
   }
 
-  const result = await listSimDataCacheForZone(czoneId.value);
+  const userId = await getSessionUserId(request.headers);
+  const result = await listSimDataCacheForZone(czoneId.value, userId);
   return serviceResult(result);
 }

--- a/src/components/czdict.tsx
+++ b/src/components/czdict.tsx
@@ -16,17 +16,38 @@ interface CzDictProps {
 export default function CzDict({ zone, setZone, locations, setLocations }: CzDictProps) {
   const { data: session } = useSession();
   const user = session?.user;
+  const userId = user?.id ?? null;
   const setSettings = useSimSettings((state) => state.setSettings);
 
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState('');
   const zoneRef = useRef(zone);
+  const previousUserIdRef = useRef<string | null>(null);
   zoneRef.current = zone;
+
+  useEffect(() => {
+    const previousUserId = previousUserIdRef.current;
+    const currentZone = zoneRef.current;
+
+    if (
+      previousUserId &&
+      previousUserId !== userId &&
+      currentZone?.user_id === previousUserId
+    ) {
+      setSettings({ zone: null, sim_id: null });
+    }
+
+    previousUserIdRef.current = userId;
+  }, [userId, setSettings]);
 
   useEffect(() => {
     let active = true;
     let es: EventSource | null = null;
     let fallbackTimer: number | null = null;
+
+    if (!userId) {
+      setLocations([]);
+    }
 
     const fetchZones = async () => {
       if (!active) return;
@@ -107,7 +128,7 @@ export default function CzDict({ zone, setZone, locations, setLocations }: CzDic
       if (fallbackTimer) clearInterval(fallbackTimer);
       clearInterval(heartbeat);
     };
-  }, [setZone, setLocations]);
+  }, [setZone, setLocations, userId]);
 
   return (
     <div className="flex flex-col items-center gap-4">

--- a/src/server/services/convenience-zones.ts
+++ b/src/server/services/convenience-zones.ts
@@ -4,6 +4,11 @@ import { invalidatePapdata } from '@/lib/papdata-cache';
 import { prisma } from '@/lib/prisma';
 import { broadcast } from '@/lib/sse-broadcast';
 import type { ServiceResult } from '@/server/api/responses';
+import {
+  ANONYMOUS_ZONE_USER_EMAIL,
+  canReadConvenienceZone,
+  zoneAccessDenied
+} from './zone-access';
 
 export const createConvenienceZoneSchema = z.object({
   name: z.string().min(1),
@@ -30,13 +35,18 @@ type ConvenienceZoneUpdateData = {
   description?: string;
 };
 
-const ANONYMOUS_ZONE_USER_EMAIL = 'anonymous-zones@delineo.local';
-
 function withReady(zone: ConvenienceZone): ConvenienceZoneWithReady {
   return {
     ...zone,
     ready: !!zone.papdata_id
   };
+}
+
+function stripOwnerRelation<T extends ConvenienceZone & { user?: unknown }>(
+  zone: T
+): ConvenienceZone {
+  const { user: _user, ...zoneData } = zone;
+  return zoneData;
 }
 
 async function getAnonymousZoneUserId() {
@@ -57,9 +67,13 @@ async function getAnonymousZoneUserId() {
 export async function listConvenienceZones(
   userId: string | null
 ): Promise<ConvenienceZoneWithReady[]> {
-  const zones = await prisma.convenienceZone.findMany(
-    userId ? { where: { user_id: userId } } : undefined
-  );
+  if (!userId) {
+    return [];
+  }
+
+  const zones = await prisma.convenienceZone.findMany({
+    where: { user_id: userId }
+  });
 
   return zones.map(withReady);
 }
@@ -127,15 +141,22 @@ export async function createConvenienceZone(
 }
 
 export async function getConvenienceZone(
-  id: number
+  id: number,
+  userId: string | null
 ): Promise<ServiceResult<ConvenienceZoneWithReady>> {
   try {
-    const zone = await prisma.convenienceZone.findUnique({ where: { id } });
+    const zone = await prisma.convenienceZone.findUnique({
+      where: { id },
+      include: { user: { select: { email: true } } }
+    });
     if (!zone) {
       return { ok: false, message: 'Not found', status: 404 };
     }
+    if (!canReadConvenienceZone(zone, userId)) {
+      return zoneAccessDenied(userId);
+    }
 
-    return { ok: true, data: withReady(zone) };
+    return { ok: true, data: withReady(stripOwnerRelation(zone)) };
   } catch (error) {
     return { ok: false, message: String(error), status: 500 };
   }

--- a/src/server/services/simdata-cache.ts
+++ b/src/server/services/simdata-cache.ts
@@ -1,6 +1,7 @@
 import type { SimData } from '@/generated/prisma/client';
 import { prisma } from '@/lib/prisma';
 import type { ServiceResult } from '@/server/api/responses';
+import { canReadConvenienceZone, zoneAccessDenied } from './zone-access';
 
 type SimDataCacheEntry = {
   name: SimData['name'];
@@ -9,11 +10,15 @@ type SimDataCacheEntry = {
 };
 
 export async function listSimDataCacheForZone(
-  czoneId: number
+  czoneId: number,
+  userId: string | null
 ): Promise<ServiceResult<SimDataCacheEntry[]>> {
   const czone = await prisma.convenienceZone.findUnique({
     where: { id: czoneId },
-    include: { simdata: { orderBy: { id: 'desc' } } }
+    include: {
+      user: { select: { email: true } },
+      simdata: { orderBy: { id: 'desc' } }
+    }
   });
 
   if (!czone) {
@@ -22,6 +27,9 @@ export async function listSimDataCacheForZone(
       message: `Could not find convenience zone #${czoneId}`,
       status: 404
     };
+  }
+  if (!canReadConvenienceZone(czone, userId)) {
+    return zoneAccessDenied(userId);
   }
 
   return {

--- a/src/server/services/zone-access.test.mjs
+++ b/src/server/services/zone-access.test.mjs
@@ -1,0 +1,47 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  ANONYMOUS_ZONE_USER_EMAIL,
+  canReadConvenienceZone,
+  zoneAccessDenied
+} from './zone-access.ts';
+
+test('canReadConvenienceZone allows the owner', () => {
+  assert.equal(
+    canReadConvenienceZone({ user_id: 'user-1' }, 'user-1'),
+    true
+  );
+});
+
+test('canReadConvenienceZone rejects anonymous access to owner-backed zones', () => {
+  assert.equal(
+    canReadConvenienceZone({ user_id: 'user-1' }, null),
+    false
+  );
+});
+
+test('canReadConvenienceZone treats anonymous-system zones as public', () => {
+  assert.equal(
+    canReadConvenienceZone(
+      {
+        user_id: 'anonymous-user',
+        user: { email: ANONYMOUS_ZONE_USER_EMAIL }
+      },
+      null
+    ),
+    true
+  );
+});
+
+test('zoneAccessDenied distinguishes anonymous and wrong-user requests', () => {
+  assert.deepEqual(zoneAccessDenied(null), {
+    ok: false,
+    message: 'Authentication required',
+    status: 401
+  });
+  assert.deepEqual(zoneAccessDenied('user-2'), {
+    ok: false,
+    message: 'Forbidden',
+    status: 403
+  });
+});

--- a/src/server/services/zone-access.ts
+++ b/src/server/services/zone-access.ts
@@ -1,0 +1,23 @@
+export const ANONYMOUS_ZONE_USER_EMAIL = 'anonymous-zones@delineo.local';
+
+type ZoneAccessRecord = {
+  user_id: string;
+  user?: { email: string | null } | null;
+};
+
+export function canReadConvenienceZone(
+  zone: ZoneAccessRecord,
+  userId: string | null
+) {
+  if (zone.user?.email === ANONYMOUS_ZONE_USER_EMAIL) {
+    return true;
+  }
+
+  return !!userId && zone.user_id === userId;
+}
+
+export function zoneAccessDenied(userId: string | null) {
+  return userId
+    ? { ok: false as const, message: 'Forbidden', status: 403 }
+    : { ok: false as const, message: 'Authentication required', status: 401 };
+}


### PR DESCRIPTION
## Summary
- hide owner-backed convenience zones from logged-out users
- enforce zone read access for direct zone lookup and previous-run cache
- keep anonymous-system generated zones readable for guest workflows
- clear stale selected private zones when auth state changes

## Verification
- pnpm test
- pnpm typecheck
- pnpm exec biome lint src/server/services/zone-access.ts src/server/services/convenience-zones.ts src/server/services/simdata-cache.ts 'src/app/api/convenience-zones/[czone_id]/route.ts' 'src/app/api/simdata/cache/[czone_id]/route.ts' src/components/czdict.tsx src/server/services/zone-access.test.mjs

Note: full pnpm lint still fails on existing DMP selector/matrix lint issues unrelated to this branch.