### PR TITLE
Save guest zones on login

### DIFF
--- a/prisma/migrations/2_add_guest_zone_claims/migration.sql
+++ b/prisma/migrations/2_add_guest_zone_claims/migration.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "ConvenienceZone" ADD COLUMN "guest_claim_token_hash" TEXT;
+
+CREATE UNIQUE INDEX "ConvenienceZone_guest_claim_token_hash_key" ON "ConvenienceZone"("guest_claim_token_hash");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -76,6 +76,7 @@ model ConvenienceZone {
   created_at        DateTime @default(now())
   user_id           String
   user              User @relation(references: [id], fields: [user_id], onDelete: Cascade)
+  guest_claim_token_hash String?   @unique
   papdata_id        String?         // UUID for papdata file ({id}.gz)
   patterns_id       String?         // UUID for movement patterns file ({id}.gz)
   simdata           SimData[]

--- a/src/app/api/convenience-zones/[czone_id]/route.ts
+++ b/src/app/api/convenience-zones/[czone_id]/route.ts
@@ -2,6 +2,7 @@ import type { NextRequest } from 'next/server';
 import { jsonMessage, serviceResult } from '@/server/api/responses';
 import { parseNonNegativeRouteNumber } from '@/server/api/route-params';
 import { getSessionUserId, requireSessionUserId } from '@/server/api/session';
+import { getGuestZoneClaimTokenHashesFromHeaders } from '@/server/services/guest-zone-claims';
 import {
   deleteConvenienceZone,
   getConvenienceZone,
@@ -20,7 +21,14 @@ export async function GET(
   }
 
   const userId = await getSessionUserId(request.headers);
-  const result = await getConvenienceZone(id.value, userId);
+  const guestClaimTokenHashes = getGuestZoneClaimTokenHashesFromHeaders(
+    request.headers
+  );
+  const result = await getConvenienceZone(
+    id.value,
+    userId,
+    guestClaimTokenHashes
+  );
   return serviceResult(result);
 }
 

--- a/src/app/api/convenience-zones/claim/route.ts
+++ b/src/app/api/convenience-zones/claim/route.ts
@@ -1,0 +1,32 @@
+import type { NextRequest } from 'next/server';
+import {
+  badRequest,
+  jsonMessage,
+  serviceResult
+} from '@/server/api/responses';
+import { requireSessionUserId } from '@/server/api/session';
+import { claimGuestZonesSchema } from '@/server/services/guest-zone-claims';
+import { claimGuestConvenienceZones } from '@/server/services/convenience-zones';
+
+export async function POST(request: NextRequest) {
+  const session = await requireSessionUserId(request.headers);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  try {
+    const body = await request.json();
+    const parsed = claimGuestZonesSchema.safeParse(body);
+    if (!parsed.success) {
+      return badRequest(parsed.error.message);
+    }
+
+    const result = await claimGuestConvenienceZones(
+      parsed.data.claim_tokens,
+      session.userId
+    );
+    return serviceResult(result);
+  } catch {
+    return jsonMessage('Internal server error', 500);
+  }
+}

--- a/src/app/api/convenience-zones/route.ts
+++ b/src/app/api/convenience-zones/route.ts
@@ -6,6 +6,7 @@ import {
   serviceResult
 } from '@/server/api/responses';
 import { getSessionUserId } from '@/server/api/session';
+import { getGuestZoneClaimTokenHashesFromHeaders } from '@/server/services/guest-zone-claims';
 import {
   createConvenienceZone,
   createConvenienceZoneSchema,
@@ -14,7 +15,10 @@ import {
 
 export async function GET(request: NextRequest) {
   const userId = await getSessionUserId(request.headers);
-  const zones = await listConvenienceZones(userId);
+  const guestClaimTokenHashes = getGuestZoneClaimTokenHashesFromHeaders(
+    request.headers
+  );
+  const zones = await listConvenienceZones(userId, guestClaimTokenHashes);
   return jsonData(zones);
 }
 

--- a/src/app/api/simdata/[id]/route.ts
+++ b/src/app/api/simdata/[id]/route.ts
@@ -12,6 +12,13 @@ const updateSchema = z.object({
   name: z.string().min(2).optional()
 });
 
+function getPublicZone<T extends { guest_claim_token_hash?: unknown }>(
+  zone: T
+) {
+  const { guest_claim_token_hash: _claimHash, ...publicZone } = zone;
+  return publicZone;
+}
+
 /** Optionally gzip-compress a response body if the client accepts it. */
 function maybeCompress(
   body: BodyInit,
@@ -64,6 +71,7 @@ export async function GET(
 
   const fileId = simdata.file_id;
   const mapCachePath = `${DB_FOLDER}${fileId}.map.json`;
+  const publicZone = getPublicZone(simdata.czone);
 
   const acceptEncoding = request.headers.get('accept-encoding');
 
@@ -106,7 +114,7 @@ export async function GET(
         data: {
           name: simdata.name,
           length: simdata.length,
-          zone: simdata.czone,
+          zone: publicZone,
           papdata: parsed.papdata,
           simdata: filteredSimdata,
           hotspots: parsed.hotspots ?? {}
@@ -120,7 +128,7 @@ export async function GET(
     }
 
     // Non-paginated: splice header + raw cache bytes + suffix (zero-parse)
-    const headerStr = `{"data":{"name":${JSON.stringify(simdata.name)},"length":${simdata.length},"zone":${JSON.stringify(simdata.czone)}`;
+    const headerStr = `{"data":{"name":${JSON.stringify(simdata.name)},"length":${simdata.length},"zone":${JSON.stringify(publicZone)}`;
 
     const body = Buffer.concat([
       Buffer.from(headerStr, 'utf8'),

--- a/src/app/api/simdata/cache/[czone_id]/route.ts
+++ b/src/app/api/simdata/cache/[czone_id]/route.ts
@@ -2,6 +2,7 @@ import type { NextRequest } from 'next/server';
 import { jsonMessage, serviceResult } from '@/server/api/responses';
 import { parseNonNegativeRouteNumber } from '@/server/api/route-params';
 import { getSessionUserId } from '@/server/api/session';
+import { getGuestZoneClaimTokenHashesFromHeaders } from '@/server/services/guest-zone-claims';
 import { listSimDataCacheForZone } from '@/server/services/simdata-cache';
 
 export async function GET(
@@ -15,6 +16,13 @@ export async function GET(
   }
 
   const userId = await getSessionUserId(request.headers);
-  const result = await listSimDataCacheForZone(czoneId.value, userId);
+  const guestClaimTokenHashes = getGuestZoneClaimTokenHashesFromHeaders(
+    request.headers
+  );
+  const result = await listSimDataCacheForZone(
+    czoneId.value,
+    userId,
+    guestClaimTokenHashes
+  );
   return serviceResult(result);
 }

--- a/src/app/cz-generation/page.tsx
+++ b/src/app/cz-generation/page.tsx
@@ -58,6 +58,10 @@ import {
   mergeGeoJsonFeatures,
   normalizeCbgId
 } from '@/lib/cz-geo';
+import {
+  createGuestZoneClaimToken,
+  rememberGuestZoneClaim
+} from '@/lib/guest-zone-claims';
 import { getStateFromCBG } from '@/lib/simulation-zone';
 import useSimSettings, { type ConvenienceZone } from '@/stores/simsettings';
 import '@/styles/cz-generation.css';
@@ -155,9 +159,16 @@ function FormField({
   );
 }
 
-async function fetchZoneById(zoneId: number): Promise<ConvenienceZone | null> {
+async function fetchZoneById(
+  zoneId: number,
+  guestClaimToken?: string | null
+): Promise<ConvenienceZone | null> {
   try {
-    const res = await fetch(`/api/convenience-zones/${zoneId}`);
+    const res = await fetch(`/api/convenience-zones/${zoneId}`, {
+      headers: guestClaimToken
+        ? { 'X-Delineo-Guest-Zone-Claims': guestClaimToken }
+        : {}
+    });
     if (!res.ok) return null;
     const json = await res.json().catch(() => ({}));
     const zone = json?.data as ConvenienceZone | undefined;
@@ -169,7 +180,8 @@ async function fetchZoneById(zoneId: number): Promise<ConvenienceZone | null> {
 
 function waitForZoneReady(
   zoneId: number,
-  onProgress: (percent: number) => void
+  onProgress: (percent: number) => void,
+  guestClaimToken?: string | null
 ): Promise<ConvenienceZone | null> {
   return new Promise((resolve) => {
     let done = false;
@@ -195,7 +207,7 @@ function waitForZoneReady(
     }, 1000);
 
     const checkReady = async () => {
-      const zone = await fetchZoneById(zoneId);
+      const zone = await fetchZoneById(zoneId, guestClaimToken);
       if (zone) finish(zone);
     };
 
@@ -2275,6 +2287,8 @@ export default function CZGeneration() {
         setDescription(descriptionToSave);
       }
 
+      const guestClaimToken = user?.id ? null : createGuestZoneClaimToken();
+
       const finalizePayload = {
         name: cityName,
         description: descriptionToSave,
@@ -2284,7 +2298,8 @@ export default function CZGeneration() {
         latitude: mapCenter?.[0] || 0,
         longitude: mapCenter?.[1] || 0,
         use_test_data: useTestData,
-        ...(user?.id ? { user_id: user.id } : {})
+        ...(user?.id ? { user_id: user.id } : {}),
+        ...(guestClaimToken ? { guest_claim_token: guestClaimToken } : {})
       };
 
       const resp = await fetch(algUrl('finalize-cz'), {
@@ -2301,6 +2316,9 @@ export default function CZGeneration() {
       }
 
       const zoneId: number = data.id;
+      if (guestClaimToken) {
+        rememberGuestZoneClaim(zoneId, guestClaimToken);
+      }
       setFinalizeProgress(15);
       setFinalizeStatusMessage(
         user?.id
@@ -2308,9 +2326,13 @@ export default function CZGeneration() {
           : 'Zone generated. Generating movement patterns...'
       );
 
-      const readyZone = await waitForZoneReady(zoneId, (pct) => {
-        setFinalizeProgress(pct);
-      });
+      const readyZone = await waitForZoneReady(
+        zoneId,
+        (pct) => {
+          setFinalizeProgress(pct);
+        },
+        guestClaimToken
+      );
 
       if (readyZone) {
         setSettings({

--- a/src/components/auth-provider.tsx
+++ b/src/components/auth-provider.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useSession } from '@/lib/auth-client';
+import { claimGuestZonesForCurrentSession } from '@/lib/guest-zone-claims';
 import useAuthStore from '@/stores/useAuthStore';
 
 export default function AuthProvider({
@@ -11,6 +12,7 @@ export default function AuthProvider({
 }) {
   const { data: session, isPending } = useSession();
   const setUser = useAuthStore((state) => state.setUser);
+  const claimAttemptedForUserRef = useRef<string | null>(null);
 
   useEffect(() => {
     if (isPending) return;
@@ -26,6 +28,26 @@ export default function AuthProvider({
         : null
     );
   }, [session, isPending, setUser]);
+
+  useEffect(() => {
+    if (isPending) return;
+
+    const userId = session?.user?.id ?? null;
+    if (!userId) {
+      claimAttemptedForUserRef.current = null;
+      return;
+    }
+
+    if (claimAttemptedForUserRef.current === userId) {
+      return;
+    }
+
+    claimAttemptedForUserRef.current = userId;
+    claimGuestZonesForCurrentSession().catch((error) => {
+      console.error('Failed to save guest zones after login:', error);
+      claimAttemptedForUserRef.current = null;
+    });
+  }, [session?.user?.id, isPending]);
 
   return <>{children}</>;
 }

--- a/src/components/czdict.tsx
+++ b/src/components/czdict.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from 'react';
 import { useSession } from '@/lib/auth-client';
+import { getGuestZoneClaimHeaders } from '@/lib/guest-zone-claims';
 import type { ConvenienceZone } from '@/stores/simsettings';
 import useSimSettings from '@/stores/simsettings';
 import EditDeleteActions from './edit-delete-actions';
@@ -52,7 +53,9 @@ export default function CzDict({ zone, setZone, locations, setLocations }: CzDic
     const fetchZones = async () => {
       if (!active) return;
       try {
-        const res = await fetch('/api/convenience-zones');
+        const res = await fetch('/api/convenience-zones', {
+          headers: getGuestZoneClaimHeaders()
+        });
         const json = await res.json().catch(() => ({}));
         const locs = Array.isArray(json.data) ? json.data : [];
 
@@ -121,12 +124,19 @@ export default function CzDict({ zone, setZone, locations, setLocations }: CzDic
     });
 
     const heartbeat = window.setInterval(fetchZones, 60_000);
+    window.addEventListener('delineo:guest-zone-claims-changed', fetchZones);
+    window.addEventListener('delineo:guest-zones-claimed', fetchZones);
 
     return () => {
       active = false;
       if (es) es.close();
       if (fallbackTimer) clearInterval(fallbackTimer);
       clearInterval(heartbeat);
+      window.removeEventListener(
+        'delineo:guest-zone-claims-changed',
+        fetchZones
+      );
+      window.removeEventListener('delineo:guest-zones-claimed', fetchZones);
     };
   }, [setZone, setLocations, userId]);
 
@@ -183,6 +193,13 @@ export default function CzDict({ zone, setZone, locations, setLocations }: CzDic
           })}
         </div>
       </div>
+
+      {!user && (
+        <p className="sim_guest_save_notice">
+          Log in to save generated zones. Zones created during this visit will
+          be saved to your account when you log in.
+        </p>
+      )}
 
       {zone?.description && (
         <div className="sim_zone_description">

--- a/src/components/settings-components.tsx
+++ b/src/components/settings-components.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from 'react';
 import { Info } from 'lucide-react';
+import { getGuestZoneClaimHeaders } from '@/lib/guest-zone-claims';
 import '@/styles/settings-components.css';
 import Slider from './ui/slider';
 
@@ -245,7 +246,9 @@ export function SimRunSelector({
       return;
     }
     setLoading(true);
-    fetch(`/api/simdata/cache/${czone_id}`)
+    fetch(`/api/simdata/cache/${czone_id}`, {
+      headers: getGuestZoneClaimHeaders()
+    })
       .then((res) => {
         if (!res.ok) throw new Error(`Invalid cache response ${res.status}`);
         return res.json();

--- a/src/lib/guest-zone-claims.ts
+++ b/src/lib/guest-zone-claims.ts
@@ -1,0 +1,134 @@
+'use client';
+
+const STORAGE_KEY = 'delineo-guest-zone-claims';
+const GUEST_ZONE_CLAIMS_HEADER = 'X-Delineo-Guest-Zone-Claims';
+
+type GuestZoneClaim = {
+  zoneId: number;
+  token: string;
+  createdAt: string;
+};
+
+function readClaims(): GuestZoneClaim[] {
+  if (typeof window === 'undefined') {
+    return [];
+  }
+
+  try {
+    const parsed = JSON.parse(
+      window.sessionStorage.getItem(STORAGE_KEY) || '[]'
+    );
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+
+    return parsed.filter(
+      (claim): claim is GuestZoneClaim =>
+        typeof claim === 'object' &&
+        claim !== null &&
+        Number.isFinite(Number(claim.zoneId)) &&
+        typeof claim.token === 'string' &&
+        typeof claim.createdAt === 'string'
+    );
+  } catch {
+    return [];
+  }
+}
+
+function writeClaims(claims: GuestZoneClaim[]) {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  window.sessionStorage.setItem(STORAGE_KEY, JSON.stringify(claims.slice(-100)));
+  window.dispatchEvent(new Event('delineo:guest-zone-claims-changed'));
+}
+
+function randomTokenBytes() {
+  const bytes = new Uint8Array(32);
+  window.crypto.getRandomValues(bytes);
+  return bytes;
+}
+
+function base64UrlEncode(bytes: Uint8Array) {
+  let binary = '';
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+
+  return window
+    .btoa(binary)
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/g, '');
+}
+
+export function createGuestZoneClaimToken() {
+  if (
+    typeof window !== 'undefined' &&
+    window.crypto &&
+    'getRandomValues' in window.crypto
+  ) {
+    return base64UrlEncode(randomTokenBytes());
+  }
+
+  return `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+export function rememberGuestZoneClaim(zoneId: number, token: string) {
+  const claims = readClaims().filter((claim) => claim.zoneId !== zoneId);
+  claims.push({
+    zoneId,
+    token,
+    createdAt: new Date().toISOString()
+  });
+  writeClaims(claims);
+}
+
+export function getGuestZoneClaimTokens() {
+  return readClaims().map((claim) => claim.token);
+}
+
+export function getGuestZoneClaimHeaders(): HeadersInit {
+  const tokens = getGuestZoneClaimTokens();
+  return tokens.length ? { [GUEST_ZONE_CLAIMS_HEADER]: tokens.join(',') } : {};
+}
+
+export function forgetGuestZoneClaims(zoneIds?: number[]) {
+  if (!zoneIds) {
+    writeClaims([]);
+    return;
+  }
+
+  const zoneIdSet = new Set(zoneIds);
+  writeClaims(readClaims().filter((claim) => !zoneIdSet.has(claim.zoneId)));
+}
+
+export async function claimGuestZonesForCurrentSession() {
+  const claimTokens = getGuestZoneClaimTokens();
+  if (claimTokens.length === 0) {
+    return 0;
+  }
+
+  const response = await fetch('/api/convenience-zones/claim', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ claim_tokens: claimTokens })
+  });
+
+  if (!response.ok) {
+    throw new Error(`Guest zone claim failed with status ${response.status}`);
+  }
+
+  const json = await response.json().catch(() => ({}));
+  const claimedZoneIds = Array.isArray(json.data?.claimed_zone_ids)
+    ? json.data.claimed_zone_ids
+        .map((id: unknown) => Number(id))
+        .filter((id: number) => Number.isFinite(id))
+    : [];
+
+  forgetGuestZoneClaims();
+
+  window.dispatchEvent(new Event('delineo:guest-zones-claimed'));
+  return claimedZoneIds.length;
+}

--- a/src/server/services/convenience-zones.ts
+++ b/src/server/services/convenience-zones.ts
@@ -5,6 +5,10 @@ import { prisma } from '@/lib/prisma';
 import { broadcast } from '@/lib/sse-broadcast';
 import type { ServiceResult } from '@/server/api/responses';
 import {
+  hashGuestZoneClaimToken,
+  guestZoneClaimTokensSchema
+} from './guest-zone-claims';
+import {
   ANONYMOUS_ZONE_USER_EMAIL,
   canReadConvenienceZone,
   zoneAccessDenied
@@ -19,14 +23,17 @@ export const createConvenienceZoneSchema = z.object({
   start_date: z.string().datetime(),
   length: z.number().nonnegative(),
   size: z.number().nonnegative(),
-  user_id: z.string().min(1).nullable().optional()
+  user_id: z.string().min(1).nullable().optional(),
+  guest_claim_token: z.string().min(16).max(256).nullable().optional()
 });
 
 export type CreateConvenienceZoneInput = z.infer<
   typeof createConvenienceZoneSchema
 >;
 
-export type ConvenienceZoneWithReady = ConvenienceZone & {
+type PublicConvenienceZone = Omit<ConvenienceZone, 'guest_claim_token_hash'>;
+
+export type ConvenienceZoneWithReady = PublicConvenienceZone & {
   ready: boolean;
 };
 
@@ -35,18 +42,16 @@ type ConvenienceZoneUpdateData = {
   description?: string;
 };
 
-function withReady(zone: ConvenienceZone): ConvenienceZoneWithReady {
-  return {
-    ...zone,
-    ready: !!zone.papdata_id
-  };
+function toPublicZone(zone: ConvenienceZone): PublicConvenienceZone {
+  const { guest_claim_token_hash: _claimHash, ...publicZone } = zone;
+  return publicZone;
 }
 
-function stripOwnerRelation<T extends ConvenienceZone & { user?: unknown }>(
-  zone: T
-): ConvenienceZone {
-  const { user: _user, ...zoneData } = zone;
-  return zoneData;
+function withReady(zone: ConvenienceZone): ConvenienceZoneWithReady {
+  return {
+    ...toPublicZone(zone),
+    ready: !!zone.papdata_id
+  };
 }
 
 async function getAnonymousZoneUserId() {
@@ -65,10 +70,19 @@ async function getAnonymousZoneUserId() {
 }
 
 export async function listConvenienceZones(
-  userId: string | null
+  userId: string | null,
+  guestClaimTokenHashes: string[] = []
 ): Promise<ConvenienceZoneWithReady[]> {
   if (!userId) {
-    return [];
+    if (guestClaimTokenHashes.length === 0) {
+      return [];
+    }
+
+    const zones = await prisma.convenienceZone.findMany({
+      where: { guest_claim_token_hash: { in: guestClaimTokenHashes } }
+    });
+
+    return zones.map(withReady);
   }
 
   const zones = await prisma.convenienceZone.findMany({
@@ -81,7 +95,7 @@ export async function listConvenienceZones(
 export async function createConvenienceZone(
   input: CreateConvenienceZoneInput,
   sessionUserId: string | null
-): Promise<ServiceResult<ConvenienceZone>> {
+): Promise<ServiceResult<ConvenienceZoneWithReady>> {
   const {
     name,
     description,
@@ -91,7 +105,8 @@ export async function createConvenienceZone(
     start_date,
     length,
     size,
-    user_id: bodyUserId
+    user_id: bodyUserId,
+    guest_claim_token: guestClaimToken
   } = input;
 
   if (sessionUserId && bodyUserId && bodyUserId !== sessionUserId) {
@@ -121,6 +136,10 @@ export async function createConvenienceZone(
   }
 
   const user_id = requestedUserId ?? (await getAnonymousZoneUserId());
+  const guest_claim_token_hash =
+    requestedUserId || !guestClaimToken
+      ? null
+      : hashGuestZoneClaimToken(guestClaimToken);
 
   const zone = await prisma.convenienceZone.create({
     data: {
@@ -132,34 +151,74 @@ export async function createConvenienceZone(
       start_date,
       length,
       size,
-      user_id
+      user_id,
+      guest_claim_token_hash
     }
   });
 
   broadcast({ type: 'zone-created', zone_id: zone.id });
-  return { ok: true, data: zone };
+  return { ok: true, data: withReady(zone) };
 }
 
 export async function getConvenienceZone(
   id: number,
-  userId: string | null
+  userId: string | null,
+  guestClaimTokenHashes: string[] = []
 ): Promise<ServiceResult<ConvenienceZoneWithReady>> {
   try {
     const zone = await prisma.convenienceZone.findUnique({
-      where: { id },
-      include: { user: { select: { email: true } } }
+      where: { id }
     });
     if (!zone) {
       return { ok: false, message: 'Not found', status: 404 };
     }
-    if (!canReadConvenienceZone(zone, userId)) {
+    if (!canReadConvenienceZone(zone, userId, guestClaimTokenHashes)) {
       return zoneAccessDenied(userId);
     }
 
-    return { ok: true, data: withReady(stripOwnerRelation(zone)) };
+    return { ok: true, data: withReady(zone) };
   } catch (error) {
     return { ok: false, message: String(error), status: 500 };
   }
+}
+
+export async function claimGuestConvenienceZones(
+  claimTokens: string[],
+  userId: string
+): Promise<ServiceResult<{ claimed_zone_ids: number[] }>> {
+  const parsed = guestZoneClaimTokensSchema.safeParse(claimTokens);
+  if (!parsed.success) {
+    return { ok: false, message: parsed.error.message, status: 400 };
+  }
+
+  const tokenHashes = parsed.data.map(hashGuestZoneClaimToken);
+  if (tokenHashes.length === 0) {
+    return { ok: true, data: { claimed_zone_ids: [] } };
+  }
+
+  const zones = await prisma.convenienceZone.findMany({
+    where: { guest_claim_token_hash: { in: tokenHashes } },
+    select: { id: true }
+  });
+  const zoneIds = zones.map((zone) => zone.id);
+
+  if (zoneIds.length === 0) {
+    return { ok: true, data: { claimed_zone_ids: [] } };
+  }
+
+  await prisma.convenienceZone.updateMany({
+    where: { id: { in: zoneIds } },
+    data: {
+      user_id: userId,
+      guest_claim_token_hash: null
+    }
+  });
+
+  for (const zoneId of zoneIds) {
+    broadcast({ type: 'zone-updated', zone_id: zoneId });
+  }
+
+  return { ok: true, data: { claimed_zone_ids: zoneIds } };
 }
 
 export function getConvenienceZoneUpdateData(body: {

--- a/src/server/services/guest-zone-claims.test.mjs
+++ b/src/server/services/guest-zone-claims.test.mjs
@@ -1,0 +1,34 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  GUEST_ZONE_CLAIMS_HEADER,
+  getGuestZoneClaimTokenHashesFromHeaders,
+  hashGuestZoneClaimToken
+} from './guest-zone-claims.ts';
+
+test('hashGuestZoneClaimToken returns stable non-raw token hashes', () => {
+  const token = 'a-valid-guest-claim-token';
+  const hash = hashGuestZoneClaimToken(token);
+
+  assert.equal(hash, hashGuestZoneClaimToken(token));
+  assert.notEqual(hash, token);
+  assert.equal(hash.length, 64);
+});
+
+test('getGuestZoneClaimTokenHashesFromHeaders parses comma-separated claims', () => {
+  const headers = new Headers({
+    [GUEST_ZONE_CLAIMS_HEADER]:
+      'first-valid-guest-token, second-valid-guest-token'
+  });
+
+  assert.deepEqual(getGuestZoneClaimTokenHashesFromHeaders(headers), [
+    hashGuestZoneClaimToken('first-valid-guest-token'),
+    hashGuestZoneClaimToken('second-valid-guest-token')
+  ]);
+});
+
+test('getGuestZoneClaimTokenHashesFromHeaders ignores invalid claim headers', () => {
+  const headers = new Headers({ [GUEST_ZONE_CLAIMS_HEADER]: 'too-short' });
+
+  assert.deepEqual(getGuestZoneClaimTokenHashesFromHeaders(headers), []);
+});

--- a/src/server/services/guest-zone-claims.ts
+++ b/src/server/services/guest-zone-claims.ts
@@ -1,0 +1,38 @@
+import { createHash } from 'node:crypto';
+import { z } from 'zod';
+
+export const GUEST_ZONE_CLAIMS_HEADER = 'x-delineo-guest-zone-claims';
+
+const guestZoneClaimTokenSchema = z.string().min(16).max(256);
+
+export const guestZoneClaimTokensSchema = z
+  .array(guestZoneClaimTokenSchema)
+  .max(100);
+
+export const claimGuestZonesSchema = z.object({
+  claim_tokens: guestZoneClaimTokensSchema
+});
+
+export function hashGuestZoneClaimToken(token: string) {
+  return createHash('sha256').update(token).digest('hex');
+}
+
+export function getGuestZoneClaimTokenHashesFromHeaders(headers: Headers) {
+  const rawHeader = headers.get(GUEST_ZONE_CLAIMS_HEADER);
+  if (!rawHeader) {
+    return [];
+  }
+
+  const parsed = guestZoneClaimTokensSchema.safeParse(
+    rawHeader
+      .split(',')
+      .map((token) => token.trim())
+      .filter(Boolean)
+  );
+
+  if (!parsed.success) {
+    return [];
+  }
+
+  return parsed.data.map(hashGuestZoneClaimToken);
+}

--- a/src/server/services/simdata-cache.ts
+++ b/src/server/services/simdata-cache.ts
@@ -11,12 +11,12 @@ type SimDataCacheEntry = {
 
 export async function listSimDataCacheForZone(
   czoneId: number,
-  userId: string | null
+  userId: string | null,
+  guestClaimTokenHashes: string[] = []
 ): Promise<ServiceResult<SimDataCacheEntry[]>> {
   const czone = await prisma.convenienceZone.findUnique({
     where: { id: czoneId },
     include: {
-      user: { select: { email: true } },
       simdata: { orderBy: { id: 'desc' } }
     }
   });
@@ -28,7 +28,7 @@ export async function listSimDataCacheForZone(
       status: 404
     };
   }
-  if (!canReadConvenienceZone(czone, userId)) {
+  if (!canReadConvenienceZone(czone, userId, guestClaimTokenHashes)) {
     return zoneAccessDenied(userId);
   }
 

--- a/src/server/services/zone-access.test.mjs
+++ b/src/server/services/zone-access.test.mjs
@@ -1,35 +1,48 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import {
-  ANONYMOUS_ZONE_USER_EMAIL,
   canReadConvenienceZone,
   zoneAccessDenied
 } from './zone-access.ts';
 
 test('canReadConvenienceZone allows the owner', () => {
   assert.equal(
-    canReadConvenienceZone({ user_id: 'user-1' }, 'user-1'),
+    canReadConvenienceZone({ user_id: 'user-1' }, 'user-1', []),
     true
   );
 });
 
 test('canReadConvenienceZone rejects anonymous access to owner-backed zones', () => {
   assert.equal(
-    canReadConvenienceZone({ user_id: 'user-1' }, null),
+    canReadConvenienceZone({ user_id: 'user-1' }, null, []),
     false
   );
 });
 
-test('canReadConvenienceZone treats anonymous-system zones as public', () => {
+test('canReadConvenienceZone allows matching guest claim token hashes', () => {
   assert.equal(
     canReadConvenienceZone(
       {
         user_id: 'anonymous-user',
-        user: { email: ANONYMOUS_ZONE_USER_EMAIL }
+        guest_claim_token_hash: 'hash-1'
+      },
+      null,
+      ['hash-1']
+    ),
+    true
+  );
+});
+
+test('canReadConvenienceZone rejects anonymous zones without matching claims', () => {
+  assert.equal(
+    canReadConvenienceZone(
+      {
+        user_id: 'anonymous-user',
+        guest_claim_token_hash: 'hash-1'
       },
       null
     ),
-    true
+    false
   );
 });
 

--- a/src/server/services/zone-access.ts
+++ b/src/server/services/zone-access.ts
@@ -2,18 +2,22 @@ export const ANONYMOUS_ZONE_USER_EMAIL = 'anonymous-zones@delineo.local';
 
 type ZoneAccessRecord = {
   user_id: string;
-  user?: { email: string | null } | null;
+  guest_claim_token_hash?: string | null;
 };
 
 export function canReadConvenienceZone(
   zone: ZoneAccessRecord,
-  userId: string | null
+  userId: string | null,
+  guestClaimTokenHashes: string[] = []
 ) {
-  if (zone.user?.email === ANONYMOUS_ZONE_USER_EMAIL) {
+  if (userId && zone.user_id === userId) {
     return true;
   }
 
-  return !!userId && zone.user_id === userId;
+  return (
+    !!zone.guest_claim_token_hash &&
+    guestClaimTokenHashes.includes(zone.guest_claim_token_hash)
+  );
 }
 
 export function zoneAccessDenied(userId: string | null) {

--- a/src/styles/simulator.css
+++ b/src/styles/simulator.css
@@ -305,6 +305,15 @@ div.sim_output {
   padding: 0 16px;
 }
 
+.sim_guest_save_notice {
+  width: 100%;
+  margin: -2px 0 0;
+  color: var(--color-text-muted);
+  font-size: 12px;
+  line-height: 1.45;
+  text-align: center;
+}
+
 .sim_table_row {
   display: flex;
   width: 100%;


### PR DESCRIPTION
## Summary
- track logged-out generated zones with session-scoped guest claim tokens
- show guest-generated zones in the Zones list while logged out without exposing other users' zones
- claim those guest zones onto the user account after login and show a login-to-save notice
- enforce guest/user access checks across zone and simdata APIs

## Verification
- pnpm test
- pnpm typecheck
- focused Biome lint on changed files
- full pnpm lint still has pre-existing DMP lint issues outside this change

Companion Algorithms PR: https://github.com/Delineo-Disease-Modeling/Algorithms/pull/13