### PR TITLE
Refactor CZ generation workflow

### DIFF
--- a/refactor-plan.md
+++ b/refactor-plan.md
@@ -1,0 +1,461 @@
+# Fullstack Refactor Plan
+
+Baseline: `origin/main` at `4f4b4ef3652313d98ef629f1ecfa0d4e3594b952`
+(`Disable lockdown probability control`), fetched on 2026-05-14.
+
+This supersedes the old Vite-to-Next migration note. `main` is already a
+Next.js App Router application with Prisma, Better Auth, Zustand, MapLibre, and
+server-side API routes. The refactor should preserve behavior and visual design
+while making the app safer to change.
+
+## Current State
+
+- `src/app/cz-generation/page.tsx` is the main refactor target at 4,554 lines.
+  It mixes algorithm selection, seed lookup, editable CBG state, trace playback,
+  API calls, map state, finalization, and a large JSX surface.
+- `src/components/modelmap.tsx` is 1,574 lines and combines data preparation,
+  geometry helpers, icon generation, MapLibre layers, playback state, and view
+  controls.
+- API routes under `src/app/api` total about 2,029 lines. They repeat request
+  parsing, id validation, auth checks, response shape handling, and file/db
+  resolution logic.
+- Shared simulator data types are informal. Papdata, patterns, simulation
+  timestep data, chart data, and map cache payloads are represented with many
+  `any` casts.
+- Styling is split across many global CSS files imported by pages/components.
+  There is no clear ownership model for page styles versus reusable component
+  styles.
+- The README still describes the old client/server Vite setup and should be
+  brought in line with the current Next.js app.
+
+## Baseline Checks
+
+Run from a clean `origin/main` checkout:
+
+```bash
+/Users/ryad/Code/delineo/Fullstack/node_modules/.bin/biome lint ./src
+/Users/ryad/Code/delineo/Fullstack/node_modules/.bin/tsc --noEmit -p tsconfig.json
+```
+
+Observed baseline:
+
+- TypeScript passes when generated Prisma files and installed dependencies are
+  available.
+- Biome reports 57 warnings, mostly `noExplicitAny`, plus one CSS selector
+  specificity warning in `src/styles/navbar.css`.
+- There is no test script in `package.json`, so the refactor needs to add a
+  minimal automated safety net before large movement.
+
+## Goals
+
+1. Preserve existing UX, URLs, API contracts, database schema, and integration
+   expectations with Algorithms and Simulation.
+2. Split large route/page/component files into cohesive modules with stable
+   interfaces.
+3. Replace broad `any` usage around simulation artifacts with shared domain
+   types and narrow runtime validation at API boundaries.
+4. Make API handlers thin: parse input, call service functions, return a
+   standard response.
+5. Add enough tests and fixtures to make future behavior changes observable.
+6. Update docs so setup and architecture match the actual Next.js repo.
+
+## Non-Goals
+
+- Do not redesign the site or change the public workflows.
+- Do not change Prisma schema or database storage unless a later bug fix
+  explicitly requires it.
+- Do not rewrite Algorithms or Simulation.
+- Do not move to a new state manager, component library, map library, or CSS
+  framework during this refactor.
+- Do not work directly on `main`.
+
+## Branching Strategy
+
+Use short-lived branches from the latest `main`.
+
+Recommended umbrella branch name:
+
+```bash
+ryad/fullstack-refactor
+```
+
+For safer review, split implementation into smaller PR branches:
+
+- `ryad/fullstack-refactor-foundation`
+- `ryad/fullstack-refactor-api-services`
+- `ryad/fullstack-refactor-cz-generation`
+- `ryad/fullstack-refactor-modelmap`
+- `ryad/fullstack-refactor-docs`
+
+Each PR should be rebased on the latest `main` before review.
+
+## Phase 0: Stabilize The Baseline
+
+Purpose: make the current app measurable before moving code.
+
+Tasks:
+
+- Add a `typecheck` script: `tsc --noEmit`.
+- Add a lightweight test runner, preferably Vitest, for pure TypeScript modules.
+- Add focused fixtures for papdata, patterns, simdata, chart data, and map cache
+  payloads under `src/test/fixtures` or an equivalent test-only folder.
+- Add tests for existing pure helpers before extracting them:
+  - date/month helpers currently in `src/app/cz-generation/page.tsx`
+  - CBG list normalization/deduping/filtering
+  - simulation request building
+  - intervention validation once the pending intervention work lands
+- Decide whether Biome warnings are allowed temporarily. If yes, document a
+  warning budget and reduce it per PR.
+
+Exit criteria:
+
+- `pnpm lint` still passes with the known warnings.
+- `pnpm typecheck` passes.
+- Initial helper tests pass.
+- No behavior changes.
+
+## Phase 1: Create Shared Domain Types
+
+Purpose: give API routes, stores, and components a shared vocabulary.
+
+Proposed structure:
+
+```text
+src/domain/
+  cz.ts
+  simulation.ts
+  papdata.ts
+  patterns.ts
+  map-cache.ts
+  chart-data.ts
+  interventions.ts
+src/server/
+  http.ts
+  auth.ts
+  files.ts
+  validation.ts
+```
+
+Tasks:
+
+- Move `ConvenienceZone`, `SimSettings`, `Interventions`, and related request
+  payload types out of stores into domain files. Stores should import domain
+  types, not define them.
+- Define narrow types for:
+  - papdata people, homes, places
+  - pattern timesteps
+  - simulation disease state timesteps
+  - map cache payloads
+  - chart data series
+  - person path response payloads
+- Add small parsing helpers for unknown JSON from disk and external services.
+  Use Zod only at boundaries where runtime validation is worth the cost.
+- Update `src/lib/papdata-cache.ts`, `src/lib/sim-processor.ts`,
+  `src/app/api/simdata/[id]/chartdata/route.ts`,
+  `src/app/api/simdata/[id]/person-path/route.ts`, and
+  `src/app/api/papdata/[czone_id]/route.ts` to consume those types.
+
+Exit criteria:
+
+- The first batch of `noExplicitAny` warnings is removed from server/data code.
+- Pure domain helpers have unit tests.
+- No route contract changes.
+
+## Phase 2: Thin API Routes Into Services
+
+Purpose: make API behavior reusable and testable without Next route wrappers.
+
+Proposed structure:
+
+```text
+src/server/services/
+  convenience-zones.ts
+  simulation-runs.ts
+  simulation-processing.ts
+  exports.ts
+  lookup-location.ts
+src/server/repositories/
+  convenience-zone-repository.ts
+  simulation-run-repository.ts
+```
+
+Tasks:
+
+- Add shared utilities for:
+  - numeric route param parsing
+  - session loading and required-auth responses
+  - ownership checks for zones and simulation runs
+  - consistent `{ data }` and `{ message }` JSON responses
+  - handling `ENOENT` for DB files
+- Extract route bodies into service functions while keeping each route file as
+  a thin adapter.
+- Consolidate duplicated simulation upload paths:
+  - `src/app/api/simdata/route.ts`
+  - `src/app/api/simdata-json/route.ts`
+- Move map cache response assembly and optional gzip handling out of
+  `src/app/api/simdata/[id]/route.ts`.
+- Move person-path calculation out of its route into a tested service/helper.
+- Preserve current auth behavior exactly, including anonymous CZ creation if it
+  is still intended product behavior. If not intended, capture that as a
+  separate product/security change rather than mixing it into this refactor.
+
+Exit criteria:
+
+- Route handlers are short and mostly read as parse, authorize, call service,
+  return response.
+- Service functions have unit tests around success and expected error cases.
+- Existing API endpoints keep the same status codes and response shapes.
+
+## Phase 3: Split CZ Generation
+
+Purpose: reduce the 4,554-line page into a feature folder without changing the
+workflow.
+
+Proposed structure:
+
+```text
+src/features/cz-generation/
+  page-client.tsx
+  types.ts
+  constants.ts
+  date-utils.ts
+  geojson-utils.ts
+  api.ts
+  hooks/
+    use-pattern-availability.ts
+    use-seed-resolution.ts
+    use-seed-editing.ts
+    use-clustering-preview.ts
+    use-guided-destinations.ts
+    use-trace-playback.ts
+    use-zone-metrics.ts
+    use-finalize-zone.ts
+  components/
+    setup-panel.tsx
+    algorithm-guide.tsx
+    seed-preview-panel.tsx
+    seed-edit-toolbar.tsx
+    guided-destinations-panel.tsx
+    trace-panel.tsx
+    manual-candidates-panel.tsx
+    zone-summary-panel.tsx
+    finalization-panel.tsx
+```
+
+Tasks:
+
+- Keep `src/app/cz-generation/page.tsx` as a small route entry that renders the
+  feature client component.
+- Move constants and local types first. This should be a mechanical PR with no
+  behavioral changes.
+- Extract pure helpers next:
+  - month/date conversion
+  - CBG list dedupe/equality
+  - GeoJSON filtering and ID extraction
+  - trace layer derivation
+  - guided selection summaries
+- Extract API client functions into `api.ts`:
+  - `pattern-availability`
+  - `cbg-geojson`
+  - `cz-metrics`
+  - `candidate-pois`
+  - `frontier-candidates`
+  - `second-order-destinations`
+  - `cluster-cbgs`
+  - `finalize-cz`
+  - `export-cz-map-html`
+- Extract hooks by workflow state, not by technical mechanism. Each hook should
+  own one API interaction or one state machine.
+- Extract presentational panels after state ownership is clear.
+- Keep the current CSS class names initially to avoid visual churn. Only
+  reorganize CSS after screenshots confirm parity.
+
+Exit criteria:
+
+- `src/app/cz-generation/page.tsx` is below 100 lines.
+- Feature modules have named responsibilities and limited cross imports.
+- Existing seed lookup, seed editing, clustering, guided selection, trace view,
+  finalization, and map export workflows still work.
+
+## Phase 4: Split Model Map
+
+Purpose: isolate map data transformation from MapLibre rendering.
+
+Proposed structure:
+
+```text
+src/features/model-map/
+  model-map.tsx
+  clustered-map.tsx
+  playback-controls.tsx
+  emoji-overlay.tsx
+  geometry.ts
+  household-layout.ts
+  poi-icons.ts
+  people-dots.ts
+  layers.ts
+  types.ts
+```
+
+Tasks:
+
+- Move geometry helpers into `geometry.ts` and test them with simple polygon and
+  multipolygon fixtures.
+- Move household layout generation into `household-layout.ts`.
+- Move icon and people-dot GeoJSON generation into pure modules.
+- Replace module-level mutable caches where practical with memoized values owned
+  by the component or by explicit cache helpers.
+- Type MapLibre event and feature objects narrowly enough to remove broad `any`
+  from click handlers, popup state, and data props.
+- Keep `ModelMap` as the public component API while introducing smaller internal
+  components.
+
+Exit criteria:
+
+- `src/components/modelmap.tsx` is either removed or becomes a compatibility
+  re-export.
+- Pure map data functions have tests.
+- Simulation playback, heatmap/marker modes, popups, and person path selection
+  still work.
+
+## Phase 5: Normalize UI State And Stores
+
+Purpose: make global state intentional.
+
+Tasks:
+
+- Keep only cross-route or cross-component state in Zustand stores.
+- Move page-local state from stores into feature hooks where it is not shared.
+- Replace ad hoc fetch/loading/error state with a small local pattern used
+  consistently by CZ generation and simulator pages.
+- Audit `src/stores/simsettings.ts` and `src/stores/mapdata.ts` for values that
+  are actually server data, derived data, or route params.
+- Keep persisted auth state isolated in `useAuthStore` unless Better Auth now
+  makes parts redundant.
+
+Exit criteria:
+
+- Store modules are small and domain-typed.
+- Feature hooks expose explicit command functions and derived state.
+- Simulator and CZ generation code no longer read arbitrary store snapshots
+  except at clear submission points.
+
+## Phase 6: Styling And Component Ownership
+
+Purpose: reduce accidental global CSS coupling.
+
+Tasks:
+
+- Keep current visual design, but group styles by feature or reusable component.
+- Fix the baseline `navbar.css` specificity warning.
+- Introduce simple reusable primitives only where repeated UI exists already:
+  buttons, sliders, form rows, error banners, loading/progress blocks, tabs, and
+  panel shells.
+- Avoid a broad redesign or Tailwind conversion. The risk is not worth mixing
+  into the structural refactor.
+- Use visual regression checks for:
+  - home page
+  - about page
+  - team page
+  - simulator setup page
+  - simulator run page
+  - CZ generation input/edit/finalizing states
+
+Exit criteria:
+
+- CSS ownership is clear.
+- No page-level visual drift except intentional bug fixes.
+- Reusable UI components are used where they reduce duplication.
+
+## Phase 7: Docs And Developer Workflow
+
+Purpose: make the repo easier to run and maintain.
+
+Tasks:
+
+- Rewrite `README.md` for the current Next.js app. Remove references to running
+  from `client`.
+- Document required environment variables:
+  - `PRISMA_DB_URL`
+  - `BETTER_AUTH_URL`
+  - `BETTER_AUTH_SECRET`
+  - `DB_FOLDER`
+  - `NEXT_PUBLIC_ALG_URL`
+  - `NEXT_PUBLIC_SIM_URL`
+  - any server-only `ALG_URL` usage
+- Document generated Prisma output under `src/generated/prisma`.
+- Document local dependencies on Algorithms and Simulation, including expected
+  ports and health checks.
+- Add a short architecture section that points to `src/domain`,
+  `src/server`, and `src/features`.
+
+Exit criteria:
+
+- A new contributor can install, configure, run, lint, typecheck, and build the
+  app from the README.
+- The old Vite/client/server instructions are gone.
+
+## Validation Gates For Every PR
+
+Required:
+
+```bash
+pnpm lint
+pnpm typecheck
+pnpm test
+```
+
+When relevant:
+
+```bash
+pnpm build
+```
+
+Manual checks:
+
+- Log in and load saved convenience zones.
+- Generate a convenience zone from a ZIP/location.
+- Edit seed CBGs on the map.
+- Run each clustering algorithm currently exposed in the UI.
+- Finalize a zone and confirm papdata/patterns are attached.
+- Run a simulation using a finalized zone.
+- Open a saved simulation run.
+- Verify output charts, map playback, heatmap/marker modes, and person path.
+- Export CZ and simulation artifacts.
+
+## Suggested PR Sequence
+
+1. Foundation: add `typecheck`, test runner, fixtures, and README note about the
+   ongoing refactor.
+2. Domain types: add shared simulation/CZ/papdata/map-cache types and migrate
+   server data helpers.
+3. API services: extract common route utilities and service modules.
+4. CZ generation extraction, part 1: constants, types, pure helpers, API client.
+5. CZ generation extraction, part 2: hooks and panel components.
+6. Model map extraction: geometry/layout/dot/icon helpers, then rendering split.
+7. Store cleanup and UI state normalization.
+8. Styling ownership and docs.
+
+## Risks
+
+- CZ generation has many interdependent states. Extract hooks in workflow order
+  and keep screenshots/manual checks after each PR.
+- Simulation data files can be large. Avoid adding full-file parsing where
+  streaming currently protects memory usage.
+- API routes currently encode product decisions, especially around auth and
+  anonymous zone creation. Preserve behavior unless a separate product decision
+  says otherwise.
+- Generated Prisma files are required for typechecking. CI should run
+  `prisma generate` before `tsc`.
+- External services on Algorithms and Simulation must remain compatible. Treat
+  request/response payload changes as separate integration work.
+
+## Definition Of Done
+
+- Large files are reduced to focused modules without losing current behavior.
+- Core simulation artifact types are shared across server and client code.
+- Server routes are thin wrappers over tested services.
+- Biome `noExplicitAny` warnings are either resolved or isolated to documented
+  third-party boundary adapters.
+- README matches the actual Next.js workflow.
+- The full validation gate passes from a clean branch based on latest `main`.

--- a/refactor-plan.md
+++ b/refactor-plan.md
@@ -1,7 +1,7 @@
 # Fullstack Refactor Plan
 
-Baseline: `origin/main` at `4f4b4ef3652313d98ef629f1ecfa0d4e3594b952`
-(`Disable lockdown probability control`), fetched on 2026-05-14.
+Baseline: `origin/main` at `7d8ddf3` (`Made website page layouts more
+consistent Added smoother AOS/loading animations`), refreshed on 2026-05-19.
 
 This supersedes the old Vite-to-Next migration note. `main` is already a
 Next.js App Router application with Prisma, Better Auth, Zustand, MapLibre, and
@@ -10,13 +10,16 @@ while making the app safer to change.
 
 ## Current State
 
-- `src/app/cz-generation/page.tsx` is the main refactor target at 4,554 lines.
+- `src/app/cz-generation/page.tsx` is the main refactor target at 4,074 lines.
   It mixes algorithm selection, seed lookup, editable CBG state, trace playback,
   API calls, map state, finalization, and a large JSX surface.
-- `src/components/modelmap.tsx` is 1,574 lines and combines data preparation,
-  geometry helpers, icon generation, MapLibre layers, playback state, and view
-  controls.
-- API routes under `src/app/api` total about 2,029 lines. They repeat request
+- `src/components/modelmap.tsx` is 782 lines after an initial model-map data
+  extraction. `src/features/model-map/map-data.ts` is now 1,047 lines and still
+  holds substantial pure map transformation logic.
+- `src/features/cz-generation` already contains constants, helpers, types, and
+  an API client. The next CZ-generation work should extract workflow hooks and
+  presentational panels.
+- API routes under `src/app/api` total about 2,202 lines. They repeat request
   parsing, id validation, auth checks, response shape handling, and file/db
   resolution logic.
 - Shared simulator data types are informal. Papdata, patterns, simulation
@@ -25,26 +28,26 @@ while making the app safer to change.
 - Styling is split across many global CSS files imported by pages/components.
   There is no clear ownership model for page styles versus reusable component
   styles.
-- The README still describes the old client/server Vite setup and should be
-  brought in line with the current Next.js app.
+- `package.json` now has `lint`, `typecheck`, and `test` scripts. Tests use the
+  Node test runner and currently cover selected pure helpers and route/service
+  utilities.
 
 ## Baseline Checks
 
-Run from a clean `origin/main` checkout:
+Run from a clean checkout:
 
 ```bash
-/Users/ryad/Code/delineo/Fullstack/node_modules/.bin/biome lint ./src
-/Users/ryad/Code/delineo/Fullstack/node_modules/.bin/tsc --noEmit -p tsconfig.json
+pnpm lint
+pnpm typecheck
+pnpm test
 ```
 
 Observed baseline:
 
-- TypeScript passes when generated Prisma files and installed dependencies are
-  available.
-- Biome reports 57 warnings, mostly `noExplicitAny`, plus one CSS selector
-  specificity warning in `src/styles/navbar.css`.
-- There is no test script in `package.json`, so the refactor needs to add a
-  minimal automated safety net before large movement.
+- `pnpm lint`, `pnpm typecheck`, and `pnpm test` pass on
+  `ryad/fullstack-refactor` before the next extraction.
+- `pnpm test` currently runs 18 Node tests.
+- Keep this validation gate green after each small extraction.
 
 ## Goals
 
@@ -95,8 +98,8 @@ Purpose: make the current app measurable before moving code.
 
 Tasks:
 
-- Add a `typecheck` script: `tsc --noEmit`.
-- Add a lightweight test runner, preferably Vitest, for pure TypeScript modules.
+- Keep the existing `typecheck` script: `tsc --noEmit`.
+- Keep the existing Node test runner unless a later need justifies Vitest.
 - Add focused fixtures for papdata, patterns, simdata, chart data, and map cache
   payloads under `src/test/fixtures` or an equivalent test-only folder.
 - Add tests for existing pure helpers before extracting them:

--- a/refactor.md
+++ b/refactor.md
@@ -6,7 +6,7 @@
 
 - Start feature and fix work from the latest `main` on a short-lived branch.
 - Prefer branch names like `ryad/<feature-or-fix>`.
-- Use the foundation worktree and branch when coordinating refactor work: `Fullstack-refactor-foundation` on `ryad/fullstack-refactor-foundation`.
+- Use `ryad/fullstack-refactor` as the current refactor branch.
 - Treat unrelated dirty files as someone else's work. Do not revert, rewrite, or reformat outside the assigned ownership area.
 
 ## Current App Shape

--- a/src/app/api/dmp/matrices/[id]/route.ts
+++ b/src/app/api/dmp/matrices/[id]/route.ts
@@ -6,7 +6,8 @@ import { prisma } from '@/lib/prisma';
 const TWO_MB = 2 * 1024 * 1024;
 
 function validateMatrixCsv(content: string): string | null {
-  if (content.length > TWO_MB) return 'Matrix file exceeds the 2 MB size limit.';
+  if (content.length > TWO_MB)
+    return 'Matrix file exceeds the 2 MB size limit.';
 
   const dataLines = content.split('\n').filter((line) => {
     const t = line.trim();
@@ -15,14 +16,23 @@ function validateMatrixCsv(content: string): string | null {
 
   if (dataLines.length === 0) return 'CSV file has no data rows.';
 
-  const numStates = dataLines[0].split(',').map((v) => v.trim()).filter(Boolean).length;
-  if (numStates < 2) return `First data row has only ${numStates} column(s); expected at least 2 states.`;
+  const numStates = dataLines[0]
+    .split(',')
+    .map((v) => v.trim())
+    .filter(Boolean).length;
+  if (numStates < 2)
+    return `First data row has only ${numStates} column(s); expected at least 2 states.`;
 
   for (let i = 0; i < dataLines.length; i++) {
-    const values = dataLines[i].split(',').map((v) => v.trim()).filter(Boolean);
-    if (values.length !== numStates) return `Row ${i + 1} has ${values.length} column(s) but expected ${numStates}.`;
+    const values = dataLines[i]
+      .split(',')
+      .map((v) => v.trim())
+      .filter(Boolean);
+    if (values.length !== numStates)
+      return `Row ${i + 1} has ${values.length} column(s) but expected ${numStates}.`;
     for (const val of values) {
-      if (isNaN(Number(val))) return `Row ${i + 1} contains a non-numeric value: "${val}".`;
+      if (Number.isNaN(Number(val)))
+        return `Row ${i + 1} contains a non-numeric value: "${val}".`;
     }
   }
 
@@ -68,7 +78,10 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
   try {
     const session = await auth.api.getSession({ headers: request.headers });
     if (!session?.user) {
-      return Response.json({ message: 'Authentication required.' }, { status: 401 });
+      return Response.json(
+        { message: 'Authentication required.' },
+        { status: 401 }
+      );
     }
 
     const { id } = await params;
@@ -77,15 +90,23 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
       return Response.json({ message: 'Invalid matrix ID.' }, { status: 400 });
     }
 
-    const matrix = await prisma.dmpMatrix.findUnique({ where: { id: matrixId } });
+    const matrix = await prisma.dmpMatrix.findUnique({
+      where: { id: matrixId }
+    });
     if (!matrix) {
       return Response.json({ message: 'Matrix not found.' }, { status: 404 });
     }
     if (matrix.is_default) {
-      return Response.json({ message: 'Built-in matrices cannot be edited.' }, { status: 403 });
+      return Response.json(
+        { message: 'Built-in matrices cannot be edited.' },
+        { status: 403 }
+      );
     }
     if (matrix.user_id !== session.user.id) {
-      return Response.json({ message: 'Only the owner can edit this matrix.' }, { status: 403 });
+      return Response.json(
+        { message: 'Only the owner can edit this matrix.' },
+        { status: 403 }
+      );
     }
 
     const body = await request.json();
@@ -116,7 +137,10 @@ export async function DELETE(request: NextRequest, { params }: RouteParams) {
   try {
     const session = await auth.api.getSession({ headers: request.headers });
     if (!session?.user) {
-      return Response.json({ message: 'Authentication required.' }, { status: 401 });
+      return Response.json(
+        { message: 'Authentication required.' },
+        { status: 401 }
+      );
     }
 
     const { id } = await params;
@@ -125,15 +149,23 @@ export async function DELETE(request: NextRequest, { params }: RouteParams) {
       return Response.json({ message: 'Invalid matrix ID.' }, { status: 400 });
     }
 
-    const matrix = await prisma.dmpMatrix.findUnique({ where: { id: matrixId } });
+    const matrix = await prisma.dmpMatrix.findUnique({
+      where: { id: matrixId }
+    });
     if (!matrix) {
       return Response.json({ message: 'Matrix not found.' }, { status: 404 });
     }
     if (matrix.is_default) {
-      return Response.json({ message: 'Built-in matrices cannot be deleted.' }, { status: 403 });
+      return Response.json(
+        { message: 'Built-in matrices cannot be deleted.' },
+        { status: 403 }
+      );
     }
     if (matrix.user_id !== session.user.id) {
-      return Response.json({ message: 'Only the owner can delete this matrix.' }, { status: 403 });
+      return Response.json(
+        { message: 'Only the owner can delete this matrix.' },
+        { status: 403 }
+      );
     }
 
     await prisma.dmpMatrix.delete({ where: { id: matrixId } });

--- a/src/app/api/dmp/matrices/route.ts
+++ b/src/app/api/dmp/matrices/route.ts
@@ -27,18 +27,24 @@ function validateMatrixCsv(content: string): string | null {
     return 'CSV file has no data rows.';
   }
 
-  const numStates = dataLines[0].split(',').map((v) => v.trim()).filter(Boolean).length;
+  const numStates = dataLines[0]
+    .split(',')
+    .map((v) => v.trim())
+    .filter(Boolean).length;
   if (numStates < 2) {
     return `First data row has only ${numStates} column(s); expected at least 2 states.`;
   }
 
   for (let i = 0; i < dataLines.length; i++) {
-    const values = dataLines[i].split(',').map((v) => v.trim()).filter(Boolean);
+    const values = dataLines[i]
+      .split(',')
+      .map((v) => v.trim())
+      .filter(Boolean);
     if (values.length !== numStates) {
       return `Row ${i + 1} has ${values.length} column(s) but expected ${numStates}.`;
     }
     for (const val of values) {
-      if (isNaN(Number(val))) {
+      if (Number.isNaN(Number(val))) {
         return `Row ${i + 1} contains a non-numeric value: "${val}".`;
       }
     }
@@ -53,12 +59,20 @@ function validateMatrixCsv(content: string): string | null {
 }
 
 function getDefaultMatrixContent(): string {
-  const filePath = join(process.cwd(), 'public', 'data', 'matrices', 'combined_default.csv');
+  const filePath = join(
+    process.cwd(),
+    'public',
+    'data',
+    'matrices',
+    'combined_default.csv'
+  );
   return readFileSync(filePath, 'utf8');
 }
 
 async function ensureDefaultMatrix() {
-  const existing = await prisma.dmpMatrix.findFirst({ where: { is_default: true } });
+  const existing = await prisma.dmpMatrix.findFirst({
+    where: { is_default: true }
+  });
   if (existing) return;
   await prisma.dmpMatrix.create({
     data: {
@@ -107,7 +121,10 @@ export async function POST(request: NextRequest) {
   try {
     const session = await auth.api.getSession({ headers: request.headers });
     if (!session?.user) {
-      return Response.json({ message: 'Authentication required.' }, { status: 401 });
+      return Response.json(
+        { message: 'Authentication required.' },
+        { status: 401 }
+      );
     }
 
     const body = await request.json();

--- a/src/app/cz-generation/page.tsx
+++ b/src/app/cz-generation/page.tsx
@@ -5,6 +5,20 @@ import { useRouter } from 'next/navigation';
 import { Info } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
+  exportCzMapHtml,
+  fetchCandidatePois,
+  fetchCbgAtPoint,
+  fetchCbgGeoJson,
+  fetchCzMetrics,
+  fetchFrontierCandidates,
+  fetchPatternAvailability,
+  fetchSecondOrderDestinations,
+  finalizeConvenienceZone,
+  getClusteringProgressUrl,
+  startClusteringPreview,
+  type FrontierCandidatesResponse
+} from '@/features/cz-generation/api';
+import {
   CBG_GEOJSON_REQUEST_CHUNK_SIZE,
   CLUSTER_ALGORITHM_MANUAL,
   CLUSTER_ALGORITHM_OPTIONS,
@@ -247,17 +261,10 @@ export default function CZGeneration() {
   const isResolvingMapClickRef = useRef(false);
   const attemptedTraceGeoJsonFetchRef = useRef(new Set<string>());
 
-  const ALG_URL = process.env.NEXT_PUBLIC_ALG_URL || 'http://localhost:1880/';
-  const algUrl = useCallback(
-    (path: string) => new URL(path, ALG_URL).toString(),
-    [ALG_URL]
-  );
-
   const [location, setLocation] = useState('');
   const [minPop, setMinPop] = useState(5000);
-  const [clusterAlgorithm, setClusterAlgorithm] = useState<ClusterAlgorithm>(
-    'mobility_prune'
-  );
+  const [clusterAlgorithm, setClusterAlgorithm] =
+    useState<ClusterAlgorithm>('mobility_prune');
   const [showAdvancedClustering, setShowAdvancedClustering] = useState(false);
   const [seedGuardDistanceKm, setSeedGuardDistanceKm] = useState(20);
   const [mobilityPruneMinSeedCapturePct, setMobilityPruneMinSeedCapturePct] =
@@ -722,22 +729,17 @@ export default function CZGeneration() {
     const controller = new AbortController();
     setAvailableMonthsLoading(true);
 
-    const params = new URLSearchParams({
-      state: detectedStateAbbr,
-      start_date: '2018-01-01',
-      end_date: '2025-12-31'
-    });
-
-    fetch(algUrl(`pattern-availability?${params.toString()}`), {
-      signal: controller.signal
-    })
+    fetchPatternAvailability(
+      {
+        state: detectedStateAbbr,
+        startDate: '2018-01-01',
+        endDate: '2025-12-31'
+      },
+      controller.signal
+    )
       .then(async (resp) => {
-        if (!resp.ok) {
-          throw new Error(`Pattern availability failed: ${resp.status}`);
-        }
-        const json = await resp.json();
-        const months = Array.isArray(json?.data?.available_months)
-          ? (json.data.available_months as unknown[]).filter(
+        const months = Array.isArray(resp?.data?.available_months)
+          ? resp.data.available_months.filter(
               (m): m is string => typeof m === 'string'
             )
           : [];
@@ -755,7 +757,7 @@ export default function CZGeneration() {
       });
 
     return () => controller.abort();
-  }, [algUrl, detectedStateAbbr]);
+  }, [detectedStateAbbr]);
 
   const monthOptions = useMemo(
     () => [...availableMonths].sort(),
@@ -812,17 +814,11 @@ export default function CZGeneration() {
     }
 
     let cancelled = false;
-    fetch(
-      `${algUrl('cbg-geojson')}?cbgs=${encodeURIComponent(
-        selectedCBGs.join(',')
-      )}&include_neighbors=false`
-    )
-      .then(async (resp) => {
-        const data = await resp.json().catch(() => null);
-        if (cancelled || !resp.ok || !data?.features?.length) {
+    fetchCbgGeoJson(selectedCBGs, false)
+      .then((geojson) => {
+        if (cancelled || !geojson?.features?.length) {
           return;
         }
-        const geojson = data as GeoJSONData;
         setCbgGeoJSON(geojson);
         const bounds = getBoundsForGeoJson(geojson);
         if (bounds) {
@@ -841,7 +837,7 @@ export default function CZGeneration() {
     return () => {
       cancelled = true;
     };
-  }, [algUrl, guidedSelectionMode, selectedCBGs]);
+  }, [guidedSelectionMode, selectedCBGs]);
 
   useEffect(() => {
     if (traceStepIndex > maxTraceStep) {
@@ -896,11 +892,10 @@ export default function CZGeneration() {
     }
 
     attemptedTraceGeoJsonFetchRef.current.add(normalized);
-    fetch(`${algUrl('cbg-geojson')}?cbgs=${normalized}&include_neighbors=false`)
-      .then((resp) => (resp.ok ? resp.json() : null))
-      .then((data) => {
-        if (data?.features?.length) {
-          setCbgGeoJSON((prev) => mergeGeoJsonFeatures(prev, data));
+    fetchCbgGeoJson([normalized], false)
+      .then((geojson) => {
+        if (geojson?.features?.length) {
+          setCbgGeoJSON((prev) => mergeGeoJsonFeatures(prev, geojson));
         }
       })
       .catch((err) => {
@@ -909,7 +904,7 @@ export default function CZGeneration() {
           err
         );
       });
-  }, [algUrl, cbgGeoJSON, focusedTraceCbg, showCandidatePanels]);
+  }, [cbgGeoJSON, focusedTraceCbg, showCandidatePanels]);
 
   useEffect(() => {
     if (!hasGenerated || !seedCBG || selectedCBGs.length === 0) {
@@ -922,19 +917,14 @@ export default function CZGeneration() {
     const timer = setTimeout(async () => {
       setCziLoading(true);
       try {
-        const resp = await fetch(algUrl('cz-metrics'), {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            seed_cbg: seedCBG,
-            cbg_list: selectedCBGs,
-            start_date: startDate,
-            use_test_data: useTestData
-          })
+        const data = await fetchCzMetrics({
+          seed_cbg: seedCBG,
+          cbg_list: selectedCBGs,
+          start_date: startDate,
+          use_test_data: useTestData
         });
-        const data = await resp.json();
         if (!cancelled) {
-          setCziMetrics(resp.ok ? data : null);
+          setCziMetrics(data);
         }
       } catch (err) {
         if (!cancelled) {
@@ -952,7 +942,7 @@ export default function CZGeneration() {
       cancelled = true;
       clearTimeout(timer);
     };
-  }, [algUrl, hasGenerated, seedCBG, selectedCBGs, startDate, useTestData]);
+  }, [hasGenerated, seedCBG, selectedCBGs, startDate, useTestData]);
 
   useEffect(() => {
     if (!showCandidatePanels || !selectedTraceCandidateCbg) {
@@ -974,27 +964,17 @@ export default function CZGeneration() {
     setCandidatePoiLoading(true);
     setCandidatePoiError('');
 
-    fetch(algUrl('candidate-pois'), {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        seed_cbg: seedCBG,
-        candidate_cbg: selectedTraceCandidateCbg,
-        cluster_cbgs: poiCluster,
-        start_date: startDate,
-        use_test_data: useTestData,
-        limit: 8
-      })
+    fetchCandidatePois({
+      seed_cbg: seedCBG,
+      candidate_cbg: selectedTraceCandidateCbg,
+      cluster_cbgs: poiCluster,
+      start_date: startDate,
+      use_test_data: useTestData,
+      limit: 8
     })
-      .then(async (resp) => {
-        const data = await readJsonObject(resp);
+      .then((data) => {
         if (cancelled) {
           return;
-        }
-        if (!resp.ok) {
-          throw new Error(
-            getResponseErrorMessage(resp, data, 'Failed to load POI analysis.')
-          );
         }
         setCandidatePois(
           Array.isArray(data?.pois) ? (data.pois as PoiAnalysis[]) : []
@@ -1020,7 +1000,6 @@ export default function CZGeneration() {
     };
   }, [
     activeTraceStep,
-    algUrl,
     seedCBG,
     selectedCBGs,
     selectedTraceCandidateCbg,
@@ -1072,20 +1051,10 @@ export default function CZGeneration() {
       }
     }
 
-    fetch(algUrl('frontier-candidates'), {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(req)
-    })
-      .then(async (resp) => {
-        const data = await resp.json();
+    fetchFrontierCandidates(req)
+      .then((data: FrontierCandidatesResponse) => {
         if (cancelled) {
           return;
-        }
-        if (!resp.ok) {
-          throw new Error(
-            data?.message || 'Failed to load frontier candidates.'
-          );
         }
         const nextCandidates = Array.isArray(data?.candidates)
           ? data.candidates
@@ -1132,7 +1101,6 @@ export default function CZGeneration() {
       cancelled = true;
     };
   }, [
-    algUrl,
     clusterAlgorithm,
     guidedSelectionMode,
     manualEditPanelsActive,
@@ -1163,23 +1131,15 @@ export default function CZGeneration() {
     setZoneMetricsLoading(true);
     setZoneMetricsError('');
 
-    fetch(algUrl('cz-metrics'), {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        seed_cbg: seedCBG,
-        cbg_list: selectedCBGs,
-        start_date: startDate,
-        use_test_data: useTestData
-      })
+    fetchCzMetrics({
+      seed_cbg: seedCBG,
+      cbg_list: selectedCBGs,
+      start_date: startDate,
+      use_test_data: useTestData
     })
-      .then(async (resp) => {
-        const data = await resp.json();
+      .then((data) => {
         if (cancelled) {
           return;
-        }
-        if (!resp.ok) {
-          throw new Error(data?.message || 'Failed to compute zone metrics.');
         }
         setZoneMetrics(data || null);
       })
@@ -1202,7 +1162,6 @@ export default function CZGeneration() {
       cancelled = true;
     };
   }, [
-    algUrl,
     guidedSelectionMode,
     manualEditPanelsActive,
     seedCBG,
@@ -1247,7 +1206,7 @@ export default function CZGeneration() {
       new Promise((resolve, reject) => {
         let settled = false;
         const eventSource = new EventSource(
-          algUrl(`clustering-progress/${clusteringId}`)
+          getClusteringProgressUrl(clusteringId)
         );
         const timeout = window.setTimeout(
           () => {
@@ -1334,7 +1293,7 @@ export default function CZGeneration() {
           );
         };
       }),
-    [algUrl]
+    []
   );
 
   const loadSeedGeoJson = useCallback(
@@ -1354,13 +1313,8 @@ export default function CZGeneration() {
           index,
           index + CBG_GEOJSON_REQUEST_CHUNK_SIZE
         );
-        const resp = await fetch(
-          `${algUrl('cbg-geojson')}?cbgs=${encodeURIComponent(
-            chunk.join(',')
-          )}&include_neighbors=${includeNeighbors ? 'true' : 'false'}`
-        );
-        const seedGeoJson = await resp.json().catch(() => null);
-        if (!resp.ok || !seedGeoJson?.features?.length) {
+        const seedGeoJson = await fetchCbgGeoJson(chunk, includeNeighbors);
+        if (!seedGeoJson?.features?.length) {
           throw new Error(
             seedGeoJson?.message ||
               'Resolved the seed CBGs, but could not load their map boundary.'
@@ -1381,7 +1335,7 @@ export default function CZGeneration() {
 
       return mergedGeoJson;
     },
-    [algUrl]
+    []
   );
 
   const loadSeedEditGeoJson = useCallback(
@@ -1733,10 +1687,7 @@ export default function CZGeneration() {
     }
 
     try {
-      const resp = await fetch(
-        `${algUrl('cbg-geojson')}?cbgs=${normalized}&include_neighbors=true`
-      );
-      const data = await resp.json();
+      const data = await fetchCbgGeoJson([normalized], true);
       if (data?.features) {
         setCbgGeoJSON((prev) => mergeGeoJsonFeatures(prev, data));
       }
@@ -1756,10 +1707,7 @@ export default function CZGeneration() {
 
     isResolvingMapClickRef.current = true;
     try {
-      const resp = await fetch(
-        `${algUrl('cbg-at-point')}?latitude=${latlng.lat}&longitude=${latlng.lng}&state_fips=${stateHint}`
-      );
-      const data = await resp.json();
+      const data = await fetchCbgAtPoint(latlng, stateHint);
       const clickedCbg = data?.cbg;
       if (!clickedCbg || selectedCBGs.includes(clickedCbg)) {
         return;
@@ -1899,40 +1847,18 @@ export default function CZGeneration() {
     try {
       if (isGuidedSecondOrderAlgorithm) {
         setGuidedDestinationLoading(true);
-        const resp = await fetch(algUrl('second-order-destinations'), {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            cbg: coreCbg,
-            seed_cbgs: resolvedSeedCbgs,
-            start_date: startDate,
-            use_test_data: isTestMode,
-            limit: 12
-          })
+        const data = await fetchSecondOrderDestinations({
+          cbg: coreCbg,
+          seed_cbgs: resolvedSeedCbgs,
+          start_date: startDate,
+          use_test_data: isTestMode,
+          limit: 12
         });
-        const data = (await readJsonObject(resp)) as Record<
-          string,
-          unknown
-        > | null;
-        if (!resp.ok || !data) {
-          throw new Error(
-            getResponseErrorMessage(
-              resp,
-              data,
-              'Failed to load connected city destinations.'
-            )
-          );
-        }
 
         let seedGeoJson = setupSeedGeoJSON;
         if (!seedGeoJson?.features?.length) {
-          const seedGeoResp = await fetch(
-            `${algUrl('cbg-geojson')}?cbgs=${encodeURIComponent(
-              resolvedSeedCbgs.join(',')
-            )}&include_neighbors=false`
-          );
-          const seedGeoData = await seedGeoResp.json().catch(() => null);
-          if (!seedGeoResp.ok || !seedGeoData?.features?.length) {
+          const seedGeoData = await fetchCbgGeoJson(resolvedSeedCbgs, false);
+          if (!seedGeoData?.features?.length) {
             throw new Error(
               seedGeoData?.message ||
                 'Resolved the seed region, but could not load its map boundary.'
@@ -2053,23 +1979,7 @@ export default function CZGeneration() {
         clusterReq.seed_cbgs = resolvedSeedCbgs;
       }
 
-      const resp = await fetch(algUrl('cluster-cbgs'), {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(clusterReq)
-      });
-      const kickoffData = (await readJsonObject(
-        resp
-      )) as ClusteringPreviewResponse | null;
-      if (!resp.ok) {
-        throw new Error(
-          getResponseErrorMessage(
-            resp,
-            kickoffData,
-            'Failed to cluster CBGs. Please try again.'
-          )
-        );
-      }
+      const kickoffData = await startClusteringPreview(clusterReq);
 
       let data = kickoffData;
       if (!Array.isArray(data?.cluster)) {
@@ -2302,13 +2212,8 @@ export default function CZGeneration() {
         ...(guestClaimToken ? { guest_claim_token: guestClaimToken } : {})
       };
 
-      const resp = await fetch(algUrl('finalize-cz'), {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(finalizePayload)
-      });
-      const data = await resp.json();
-      if (!resp.ok || !data?.id) {
+      const data = await finalizeConvenienceZone(finalizePayload);
+      if (!data?.id) {
         throw new Error(
           data?.message ||
             'Failed to create convenience zone. Please try again.'
@@ -2367,36 +2272,15 @@ export default function CZGeneration() {
     try {
       const suggestedName =
         String(cityName || location || 'cz-map').trim() || 'cz-map';
-      const resp = await fetch(algUrl('export-cz-map-html'), {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          cbg_list: selectedCBGs,
-          name: suggestedName
-        })
+      const exportedMap = await exportCzMapHtml({
+        cbg_list: selectedCBGs,
+        name: suggestedName
       });
-      if (!resp.ok) {
-        const errorData = await resp.json().catch(() => null);
-        throw new Error(
-          errorData?.message || 'Failed to export the CZ HTML map.'
-        );
-      }
 
-      const blob = await resp.blob();
-      const disposition = resp.headers.get('content-disposition') || '';
-      const filenameMatch = disposition.match(/filename="?([^"]+)"?/);
-      const filename =
-        filenameMatch?.[1] ||
-        `${
-          suggestedName
-            .replace(/[^A-Za-z0-9._-]+/g, '-')
-            .replace(/^-+|-+$/g, '') || 'cz-map'
-        }.html`;
-
-      const url = URL.createObjectURL(blob);
+      const url = URL.createObjectURL(exportedMap.blob);
       const anchor = document.createElement('a');
       anchor.href = url;
-      anchor.download = filename;
+      anchor.download = exportedMap.filename;
       document.body.appendChild(anchor);
       anchor.click();
       anchor.remove();

--- a/src/app/cz-generation/page.tsx
+++ b/src/app/cz-generation/page.tsx
@@ -1,13 +1,10 @@
 'use client';
 
 import dynamic from 'next/dynamic';
-import { useRouter } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
-  exportCzMapHtml,
   fetchCbgAtPoint,
   fetchCbgGeoJson,
-  finalizeConvenienceZone,
   lookupLocation
 } from '@/features/cz-generation/api';
 import { CandidateAnalysisPanel } from '@/features/cz-generation/components/candidate-analysis-panel';
@@ -20,7 +17,6 @@ import {
   CLUSTER_ALGORITHM_MANUAL,
   CLUSTER_ALGORITHM_OPTIONS,
   EMPTY_LIST,
-  GUIDED_HARD_EXPLICIT_POPULATION,
   GUIDED_REGION_PALETTE,
   GUIDED_SEED_STYLE,
   type ClusterAlgorithm
@@ -29,7 +25,6 @@ import {
   clampIndex,
   dedupeCbgList,
   endDateFromMonth,
-  getLengthHours,
   monthFromDate,
   monthFromEndDate,
   sameStringArray,
@@ -41,6 +36,7 @@ import { useGenerationPreviewSubmit } from '@/features/cz-generation/hooks/use-g
 import { useManualFrontierCandidates } from '@/features/cz-generation/hooks/use-manual-frontier-candidates';
 import { usePatternAvailability } from '@/features/cz-generation/hooks/use-pattern-availability';
 import { useSeedEditing } from '@/features/cz-generation/hooks/use-seed-editing';
+import { useZoneFinalization } from '@/features/cz-generation/hooks/use-zone-finalization';
 import type {
   ClusterAlgorithmMetadata,
   GuidedDestinationCandidate,
@@ -50,7 +46,6 @@ import type {
   TraceLayerData,
   TracePayload
 } from '@/features/cz-generation/types';
-import { useSession } from '@/lib/auth-client';
 import {
   type GeoJSONData,
   getBoundsForGeoJson,
@@ -59,12 +54,7 @@ import {
   mergeGeoJsonFeatures,
   normalizeCbgId
 } from '@/lib/cz-geo';
-import {
-  createGuestZoneClaimToken,
-  rememberGuestZoneClaim
-} from '@/lib/guest-zone-claims';
 import { getStateFromCBG } from '@/lib/simulation-zone';
-import useSimSettings, { type ConvenienceZone } from '@/stores/simsettings';
 import '@/styles/cz-generation.css';
 
 const InteractiveMap = dynamic(() => import('@/components/interactive-map'), {
@@ -74,91 +64,7 @@ const CBGMap = dynamic(() => import('@/components/cbg-map'), { ssr: false });
 
 const EMPTY_CBG_LIST: string[] = [];
 
-async function fetchZoneById(
-  zoneId: number,
-  guestClaimToken?: string | null
-): Promise<ConvenienceZone | null> {
-  try {
-    const res = await fetch(`/api/convenience-zones/${zoneId}`, {
-      headers: guestClaimToken
-        ? { 'X-Delineo-Guest-Zone-Claims': guestClaimToken }
-        : {}
-    });
-    if (!res.ok) return null;
-    const json = await res.json().catch(() => ({}));
-    const zone = json?.data as ConvenienceZone | undefined;
-    return zone?.ready ? zone : null;
-  } catch {
-    return null;
-  }
-}
-
-function waitForZoneReady(
-  zoneId: number,
-  onProgress: (percent: number) => void,
-  guestClaimToken?: string | null
-): Promise<ConvenienceZone | null> {
-  return new Promise((resolve) => {
-    let done = false;
-    let currentProgress = 15;
-    let es: EventSource | null = null;
-
-    const finish = (zone: ConvenienceZone | null) => {
-      if (done) return;
-      done = true;
-      if (progressTimer) clearInterval(progressTimer);
-      if (pollTimer) clearInterval(pollTimer);
-      if (es) es.close();
-      resolve(zone);
-    };
-
-    const progressTimer = window.setInterval(() => {
-      if (done) return;
-      currentProgress = Math.min(
-        92,
-        currentProgress + (92 - currentProgress) * 0.05
-      );
-      onProgress(Math.round(currentProgress));
-    }, 1000);
-
-    const checkReady = async () => {
-      const zone = await fetchZoneById(zoneId, guestClaimToken);
-      if (zone) finish(zone);
-    };
-
-    const pollTimer = window.setInterval(checkReady, 5000);
-
-    try {
-      es = new EventSource('/api/convenience-zones/events');
-      es.onmessage = (ev) => {
-        try {
-          const payload = JSON.parse(ev.data);
-          if (
-            payload?.type === 'zone-ready' &&
-            Number(payload.zone_id) === zoneId
-          ) {
-            checkReady();
-          }
-        } catch {
-          // ignore non-JSON heartbeats
-        }
-      };
-      es.onerror = () => {
-        // polling remains as fallback
-      };
-    } catch {
-      // EventSource may be unavailable; polling will still run
-    }
-
-    checkReady();
-  });
-}
-
 export default function CZGeneration() {
-  const router = useRouter();
-  const { data: session, isPending } = useSession();
-  const user = session?.user;
-  const setSettings = useSimSettings((state) => state.setSettings);
   const isResolvingMapClickRef = useRef(false);
   const attemptedTraceGeoJsonFetchRef = useRef(new Set<string>());
 
@@ -240,10 +146,7 @@ export default function CZGeneration() {
     useState('');
   const [focusedTraceCbg, setFocusedTraceCbg] = useState('');
   const [focusedTraceNonce, setFocusedTraceNonce] = useState(0);
-  const [savingHtmlMap, setSavingHtmlMap] = useState(false);
   const [zoneEditMode, setZoneEditMode] = useState(false);
-  const [finalizeProgress, setFinalizeProgress] = useState(0);
-  const [finalizeStatusMessage, setFinalizeStatusMessage] = useState('');
   const hasGenerated = phase === 'edit' || phase === 'finalizing';
   const isFinalizing = phase === 'finalizing';
   const isGuidedSecondOrderAlgorithm =
@@ -986,217 +889,36 @@ export default function CZGeneration() {
     setMobilityPruneMinSeedCapturePct
   });
 
-  const finalizeCZ = async () => {
-    if (selectedCBGs.length === 0) {
-      setError('Please select at least one CBG');
-      return;
-    }
-
-    if (isPending) {
-      setError(
-        'Please wait while we check whether this zone should be saved to your account.'
-      );
-      return;
-    }
-
-    const lengthHours = getLengthHours(startDate, endDate);
-    if (!lengthHours || lengthHours <= 0) {
-      setError('End date must be after start date.');
-      return;
-    }
-
-    if (
-      guidedSelectionMode &&
-      guidedSelectionSummary.selectedPopulation >
-        GUIDED_HARD_EXPLICIT_POPULATION
-    ) {
-      setError(
-        `Guided explicit population is ${Number(
-          guidedSelectionSummary.selectedPopulation
-        ).toLocaleString()}, which is above the supported cap of ${GUIDED_HARD_EXPLICIT_POPULATION.toLocaleString()}. Remove some connected cities before finalizing.`
-      );
-      return;
-    }
-
-    setPhase('finalizing');
-    setError('');
-    setFinalizeProgress(5);
-    setFinalizeStatusMessage('Creating convenience zone...');
-
-    try {
-      const trimmedDescription = String(description ?? '').trim();
-      const now = new Date();
-      const algorithmLabel =
-        CLUSTER_ALGORITHM_OPTIONS.find(
-          (option) => option.value === clusterAlgorithm
-        )?.label || clusterAlgorithm;
-
-      const generatedDescription = [
-        `Auto-generated on ${now.toLocaleString()}`,
-        `Location: ${cityName || location || 'N/A'}`,
-        `Seed CBG: ${seedCBG || 'N/A'}`,
-        `Algorithm: ${algorithmLabel}`,
-        clusterAlgorithm === 'mobility_prune'
-          ? `Minimum seed movement captured: ${Number(
-              mobilityPruneMinSeedCapturePct || 0
-            ).toFixed(0)}%`
-          : isGuidedSecondOrderAlgorithm
-            ? 'Minimum population filter: not used in guided connected cities mode'
-            : `Minimum population: ${Number(minPop || 0).toLocaleString()}`,
-        `Date range: ${startDate} to ${endDate}`,
-        `CBGs in zone: ${selectedCBGs.length}`,
-        `Test data mode: ${useTestData ? 'Yes' : 'No'}`
-      ];
-
-      if (isGuidedSecondOrderAlgorithm && guidedMetadata) {
-        const selectedLabels = guidedSelectedDestinations.map(
-          (destination) => destination.label
-        );
-        generatedDescription.push(
-          `Seed region: ${
-            guidedMetadata.seed_city_labels?.join(', ') ||
-            guidedMetadata.seed_zip_codes?.join(', ') ||
-            `${guidedMetadata.seed_cbgs.length} seed CBGs`
-          }`
-        );
-        generatedDescription.push(
-          `Selected connected cities: ${
-            selectedLabels.length ? selectedLabels.join(', ') : 'Seed only'
-          }`
-        );
-        generatedDescription.push(
-          `Explicit linked CBGs: ${selectedCBGs.length}`
-        );
-        generatedDescription.push(
-          `Explicit population: ${Number(
-            guidedSelectionSummary.selectedPopulation || 0
-          ).toLocaleString()}`
-        );
-        generatedDescription.push(
-          `Captured external outbound flow (linked CBGs): ${(
-            guidedSelectionSummary.selectedLinkedOutboundShare * 100
-          ).toFixed(1)}%`
-        );
-        generatedDescription.push(
-          `Captured total seed movement: ${(
-            guidedSelectionSummary.selectedSeedMovementShare * 100
-          ).toFixed(1)}%`
-        );
-        generatedDescription.push(
-          `Unmodeled external pressure: ${(
-            guidedSelectionSummary.externalRemainderShare * 100
-          ).toFixed(1)}%`
-        );
-      }
-
-      if (clusterAlgorithm === 'greedy_weight_seed_guard') {
-        generatedDescription.push(
-          `Seed guard distance (km): ${seedGuardDistanceKm}`
-        );
-      }
-      const descriptionToSave =
-        trimmedDescription || generatedDescription.join('\n');
-      if (!trimmedDescription) {
-        setDescription(descriptionToSave);
-      }
-
-      const guestClaimToken = user?.id ? null : createGuestZoneClaimToken();
-
-      const finalizePayload = {
-        name: cityName,
-        description: descriptionToSave,
-        cbg_list: selectedCBGs,
-        start_date: new Date(`${startDate}T00:00:00`).toISOString(),
-        length: lengthHours,
-        latitude: mapCenter?.[0] || 0,
-        longitude: mapCenter?.[1] || 0,
-        use_test_data: useTestData,
-        ...(user?.id ? { user_id: user.id } : {}),
-        ...(guestClaimToken ? { guest_claim_token: guestClaimToken } : {})
-      };
-
-      const data = await finalizeConvenienceZone(finalizePayload);
-      if (!data?.id) {
-        throw new Error(
-          data?.message ||
-            'Failed to create convenience zone. Please try again.'
-        );
-      }
-
-      const zoneId: number = data.id;
-      if (guestClaimToken) {
-        rememberGuestZoneClaim(zoneId, guestClaimToken);
-      }
-      setFinalizeProgress(15);
-      setFinalizeStatusMessage(
-        user?.id
-          ? 'Zone saved. Generating movement patterns...'
-          : 'Zone generated. Generating movement patterns...'
-      );
-
-      const readyZone = await waitForZoneReady(
-        zoneId,
-        (pct) => {
-          setFinalizeProgress(pct);
-        },
-        guestClaimToken
-      );
-
-      if (readyZone) {
-        setSettings({
-          zone: readyZone,
-          hours: readyZone.length,
-          sim_id: null
-        });
-      }
-
-      setFinalizeProgress(100);
-      setFinalizeStatusMessage('Generation complete. Opening simulator...');
-
-      router.push('/simulator');
-    } catch (err) {
-      console.error('Error finalizing CZ:', err);
-      setError(
-        err instanceof Error
-          ? err.message
-          : 'Failed to create convenience zone. Please try again.'
-      );
-      setPhase('edit');
-    }
-  };
-
-  const saveCZHtmlMap = async () => {
-    if (!selectedCBGs.length) {
-      setError('Please select at least one CBG');
-      return;
-    }
-
-    setSavingHtmlMap(true);
-    try {
-      const suggestedName =
-        String(cityName || location || 'cz-map').trim() || 'cz-map';
-      const exportedMap = await exportCzMapHtml({
-        cbg_list: selectedCBGs,
-        name: suggestedName
-      });
-
-      const url = URL.createObjectURL(exportedMap.blob);
-      const anchor = document.createElement('a');
-      anchor.href = url;
-      anchor.download = exportedMap.filename;
-      document.body.appendChild(anchor);
-      anchor.click();
-      anchor.remove();
-      URL.revokeObjectURL(url);
-    } catch (err) {
-      console.error('Failed to save CZ HTML map:', err);
-      setError(
-        err instanceof Error ? err.message : 'Failed to export the CZ HTML map.'
-      );
-    } finally {
-      setSavingHtmlMap(false);
-    }
-  };
+  const {
+    isPending,
+    savingHtmlMap,
+    finalizeProgress,
+    finalizeStatusMessage,
+    finalizeCZ,
+    saveCZHtmlMap
+  } = useZoneFinalization({
+    selectedCBGs,
+    startDate,
+    endDate,
+    guidedSelectionMode,
+    guidedSelectionSummary,
+    description,
+    setDescription,
+    cityName,
+    location,
+    seedCBG,
+    clusterAlgorithm,
+    mobilityPruneMinSeedCapturePct,
+    isGuidedSecondOrderAlgorithm,
+    minPop,
+    useTestData,
+    guidedMetadata,
+    guidedSelectedDestinations,
+    seedGuardDistanceKm,
+    mapCenter,
+    setError,
+    setPhase
+  });
 
   if (isPending) {
     return (

--- a/src/app/cz-generation/page.tsx
+++ b/src/app/cz-generation/page.tsx
@@ -15,6 +15,7 @@ import {
 } from '@/features/cz-generation/api';
 import { CandidateAnalysisPanel } from '@/features/cz-generation/components/candidate-analysis-panel';
 import { FrontierCandidatesPanel } from '@/features/cz-generation/components/frontier-candidates-panel';
+import { GuidedTermsHelpModal } from '@/features/cz-generation/components/guided-terms-help-modal';
 import {
   CBG_GEOJSON_REQUEST_CHUNK_SIZE,
   CLUSTER_ALGORITHM_MANUAL,
@@ -2140,173 +2141,10 @@ export default function CZGeneration() {
           </div>
         </div>
       )}
-      {showGuidedTermsHelp && (
-        <div
-          className="czgen_modal_overlay"
-          role="dialog"
-          aria-modal="true"
-          aria-labelledby="guided-terms-title"
-          tabIndex={-1}
-          onClick={(event) => {
-            if (event.target === event.currentTarget) {
-              setShowGuidedTermsHelp(false);
-            }
-          }}
-          onKeyDown={(event) => {
-            if (event.key === 'Escape') {
-              setShowGuidedTermsHelp(false);
-            }
-          }}
-        >
-          <div className="czgen_modal czgen_modal--wide">
-            <div className="flex items-start justify-between gap-4">
-              <div>
-                <p id="guided-terms-title" className="czgen_modal_title">
-                  How Guided Ranking Works
-                </p>
-                <p className="czgen_modal_subtitle">
-                  The city cards use plain-language labels. This panel maps
-                  those labels back to the ranking terms and explains which
-                  values drive ordering versus selection context.
-                </p>
-              </div>
-              <button
-                type="button"
-                onClick={() => setShowGuidedTermsHelp(false)}
-                className="czgen_btn czgen_btn--sm"
-                style={{ flexShrink: 0 }}
-              >
-                Close
-              </button>
-            </div>
-
-            <div className="mt-4 flex flex-col gap-3 text-sm text-gray-700">
-              <div className="rounded-lg bg-[#f8fafc] px-3 py-3 text-xs text-gray-700">
-                <div className="font-semibold text-[#1f2937]">
-                  Connection (<code>coupling</code>)
-                </div>
-                <div className="mt-1">
-                  Distance-adjusted two-way connection between the seed and a
-                  city. This is the main ranking score, so the list is ordered
-                  by this value.
-                </div>
-                <pre className="mt-2 overflow-x-auto whitespace-pre-wrap font-mono text-[11px] leading-5 text-[#1f2937]">
-                  {`bidirectional_flow = outbound_flow + inbound_flow
-
-coupling =
-  bidirectional_flow / (1 + distance_km / distance_scale_km)`}
-                </pre>
-                <div className="mt-2">
-                  <span className="font-semibold">Terms:</span>{' '}
-                  <code>outbound_flow</code> is travel from the seed to the
-                  city, aggregated across the full city approximation.{' '}
-                  <code>inbound_flow</code> is travel from the city back to the
-                  seed, also aggregated across the full city approximation.{' '}
-                  <code>distance_km</code> is the distance from the seed to the
-                  selected linked CBG layer for that city.{' '}
-                  <code>distance_scale_km</code> is the distance penalty scale.
-                </div>
-              </div>
-              <div className="rounded-lg bg-[#f8fafc] px-3 py-3 text-xs text-gray-700">
-                <div className="font-semibold text-[#1f2937]">
-                  Trips Leaving Seed (
-                  <code>share_of_seed_external_outbound</code>)
-                </div>
-                <div className="mt-1">
-                  On each city card, this is the portion of trips leaving the
-                  seed that go to that full connected city. It remains a
-                  city-level ranking/context metric.
-                </div>
-                <pre className="mt-2 overflow-x-auto whitespace-pre-wrap font-mono text-[11px] leading-5 text-[#1f2937]">
-                  {`share_of_seed_external_outbound =
-  outbound_flow / total_seed_external_outbound_flow`}
-                </pre>
-                <div className="mt-2">
-                  <span className="font-semibold">Terms:</span>{' '}
-                  <code>total_seed_external_outbound_flow</code> only counts
-                  trips that leave the seed for outside destinations. The
-                  numerator is the full city approximation&apos;s outbound flow,
-                  not only the linked CBG subset.
-                </div>
-              </div>
-              <div className="rounded-lg bg-[#f8fafc] px-3 py-3 text-xs text-gray-700">
-                <div className="font-semibold text-[#1f2937]">
-                  Trips Leaving Seed In Summary
-                </div>
-                <div className="mt-1">
-                  In the footer and selection summary, this is computed only
-                  from the selected linked CBG subset, summed across the chosen
-                  cities.
-                </div>
-                <pre className="mt-2 overflow-x-auto whitespace-pre-wrap font-mono text-[11px] leading-5 text-[#1f2937]">
-                  {`linked_subset_trips_leaving_seed =
-  selected_linked_outbound_flow / total_seed_external_outbound_flow`}
-                </pre>
-                <div className="mt-2">
-                  <span className="font-semibold">Terms:</span>{' '}
-                  <code>selected_linked_outbound_flow</code> is the sum of
-                  <code>seed_outbound_flow</code> across the linked CBGs kept
-                  explicit in the zone.
-                </div>
-              </div>
-              <div className="rounded-lg bg-[#f8fafc] px-3 py-3 text-xs text-gray-700">
-                <div className="font-semibold text-[#1f2937]">
-                  Linked CBGs (<code>cbg_count</code>)
-                </div>
-                <div className="mt-1">
-                  Number of linked CBGs that would be kept explicit for this
-                  city. This is selection context, not part of the ranking
-                  formula.
-                </div>
-              </div>
-              <div className="rounded-lg bg-[#f8fafc] px-3 py-3 text-xs text-gray-700">
-                <div className="font-semibold text-[#1f2937]">
-                  Added Population (<code>population</code>)
-                </div>
-                <div className="mt-1">
-                  Estimated explicit population contributed by that city&apos;s
-                  linked CBG layer. This helps judge zone size, but it also is
-                  not part of the ranking formula.
-                </div>
-              </div>
-              <div className="rounded-lg bg-[#f8fafc] px-3 py-3 text-xs text-gray-700">
-                <div className="font-semibold text-[#1f2937]">
-                  Linked Coverage (
-                  <code>captured_bidirectional_flow_share</code>)
-                </div>
-                <div className="mt-1">
-                  Portion of the city&apos;s two-way seed connection that is
-                  covered by the selected linked CBGs. This is the note shown at
-                  the bottom of each card.
-                </div>
-                <pre className="mt-2 overflow-x-auto whitespace-pre-wrap font-mono text-[11px] leading-5 text-[#1f2937]">
-                  {`captured_bidirectional_flow_share =
-  captured_gateway_bidirectional_flow / bidirectional_flow`}
-                </pre>
-                <div className="mt-2">
-                  <span className="font-semibold">Terms:</span>{' '}
-                  <code>captured_gateway_bidirectional_flow</code> is the
-                  two-way travel covered by the chosen linked CBG subset for
-                  that city. <code>bidirectional_flow</code> is the full
-                  city-level two-way travel between the seed and that city.
-                </div>
-              </div>
-              <div className="czgen_info text-xs">
-                The list is ranked by <code>coupling</code>, shown as{' '}
-                <span className="font-semibold">Connection</span>. The other
-                values help decide whether that city is worth keeping in the
-                explicit zone once you see its linked CBG count and population
-                impact. If you want linked-CBG-only metrics, use the summary
-                UI&apos;s{' '}
-                <span className="font-semibold">Trips Leaving Seed</span> for
-                outbound capture and the city card&apos;s{' '}
-                <code>captured_bidirectional_flow_share</code> for two-way
-                coverage.
-              </div>
-            </div>
-          </div>
-        </div>
-      )}
+      <GuidedTermsHelpModal
+        open={showGuidedTermsHelp}
+        onClose={() => setShowGuidedTermsHelp(false)}
+      />
       {!hasGenerated && (
         <div className="czgen_header" data-aos="fade-up" data-aos-once="true">
           <h1 className="czgen_title">Generate a Convenience Zone</h1>

--- a/src/app/cz-generation/page.tsx
+++ b/src/app/cz-generation/page.tsx
@@ -11,8 +11,9 @@ import {
   fetchSecondOrderDestinations,
   finalizeConvenienceZone,
   getClusteringProgressUrl,
-  startClusteringPreview,
+  startClusteringPreview
 } from '@/features/cz-generation/api';
+import { CandidateAnalysisPanel } from '@/features/cz-generation/components/candidate-analysis-panel';
 import {
   CBG_GEOJSON_REQUEST_CHUNK_SIZE,
   CLUSTER_ALGORITHM_MANUAL,
@@ -2726,174 +2727,15 @@ coupling =
               )}
 
               {showCandidatePanels && (
-                <div className="czgen_subpanel h-[calc(100vh-13rem)] min-h-136 max-h-192 w-88 max-w-88">
-                  <div className="czgen_subpanel_header">
-                    <p className="czgen_subpanel_title">CBG Analysis</p>
-                  </div>
-                  <div className="px-4 py-3 border-b text-sm space-y-1" style={{ borderColor: 'var(--color-border-subtle)' }}>
-                    <div>
-                      <span className="font-semibold">CBG:</span>{' '}
-                      {selectedTraceCandidateCbg || 'N/A'}
-                    </div>
-                    <div>
-                      <span className="font-semibold">Population:</span>{' '}
-                      {String(
-                        selectedTraceFeatureProperties?.population ?? 'N/A'
-                      )}
-                    </div>
-                    <div>
-                      <span className="font-semibold">Status:</span>{' '}
-                      {selectedAnalysisStatus}
-                    </div>
-                    {selectedAnalysisCandidate && (
-                      <>
-                        <div>
-                          <span className="font-semibold">Rank:</span> #
-                          {selectedAnalysisCandidate.rank ?? '?'}
-                        </div>
-                        <div>
-                          <span className="font-semibold">Score:</span>{' '}
-                          {Number(selectedAnalysisCandidate.score ?? 0).toFixed(
-                            4
-                          )}
-                        </div>
-                        <div>
-                          <span className="font-semibold">To Cluster:</span>{' '}
-                          {Number(
-                            selectedAnalysisCandidate.movement_to_cluster ?? 0
-                          ).toLocaleString(undefined, {
-                            maximumFractionDigits: 1
-                          })}
-                        </div>
-                        {selectedAnalysisCandidate.movement_to_full_cluster !==
-                          undefined && (
-                          <div>
-                            <span className="font-semibold">
-                              To Full Cluster:
-                            </span>{' '}
-                            {Number(
-                              selectedAnalysisCandidate.movement_to_full_cluster ??
-                                0
-                            ).toLocaleString(undefined, {
-                              maximumFractionDigits: 1
-                            })}
-                          </div>
-                        )}
-                        <div>
-                          <span className="font-semibold">To Outside:</span>{' '}
-                          {Number(
-                            selectedAnalysisCandidate.movement_to_outside ?? 0
-                          ).toLocaleString(undefined, {
-                            maximumFractionDigits: 1
-                          })}
-                        </div>
-                        {selectedAnalysisCandidate.seed_distance_km !==
-                          undefined && (
-                          <div>
-                            <span className="font-semibold">
-                              Seed Distance:
-                            </span>{' '}
-                            {Number(
-                              selectedAnalysisCandidate.seed_distance_km ?? 0
-                            ).toFixed(2)}{' '}
-                            km
-                          </div>
-                        )}
-                        {selectedAnalysisCandidate.movement_contributes_after_selection !==
-                          undefined && (
-                          <div>
-                            <span className="font-semibold">
-                              Contributes After Add:
-                            </span>{' '}
-                            {selectedAnalysisCandidate.movement_contributes_after_selection
-                              ? 'Yes'
-                              : 'No'}
-                          </div>
-                        )}
-                        {selectedAnalysisCandidate.seed_movement_loss !==
-                          undefined && (
-                          <div>
-                            <span className="font-semibold">
-                              Seed Movement Lost:
-                            </span>{' '}
-                            {Number(
-                              selectedAnalysisCandidate.seed_movement_loss ?? 0
-                            ).toLocaleString(undefined, {
-                              maximumFractionDigits: 1
-                            })}
-                          </div>
-                        )}
-                        {selectedAnalysisCandidate.seed_capture_after !==
-                          undefined && (
-                          <div>
-                            <span className="font-semibold">
-                              Seed Capture After Selection:
-                            </span>{' '}
-                            {(
-                              Number(
-                                selectedAnalysisCandidate.seed_capture_after ??
-                                  0
-                              ) * 100
-                            ).toFixed(1)}
-                            %
-                          </div>
-                        )}
-                        {selectedAnalysisCandidate.czi_after !== undefined && (
-                          <div>
-                            <span className="font-semibold">
-                              Zone CZI After Selection:
-                            </span>{' '}
-                            {Number(
-                              selectedAnalysisCandidate.czi_after ?? 0
-                            ).toFixed(4)}
-                          </div>
-                        )}
-                      </>
-                    )}
-                  </div>
-                  <div className="czgen_subpanel_header">
-                    <p className="czgen_subpanel_title" style={{ fontSize: '13px' }}>Top POIs From Current Cluster</p>
-                  </div>
-                  <div className="czgen_subpanel_body" style={{ padding: '12px 16px' }}>
-                    {candidatePoiLoading ? (
-                      <div className="text-sm text-gray-500">
-                        Loading POI analysis...
-                      </div>
-                    ) : candidatePoiError ? (
-                      <div className="text-sm text-red-700">
-                        {candidatePoiError}
-                      </div>
-                    ) : candidatePois.length === 0 ? (
-                      <div className="text-sm text-gray-500">
-                        No cluster-to-POI flow found for this CBG.
-                      </div>
-                    ) : (
-                      <div className="flex flex-col gap-2">
-                        {candidatePois.map((poi) => (
-                          <div
-                            key={`${poi.placekey || poi.location_name}-${poi.rank}`}
-                            className="text-sm leading-snug"
-                          >
-                            <div className="font-medium">
-                              {poi.rank}. {poi.location_name || 'Unknown POI'}
-                            </div>
-                            <div className="text-gray-600">
-                              Flow:{' '}
-                              {Number(poi.cluster_flow ?? 0).toLocaleString(
-                                undefined,
-                                {
-                                  maximumFractionDigits: 1
-                                }
-                              )}{' '}
-                              ({Number((poi.flow_share ?? 0) * 100).toFixed(1)}
-                              %)
-                            </div>
-                          </div>
-                        ))}
-                      </div>
-                    )}
-                  </div>
-                </div>
+                <CandidateAnalysisPanel
+                  selectedCbg={selectedTraceCandidateCbg}
+                  population={selectedTraceFeatureProperties?.population}
+                  status={selectedAnalysisStatus}
+                  candidate={selectedAnalysisCandidate}
+                  pois={candidatePois}
+                  poisLoading={candidatePoiLoading}
+                  poisError={candidatePoiError}
+                />
               )}
             </div>
 

--- a/src/app/cz-generation/page.tsx
+++ b/src/app/cz-generation/page.tsx
@@ -7,18 +7,17 @@ import {
   fetchCbgGeoJson,
   lookupLocation
 } from '@/features/cz-generation/api';
-import { CandidateAnalysisPanel } from '@/features/cz-generation/components/candidate-analysis-panel';
-import { ConnectedCitiesPanel } from '@/features/cz-generation/components/connected-cities-panel';
-import { FrontierCandidatesPanel } from '@/features/cz-generation/components/frontier-candidates-panel';
-import { GeneratedActionBar } from '@/features/cz-generation/components/generated-action-bar';
+import { AlgorithmGuideModal } from '@/features/cz-generation/components/algorithm-guide-modal';
+import { FinalizingProgressModal } from '@/features/cz-generation/components/finalizing-progress-modal';
+import {
+  GenerationIntroHeader,
+  GenerationLoadingState
+} from '@/features/cz-generation/components/generation-page-chrome';
+import { GeneratedZoneWorkspace } from '@/features/cz-generation/components/generated-zone-workspace';
 import { GuidedTermsHelpModal } from '@/features/cz-generation/components/guided-terms-help-modal';
 import { SetupSeedPanel } from '@/features/cz-generation/components/setup-seed-panel';
 import {
-  CLUSTER_ALGORITHM_MANUAL,
-  CLUSTER_ALGORITHM_OPTIONS,
   EMPTY_LIST,
-  GUIDED_REGION_PALETTE,
-  GUIDED_SEED_STYLE,
   type ClusterAlgorithm
 } from '@/features/cz-generation/constants';
 import {
@@ -27,12 +26,12 @@ import {
   endDateFromMonth,
   monthFromDate,
   monthFromEndDate,
-  sameStringArray,
   startDateFromMonth
 } from '@/features/cz-generation/helpers';
 import { useCandidatePois } from '@/features/cz-generation/hooks/use-candidate-pois';
 import { useCzMetrics } from '@/features/cz-generation/hooks/use-cz-metrics';
 import { useGenerationPreviewSubmit } from '@/features/cz-generation/hooks/use-generation-preview-submit';
+import { useGuidedSelectionState } from '@/features/cz-generation/hooks/use-guided-selection-state';
 import { useManualFrontierCandidates } from '@/features/cz-generation/hooks/use-manual-frontier-candidates';
 import { usePatternAvailability } from '@/features/cz-generation/hooks/use-pattern-availability';
 import { useSeedEditing } from '@/features/cz-generation/hooks/use-seed-editing';
@@ -41,7 +40,6 @@ import type {
   ClusterAlgorithmMetadata,
   GuidedDestinationCandidate,
   GuidedSecondOrderMetadata,
-  GuidedSelectionStyle,
   TraceCandidate,
   TraceLayerData,
   TracePayload
@@ -60,7 +58,6 @@ import '@/styles/cz-generation.css';
 const InteractiveMap = dynamic(() => import('@/components/interactive-map'), {
   ssr: false
 });
-const CBGMap = dynamic(() => import('@/components/cbg-map'), { ssr: false });
 
 const EMPTY_CBG_LIST: string[] = [];
 
@@ -183,128 +180,22 @@ export default function CZGeneration() {
     ? activeTraceStep.candidates
     : EMPTY_LIST;
 
-  const guidedSelectedDestinations = useMemo(
-    () =>
-      guidedDestinations.filter((destination) =>
-        selectedGuidedDestinationIds.includes(destination.unit_id)
-      ),
-    [guidedDestinations, selectedGuidedDestinationIds]
-  );
-
-  const guidedSelectionSummary = useMemo(() => {
-    const selectedLinkedOutboundFlow = guidedSelectedDestinations.reduce(
-      (sum, destination) =>
-        sum +
-        (destination.gateway_cbgs ?? []).reduce(
-          (inner, detail) => inner + Number(detail.seed_outbound_flow ?? 0),
-          0
-        ),
-      0
-    );
-    const selectedLinkedOutboundShare = Math.min(
-      1,
-      Number(guidedMetadata?.total_seed_external_outbound_flow ?? 0) > 0
-        ? selectedLinkedOutboundFlow /
-            Number(guidedMetadata?.total_seed_external_outbound_flow ?? 0)
-        : 0
-    );
-    const selectedExternalBidirectionalShare = Math.min(
-      1,
-      guidedSelectedDestinations.reduce(
-        (sum, destination) =>
-          sum + Number(destination.share_of_seed_external_bidirectional ?? 0),
-        0
-      )
-    );
-    const selectedSeedMovementShare = Math.min(
-      1,
-      guidedSelectedDestinations.reduce(
-        (sum, destination) =>
-          sum + Number(destination.share_of_seed_total_movement ?? 0),
-        0
-      )
-    );
-    const selectedPopulation =
-      Number(guidedMetadata?.seed_population ?? 0) +
-      guidedSelectedDestinations.reduce(
-        (sum, destination) => sum + Number(destination.population ?? 0),
-        0
-      );
-    return {
-      selectedLinkedOutboundFlow,
-      selectedLinkedOutboundShare,
-      selectedExternalBidirectionalShare,
-      selectedSeedMovementShare,
-      externalRemainderShare: Math.max(
-        0,
-        1 - selectedExternalBidirectionalShare
-      ),
-      selectedPopulation
-    };
-  }, [guidedMetadata, guidedSelectedDestinations]);
-
-  const guidedSeedLabel = useMemo(() => {
-    if (guidedMetadata?.seed_city_labels?.length) {
-      return guidedMetadata.seed_city_labels.join(', ');
-    }
-    if (guidedMetadata?.seed_zip_codes?.length) {
-      return guidedMetadata.seed_zip_codes.join(', ');
-    }
-    return `${guidedSeedCbgs.length} seed CBGs`;
-  }, [guidedMetadata, guidedSeedCbgs]);
-
-  const guidedSelectedDestinationSummary = useMemo(() => {
-    const labels = guidedSelectedDestinations
-      .map((destination) => destination.label)
-      .filter(Boolean);
-    if (labels.length === 0) {
-      return 'Seed only';
-    }
-    if (labels.length <= 3) {
-      return labels.join(', ');
-    }
-    return `${labels.slice(0, 3).join(', ')} +${labels.length - 3} more`;
-  }, [guidedSelectedDestinations]);
-
-  const guidedStyleByUnitId = useMemo(() => {
-    const styleMap = new Map<string, GuidedSelectionStyle>();
-    guidedSelectedDestinations.forEach((destination, index) => {
-      styleMap.set(
-        destination.unit_id,
-        GUIDED_REGION_PALETTE[index % GUIDED_REGION_PALETTE.length]
-      );
-    });
-    return styleMap;
-  }, [guidedSelectedDestinations]);
-
-  const guidedSelectionStyleByCbg = useMemo(() => {
-    if (!guidedSelectionMode) {
-      return null;
-    }
-    const styleMap = new Map<string, GuidedSelectionStyle>();
-    guidedSeedCbgs.forEach((cbg) => {
-      const normalized = normalizeCbgId(cbg);
-      if (normalized) {
-        styleMap.set(normalized, GUIDED_SEED_STYLE);
-      }
-    });
-    guidedSelectedDestinations.forEach((destination) => {
-      const style =
-        guidedStyleByUnitId.get(destination.unit_id) || GUIDED_SEED_STYLE;
-      destination.cbgs.forEach((cbg) => {
-        const normalized = normalizeCbgId(cbg);
-        if (normalized) {
-          styleMap.set(normalized, style);
-        }
-      });
-    });
-    return styleMap;
-  }, [
-    guidedSeedCbgs,
+  const {
     guidedSelectedDestinations,
+    guidedSelectionSummary,
+    guidedSeedLabel,
+    guidedSelectedDestinationSummary,
+    guidedStyleByUnitId,
+    guidedSelectionStyleByCbg
+  } = useGuidedSelectionState({
     guidedSelectionMode,
-    guidedStyleByUnitId
-  ]);
+    guidedDestinations,
+    selectedGuidedDestinationIds,
+    guidedMetadata,
+    guidedSeedCbgs,
+    setSelectedCBGs,
+    setTotalPopulation
+  });
 
   const selectedTraceCandidate = useMemo(
     () =>
@@ -578,24 +469,8 @@ export default function CZGeneration() {
   useEffect(() => {
     if (!guidedSelectionMode) {
       setShowGuidedSummaryPanel(false);
-      return;
     }
-
-    const nextSelectedCBGs = dedupeCbgList([
-      ...guidedSeedCbgs,
-      ...guidedSelectedDestinations.flatMap((destination) => destination.cbgs)
-    ]);
-
-    setSelectedCBGs((prev) =>
-      sameStringArray(prev, nextSelectedCBGs) ? prev : nextSelectedCBGs
-    );
-    setTotalPopulation(guidedSelectionSummary.selectedPopulation);
-  }, [
-    guidedSeedCbgs,
-    guidedSelectedDestinations,
-    guidedSelectionMode,
-    guidedSelectionSummary.selectedPopulation
-  ]);
+  }, [guidedSelectionMode]);
 
   useEffect(() => {
     if (!guidedSelectionMode || selectedCBGs.length === 0) {
@@ -921,263 +796,112 @@ export default function CZGeneration() {
   });
 
   if (isPending) {
-    return (
-      <div className="czgen_page">
-        <p className="czgen_lede" style={{ textAlign: 'center', paddingTop: '60px' }}>
-          Loading...
-        </p>
-      </div>
-    );
+    return <GenerationLoadingState />;
   }
 
   return (
     <div className="czgen_page">
-      {isFinalizing && (
-        <div
-          className="czgen_modal_overlay"
-          role="dialog"
-          aria-modal="true"
-          aria-live="polite"
-        >
-          <div className="czgen_modal">
-            <p className="czgen_modal_title">Generating convenience zone</p>
-            <p className="czgen_modal_subtitle">
-              {finalizeStatusMessage || 'Preparing movement patterns...'}
-            </p>
-            <div className="czgen_progress_track">
-              <div
-                className="czgen_progress_fill"
-                style={{
-                  width: `${Math.max(2, Math.min(100, finalizeProgress))}%`
-                }}
-              />
-            </div>
-            <div className="mt-2 text-right text-xs font-medium" style={{ color: 'var(--color-text-muted)' }}>
-              {finalizeProgress}%
-            </div>
-            <p className="mt-3 text-xs" style={{ color: 'var(--color-text-muted)' }}>
-              This can take a few minutes. You&apos;ll be taken to the simulator
-              automatically once generation is complete.
-            </p>
-          </div>
-        </div>
-      )}
-      {showAlgorithmGuide && (
-        <div
-          className="czgen_modal_overlay"
-          role="dialog"
-          aria-modal="true"
-          aria-labelledby="algorithm-guide-title"
-          tabIndex={-1}
-          onClick={(event) => {
-            if (event.target === event.currentTarget) {
-              setShowAlgorithmGuide(false);
-            }
-          }}
-          onKeyDown={(event) => {
-            if (event.key === 'Escape') {
-              setShowAlgorithmGuide(false);
-            }
-          }}
-        >
-          <div className="czgen_modal" style={{ width: 'min(34rem, 92vw)' }}>
-            <div className="flex items-start justify-between gap-4">
-              <div>
-                <p id="algorithm-guide-title" className="czgen_modal_title">
-                  Algorithm Guide
-                </p>
-                <p className="czgen_modal_subtitle">
-                  Start with Mobility Prune unless the zone needs manual city
-                  selection or diagnostic tracing.
-                </p>
-              </div>
-              <button
-                type="button"
-                onClick={() => setShowAlgorithmGuide(false)}
-                className="czgen_btn czgen_btn--sm"
-                style={{ flexShrink: 0 }}
-              >
-                Close
-              </button>
-            </div>
-            <div className="mt-4 flex flex-col gap-3">
-              {CLUSTER_ALGORITHM_OPTIONS.map((option) => {
-                const manual = CLUSTER_ALGORITHM_MANUAL[option.value];
-                return (
-                  <div
-                    key={option.value}
-                    className="border-l-4 px-3 py-2 text-sm"
-                    style={{
-                      borderColor: 'var(--color-primary-blue-soft)',
-                      background: 'var(--color-bg-surface)',
-                      color: 'var(--color-text-muted)',
-                      borderRadius: '0 8px 8px 0'
-                    }}
-                  >
-                    <div className="flex flex-wrap items-center gap-2 font-semibold" style={{ color: 'var(--color-text-main)' }}>
-                      <span>{option.label}</span>
-                      {manual.recommended && (
-                        <span className="rounded-full px-2 py-0.5 text-[11px] font-semibold" style={{ background: 'rgba(22,163,74,0.1)', color: '#166534' }}>
-                          default
-                        </span>
-                      )}
-                    </div>
-                    <div className="mt-1">{manual.summary}</div>
-                  </div>
-                );
-              })}
-            </div>
-          </div>
-        </div>
-      )}
+      <FinalizingProgressModal
+        open={isFinalizing}
+        progress={finalizeProgress}
+        statusMessage={finalizeStatusMessage}
+      />
+      <AlgorithmGuideModal
+        open={showAlgorithmGuide}
+        onClose={() => setShowAlgorithmGuide(false)}
+      />
       <GuidedTermsHelpModal
         open={showGuidedTermsHelp}
         onClose={() => setShowGuidedTermsHelp(false)}
       />
-      {!hasGenerated && (
-        <div className="czgen_header" data-aos="fade-up" data-aos-once="true">
-          <h1 className="czgen_title">Generate a Convenience Zone</h1>
-          <p className="czgen_lede">
-            Define your simulation&apos;s geographic area by selecting a location and clustering nearby Census Block Groups.
-          </p>
-        </div>
-      )}
+      {!hasGenerated && <GenerationIntroHeader />}
       <form
         onSubmit={handleGenerateSubmit}
         className="czgen_form"
       >
         {hasGenerated ? (
-          <div className="w-full flex flex-col gap-4">
-            <div className="flex gap-4 w-full flex-wrap 2xl:flex-nowrap">
-              <div className="czgen_map h-[50vh] min-h-80 max-h-140 lg:h-[calc(100vh-13rem)] lg:min-h-136 lg:max-h-192 relative flex-1 min-w-0 w-full lg:min-w-176">
-                {cbgGeoJSON ? (
-                  <CBGMap
-                    cbgData={cbgGeoJSON}
-                    center={null}
-                    onCBGClick={handleCBGClick}
-                    onMapBackgroundClick={handleMapBackgroundClick}
-                    onTraceCbgInspect={
-                      manualEditPanelsActive ? null : handleTraceCbgInspect
-                    }
-                    selectedCBGs={selectedCBGs}
-                    seedCbgId={seedCBG}
-                    seedCbgIds={mapSeedCbgIds}
-                    seedGuardRadiusKm={seedGuardDistanceKm}
-                    showSeedGuardCircle={
-                      clusterAlgorithm === 'greedy_weight_seed_guard'
-                    }
-                    traceLayer={activeMapTraceLayer}
-                    selectionStyleByCbg={guidedSelectionStyleByCbg}
-                    editingEnabled={
-                      !guidedSelectionMode &&
-                      (manualEditPanelsActive || !activeMapTraceLayer)
-                    }
-                    focusedCbgId={focusedTraceCbg}
-                    focusNonce={focusedTraceNonce}
-                  />
-                ) : (
-                  <div className="h-full w-full flex items-center justify-center bg-gray-100 text-gray-500">
-                    <div className="text-center">
-                      <p>CBG map not available</p>
-                      <p className="text-sm">
-                        GeoJSON endpoint needed on Algorithms server
-                      </p>
-                    </div>
-                  </div>
-                )}
-              </div>
-
-              {guidedSelectionMode && (
-                <ConnectedCitiesPanel
-                  seedLabel={guidedSeedLabel}
-                  destinations={guidedDestinations}
-                  selectedDestinationIds={selectedGuidedDestinationIds}
-                  selectedDestinations={guidedSelectedDestinations}
-                  selectedCbgCount={selectedCBGs.length}
-                  metadata={guidedMetadata}
-                  selectionSummary={guidedSelectionSummary}
-                  styleByUnitId={guidedStyleByUnitId}
-                  loading={guidedDestinationLoading}
-                  error={guidedDestinationError}
-                  isFinalizing={isFinalizing}
-                  showSummary={showGuidedSummaryPanel}
-                  onShowSummary={() => setShowGuidedSummaryPanel(true)}
-                  onHideSummary={() => setShowGuidedSummaryPanel(false)}
-                  onShowTermsHelp={() => setShowGuidedTermsHelp(true)}
-                  onUseRecommended={selectRecommendedGuidedDestinations}
-                  onSeedOnly={() => setSelectedGuidedDestinationIds([])}
-                  onToggleDestination={toggleGuidedDestination}
-                />
-              )}
-
-              {showCandidatePanels && (
-                <FrontierCandidatesPanel
-                  candidates={displayCandidates}
-                  hasTraceLayer={Boolean(traceLayer)}
-                  loading={manualFrontierLoading}
-                  error={manualFrontierError}
-                  selectedCbg={selectedTraceCandidateCbg}
-                  onSelectCbg={handleTraceCandidateSelect}
-                />
-              )}
-
-              {showCandidatePanels && (
-                <CandidateAnalysisPanel
-                  selectedCbg={selectedTraceCandidateCbg}
-                  population={selectedTraceFeatureProperties?.population}
-                  status={selectedAnalysisStatus}
-                  candidate={selectedAnalysisCandidate}
-                  pois={candidatePois}
-                  poisLoading={candidatePoiLoading}
-                  poisError={candidatePoiError}
-                />
-              )}
-            </div>
-
-            <GeneratedActionBar
-              guidedSelectionMode={guidedSelectionMode}
-              selectedGuidedDestinationCount={
-                selectedGuidedDestinationIds.length
-              }
-              selectedCbgCount={selectedCBGs.length}
-              guidedSelectedDestinationSummary={
-                guidedSelectedDestinationSummary
-              }
-              guidedSelectionSummary={guidedSelectionSummary}
-              mobilityPruneMetadata={mobilityPruneMetadata}
-              totalPopulation={totalPopulation}
-              showTraceControls={showTraceControls}
-              growthTrace={growthTrace}
-              traceStepCount={traceSteps.length}
-              traceEnabled={traceEnabled}
-              traceStepIndex={traceStepIndex}
-              maxTraceStep={maxTraceStep}
-              onTraceEnabledChange={setTraceEnabled}
-              onJumpTraceStep={jumpToTraceStep}
-              zoneMetricsLoading={zoneMetricsLoading}
-              zoneMetricsError={zoneMetricsError}
-              zoneMetrics={zoneMetrics}
-              clusterAlgorithm={clusterAlgorithm}
-              manualEditPanelsActive={manualEditPanelsActive}
-              seedGuardDistanceKm={seedGuardDistanceKm}
-              onSeedGuardDistanceChange={setSeedGuardDistanceKm}
-              loading={loading}
-              isFinalizing={isFinalizing}
-              algorithmMetadata={algorithmMetadata}
-              zoneEditMode={zoneEditMode}
-              onEnterZoneEditMode={() => {
-                setZoneEditMode(true);
-                setTraceEnabled(false);
-              }}
-              onEnterTraceView={() => {
-                setZoneEditMode(false);
-                setTraceEnabled(Boolean(growthTrace?.steps?.length));
-              }}
-              onSaveHtmlMap={saveCZHtmlMap}
-              savingHtmlMap={savingHtmlMap}
-              onFinalize={finalizeCZ}
-            />
-          </div>
+          <GeneratedZoneWorkspace
+            cbgGeoJSON={cbgGeoJSON}
+            selectedCBGs={selectedCBGs}
+            seedCBG={seedCBG}
+            mapSeedCbgIds={mapSeedCbgIds}
+            seedGuardDistanceKm={seedGuardDistanceKm}
+            clusterAlgorithm={clusterAlgorithm}
+            activeMapTraceLayer={activeMapTraceLayer}
+            guidedSelectionStyleByCbg={guidedSelectionStyleByCbg}
+            manualEditPanelsActive={manualEditPanelsActive}
+            guidedSelectionMode={guidedSelectionMode}
+            focusedTraceCbg={focusedTraceCbg}
+            focusedTraceNonce={focusedTraceNonce}
+            onCBGClick={handleCBGClick}
+            onMapBackgroundClick={handleMapBackgroundClick}
+            onTraceCbgInspect={handleTraceCbgInspect}
+            guidedSeedLabel={guidedSeedLabel}
+            guidedDestinations={guidedDestinations}
+            selectedGuidedDestinationIds={selectedGuidedDestinationIds}
+            guidedSelectedDestinations={guidedSelectedDestinations}
+            guidedMetadata={guidedMetadata}
+            guidedSelectionSummary={guidedSelectionSummary}
+            guidedStyleByUnitId={guidedStyleByUnitId}
+            guidedDestinationLoading={guidedDestinationLoading}
+            guidedDestinationError={guidedDestinationError}
+            isFinalizing={isFinalizing}
+            showGuidedSummaryPanel={showGuidedSummaryPanel}
+            onShowGuidedSummary={() => setShowGuidedSummaryPanel(true)}
+            onHideGuidedSummary={() => setShowGuidedSummaryPanel(false)}
+            onShowGuidedTermsHelp={() => setShowGuidedTermsHelp(true)}
+            onUseRecommendedGuidedDestinations={
+              selectRecommendedGuidedDestinations
+            }
+            onSeedOnlyGuidedDestinations={() =>
+              setSelectedGuidedDestinationIds([])
+            }
+            onToggleGuidedDestination={toggleGuidedDestination}
+            showCandidatePanels={showCandidatePanels}
+            displayCandidates={displayCandidates}
+            traceLayer={traceLayer}
+            manualFrontierLoading={manualFrontierLoading}
+            manualFrontierError={manualFrontierError}
+            selectedTraceCandidateCbg={selectedTraceCandidateCbg}
+            onTraceCandidateSelect={handleTraceCandidateSelect}
+            selectedTracePopulation={selectedTraceFeatureProperties?.population}
+            selectedAnalysisStatus={selectedAnalysisStatus}
+            selectedAnalysisCandidate={selectedAnalysisCandidate}
+            candidatePois={candidatePois}
+            candidatePoiLoading={candidatePoiLoading}
+            candidatePoiError={candidatePoiError}
+            guidedSelectedDestinationSummary={
+              guidedSelectedDestinationSummary
+            }
+            mobilityPruneMetadata={mobilityPruneMetadata}
+            totalPopulation={totalPopulation}
+            showTraceControls={showTraceControls}
+            growthTrace={growthTrace}
+            traceStepCount={traceSteps.length}
+            traceEnabled={traceEnabled}
+            traceStepIndex={traceStepIndex}
+            maxTraceStep={maxTraceStep}
+            onTraceEnabledChange={setTraceEnabled}
+            onJumpTraceStep={jumpToTraceStep}
+            zoneMetricsLoading={zoneMetricsLoading}
+            zoneMetricsError={zoneMetricsError}
+            zoneMetrics={zoneMetrics}
+            loading={loading}
+            algorithmMetadata={algorithmMetadata}
+            zoneEditMode={zoneEditMode}
+            onEnterZoneEditMode={() => {
+              setZoneEditMode(true);
+              setTraceEnabled(false);
+            }}
+            onEnterTraceView={() => {
+              setZoneEditMode(false);
+              setTraceEnabled(Boolean(growthTrace?.steps?.length));
+            }}
+            onSaveHtmlMap={saveCZHtmlMap}
+            savingHtmlMap={savingHtmlMap}
+            onFinalize={finalizeCZ}
+            onSeedGuardDistanceChange={setSeedGuardDistanceKm}
+          />
         ) : (
           <div className="w-full flex flex-col gap-4 lg:flex-row lg:items-stretch" data-aos="fade-up" data-aos-once="true" data-aos-delay="80">
             <div className="czgen_map h-[50vh] min-h-80 max-h-112 lg:h-[calc(100vh-6rem)] lg:min-h-168 lg:max-h-none w-full lg:min-w-0 lg:flex-1">

--- a/src/app/cz-generation/page.tsx
+++ b/src/app/cz-generation/page.tsx
@@ -2,7 +2,6 @@
 
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/navigation';
-import { Info } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   exportCzMapHtml,
@@ -18,6 +17,7 @@ import { ConnectedCitiesPanel } from '@/features/cz-generation/components/connec
 import { FrontierCandidatesPanel } from '@/features/cz-generation/components/frontier-candidates-panel';
 import { GeneratedActionBar } from '@/features/cz-generation/components/generated-action-bar';
 import { GuidedTermsHelpModal } from '@/features/cz-generation/components/guided-terms-help-modal';
+import { SetupSeedPanel } from '@/features/cz-generation/components/setup-seed-panel';
 import {
   CBG_GEOJSON_REQUEST_CHUNK_SIZE,
   CLUSTER_ALGORITHM_MANUAL,
@@ -34,7 +34,6 @@ import {
   dedupeCbgList,
   endDateFromMonth,
   filterGeoJsonByCbgs,
-  formatMonthLabel,
   getCbgIdsFromGeoJson,
   getLengthHours,
   getPayloadErrorMessage,
@@ -87,94 +86,6 @@ const InteractiveMap = dynamic(() => import('@/components/interactive-map'), {
 const CBGMap = dynamic(() => import('@/components/cbg-map'), { ssr: false });
 
 const EMPTY_CBG_LIST: string[] = [];
-
-type FormFieldProps = {
-  label: string;
-  name: string;
-  type: 'text' | 'number' | 'date' | 'textarea' | 'select';
-  placeholder?: string;
-  disabled?: boolean;
-  value?: string | number;
-  onChange?: (
-    e: React.ChangeEvent<
-      HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement
-    >
-  ) => void;
-  min?: number | string;
-  max?: number | string;
-  options?: Array<{ value: string; label: string }>;
-  required?: boolean;
-};
-
-function FormField({
-  label,
-  name,
-  type,
-  placeholder,
-  disabled,
-  value,
-  onChange,
-  min,
-  max,
-  options,
-  required = true
-}: FormFieldProps) {
-  return (
-    <div className="flex flex-col gap-1">
-      <label className="czgen_field_label" htmlFor={name}>{label}</label>
-      {type === 'textarea' ? (
-        <textarea
-          className="formfield"
-          name={name}
-          id={name}
-          placeholder={placeholder}
-          disabled={disabled}
-          value={value as string}
-          onChange={
-            onChange as
-              | React.ChangeEventHandler<HTMLTextAreaElement>
-              | undefined
-          }
-          required={required}
-        />
-      ) : type === 'select' ? (
-        <select
-          className="formfield"
-          name={name}
-          id={name}
-          disabled={disabled}
-          value={value as string}
-          onChange={
-            onChange as React.ChangeEventHandler<HTMLSelectElement> | undefined
-          }
-          required={required}
-        >
-          {options?.map((option) => (
-            <option key={option.value} value={option.value}>
-              {option.label}
-            </option>
-          ))}
-        </select>
-      ) : (
-        <input
-          className="formfield"
-          name={name}
-          id={name}
-          type={type}
-          placeholder={placeholder}
-          disabled={disabled}
-          value={value as string | number}
-          onChange={
-            onChange as React.ChangeEventHandler<HTMLInputElement> | undefined
-          }
-          min={min}
-          max={max}
-          required={required}
-        />
-      )}
-    </div>
-  );
-}
 
 async function fetchZoneById(
   zoneId: number,
@@ -2313,421 +2224,67 @@ export default function CZGeneration() {
               />
             </div>
 
-            <div className="czgen_panel lg:w-[30rem] xl:w-[32rem] lg:flex-none lg:h-[calc(100vh-6rem)] lg:overflow-y-auto">
-              <div className="flex flex-col gap-4">
-                <div className="flex flex-col gap-3 sm:flex-row sm:items-end lg:flex-col xl:flex-row xl:items-end">
-                  <div className="flex-1 min-w-0">
-                    <FormField
-                      label="City, Address, or Location"
-                      name="location"
-                      type="text"
-                      placeholder="e.g. 55902 or TEST"
-                      value={location}
-                      onChange={(e) => {
-                        resetSeedPreview();
-                        setLocation(e.target.value);
-                      }}
-                      disabled={loading || resolvingSeed}
-                    />
-                  </div>
-                  <div className="w-full sm:w-[12rem] lg:w-full xl:w-[12rem]">
-                    <button
-                      type="button"
-                      onClick={resolveSeedPreview}
-                      disabled={
-                        loading ||
-                        resolvingSeed ||
-                        !location.trim() ||
-                        isTestLocationInput
-                      }
-                      className="czgen_btn czgen_btn--full"
-                    >
-                      {resolvingSeed ? 'Resolving Seed...' : 'Resolve Seed'}
-                    </button>
-                  </div>
-                </div>
-
-                <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-                  <div className="w-full sm:col-span-2 flex flex-col gap-0.5">
-                    <div className="flex items-center justify-between">
-                      <label htmlFor="algorithm">Clustering Algorithm</label>
-                      <button
-                        type="button"
-                        onClick={() => setShowAlgorithmGuide(true)}
-                        className="czgen_btn czgen_btn--sm"
-                      >
-                        <Info size={12} />
-                        <span style={{ marginLeft: '5px' }}>Algorithm Guide</span>
-                      </button>
-                    </div>
-                    <select
-                      className="formfield w-full"
-                      name="algorithm"
-                      id="algorithm"
-                      disabled={loading}
-                      value={clusterAlgorithm}
-                      onChange={(e) =>
-                        setClusterAlgorithm(e.target.value as ClusterAlgorithm)
-                      }
-                      required={true}
-                    >
-                      {CLUSTER_ALGORITHM_OPTIONS.map((option) => (
-                        <option key={option.value} value={option.value}>
-                          {option.label}
-                        </option>
-                      ))}
-                    </select>
-                  </div>
-                  {clusterAlgorithm === 'mobility_prune' ? (
-                    <div className="w-full sm:col-span-2">
-                      <FormField
-                        label="Minimum Seed Movement Captured (%)"
-                        name="mobility_prune_min_seed_capture"
-                        type="number"
-                        value={mobilityPruneMinSeedCapturePct}
-                        min={0}
-                        max={100}
-                        onChange={(e) =>
-                          setMobilityPruneMinSeedCapturePct(
-                            Number(e.target.value)
-                          )
-                        }
-                        disabled={loading}
-                      />
-                      <div className="mt-1 text-xs text-gray-600">
-                        Pruning stops before a removal would drop captured seed
-                        movement below this threshold.
-                      </div>
-                    </div>
-                  ) : !isGuidedSecondOrderAlgorithm ? (
-                    <div className="w-full sm:col-span-2">
-                      <FormField
-                        label="Minimum Population"
-                        name="min_pop"
-                        type="number"
-                        value={minPop}
-                        min={100}
-                        max={100_000}
-                        onChange={(e) => setMinPop(Number(e.target.value))}
-                        disabled={loading}
-                      />
-                    </div>
-                  ) : null}
-                  <div className="czgen_warning text-xs sm:col-span-2">
-                    Keep zones under 50,000 people for faster generation and
-                    review.
-                  </div>
-                  {(() => {
-                    const monthsReady = monthOptions.length > 0;
-                    const placeholderLabel = availableMonthsLoading
-                      ? 'Loading available months...'
-                      : detectedStateAbbr
-                        ? 'No months available for this state'
-                        : 'Resolve seed to see available months';
-                    const placeholderOption = [
-                      { value: '', label: placeholderLabel }
-                    ];
-                    const startValue = monthsReady
-                      ? monthFromDate(startDate)
-                      : '';
-                    const endValue = monthsReady
-                      ? monthFromEndDate(endDate)
-                      : '';
-                    const startOptions = monthsReady
-                      ? monthOptions.map((month) => ({
-                          value: month,
-                          label: formatMonthLabel(month)
-                        }))
-                      : placeholderOption;
-                    const endOptions = monthsReady
-                      ? monthOptions
-                          .filter((month) => month >= monthFromDate(startDate))
-                          .map((month) => ({
-                            value: month,
-                            label: formatMonthLabel(month)
-                          }))
-                      : placeholderOption;
-                    return (
-                      <>
-                        <div className="w-full">
-                          <FormField
-                            label="Start Month"
-                            name="start_month"
-                            type="select"
-                            value={startValue}
-                            options={startOptions}
-                            onChange={(e) => {
-                              const nextMonth = e.target.value;
-                              if (!nextMonth) return;
-                              const nextStart = startDateFromMonth(nextMonth);
-                              setStartDate(nextStart);
-                              if (monthFromEndDate(endDate) < nextMonth) {
-                                setEndDate(endDateFromMonth(nextMonth));
-                              }
-                            }}
-                            disabled={loading || !monthsReady}
-                          />
-                        </div>
-                        <div className="w-full">
-                          <FormField
-                            label="End Month"
-                            name="end_month"
-                            type="select"
-                            value={endValue}
-                            options={endOptions}
-                            onChange={(e) => {
-                              const nextMonth = e.target.value;
-                              if (!nextMonth) return;
-                              setEndDate(endDateFromMonth(nextMonth));
-                            }}
-                            disabled={loading || !monthsReady}
-                          />
-                        </div>
-                      </>
-                    );
-                  })()}
-                  <div className="w-full sm:col-span-2">
-                    <FormField
-                      label="Description"
-                      name="description"
-                      type="textarea"
-                      placeholder="a short description for this convenience zone..."
-                      value={description}
-                      onChange={(e) => setDescription(e.target.value)}
-                      disabled={loading}
-                      required={false}
-                    />
-                  </div>
-                </div>
-
-                {(setupSeedCbg || seedResolveError || isTestLocationInput) && (
-                  <div className="flex flex-col gap-2 text-sm">
-                    {setupSeedCbg && (
-                      <div className="czgen_info text-sm">
-                        <div>
-                          <span className="font-semibold">Resolved Seed:</span>{' '}
-                          {setupSeedLabel || setupSeedCbg}
-                          {setupSeedCount > 0
-                            ? ` (${setupSeedCount} CBGs)`
-                            : ''}
-                          {setupResolvedCityName
-                            ? ` for ${setupResolvedCityName}`
-                            : ''}
-                          {clusterAlgorithm === 'greedy_weight_seed_guard'
-                            ? ` | Blue ring radius: ${seedGuardDistanceKm} km`
-                            : ''}
-                        </div>
-                        {seedAdjustmentSummary.hasChanges && (
-                          <div className="mt-1 text-xs">
-                            {seedAdjustmentSummary.addedCount > 0
-                              ? `+${seedAdjustmentSummary.addedCount} added`
-                              : ''}
-                            {seedAdjustmentSummary.addedCount > 0 &&
-                            seedAdjustmentSummary.removedCount > 0
-                              ? ' | '
-                              : ''}
-                            {seedAdjustmentSummary.removedCount > 0
-                              ? `-${seedAdjustmentSummary.removedCount} removed`
-                              : ''}
-                          </div>
-                        )}
-                        <div className="mt-2 flex flex-wrap gap-2">
-                          {seedEditMode ? (
-                            <>
-                              <div className="flex overflow-hidden rounded-lg" style={{ border: '1px solid rgba(61,136,173,0.3)' }}>
-                                <button
-                                  type="button"
-                                  onClick={() => setSeedEditAction('add')}
-                                  disabled={loading || seedEditLoading}
-                                  className={`px-3 py-1.5 text-xs font-semibold font-[inherit] cursor-pointer disabled:opacity-40 ${
-                                    seedEditAction === 'add'
-                                      ? 'bg-[#dcfce7] text-[#166534]'
-                                      : ''
-                                  }`}
-                                  style={seedEditAction !== 'add' ? { color: 'var(--color-text-main)', background: 'var(--color-bg-surface)' } : undefined}
-                                >
-                                  Add
-                                </button>
-                                <button
-                                  type="button"
-                                  onClick={() => setSeedEditAction('remove')}
-                                  disabled={loading || seedEditLoading}
-                                  className={`px-3 py-1.5 text-xs font-semibold font-[inherit] cursor-pointer disabled:opacity-40 ${
-                                    seedEditAction === 'remove'
-                                      ? 'bg-[#fee2e2] text-[#991b1b]'
-                                      : ''
-                                  }`}
-                                  style={{
-                                    borderLeft: '1px solid rgba(61,136,173,0.3)',
-                                    ...(seedEditAction !== 'remove' ? { color: 'var(--color-text-main)', background: 'var(--color-bg-surface)' } : {})
-                                  }}
-                                >
-                                  Remove
-                                </button>
-                              </div>
-                              <button
-                                type="button"
-                                onClick={finishSeedEdit}
-                                disabled={loading || seedEditLoading}
-                                className="czgen_btn czgen_btn--sm"
-                              >
-                                Done
-                              </button>
-                              <button
-                                type="button"
-                                onClick={cancelSeedEdit}
-                                disabled={loading || seedEditLoading}
-                                className="czgen_btn czgen_btn--sm"
-                              >
-                                Cancel
-                              </button>
-                              <button
-                                type="button"
-                                onClick={() => {
-                                  void showMoreSeedEditNeighbors();
-                                }}
-                                disabled={loading || seedEditLoading}
-                                className="czgen_btn czgen_btn--sm"
-                              >
-                                Show More Nearby
-                              </button>
-                            </>
-                          ) : (
-                            <button
-                              type="button"
-                              onClick={() => {
-                                void beginSeedEdit();
-                              }}
-                              disabled={loading || seedEditLoading}
-                              className="czgen_btn czgen_btn--sm"
-                            >
-                              {seedEditLoading
-                                ? 'Loading Area...'
-                                : 'Adjust Seed Area'}
-                            </button>
-                          )}
-                          <button
-                            type="button"
-                            onClick={() => {
-                              void resetAdjustedSeed();
-                            }}
-                            disabled={
-                              loading ||
-                              seedEditLoading ||
-                              !seedAdjustmentSummary.hasChanges
-                            }
-                            className="czgen_btn czgen_btn--sm"
-                          >
-                            Reset
-                          </button>
-                        </div>
-                        {seedEditMode && (
-                          <div className="mt-2 text-xs czgen_info" style={{ padding: '4px 8px' }}>
-                            {seedEditAction === 'add'
-                              ? 'Add mode active'
-                              : 'Remove mode active'}
-                            {seedEditLoading ? ' | Updating map...' : ''}
-                          </div>
-                        )}
-                        {seedEditError && (
-                          <div className="mt-2 czgen_error text-xs" style={{ textAlign: 'left', maxWidth: '100%', padding: '6px 10px' }}>
-                            {seedEditError}
-                          </div>
-                        )}
-                      </div>
-                    )}
-                    {!setupSeedCbg && isTestLocationInput && (
-                      <div className="czgen_warning text-sm">
-                        Seed preview is unavailable in TEST mode.
-                      </div>
-                    )}
-                    {seedResolveError && (
-                      <div className="czgen_error text-sm" style={{ textAlign: 'left', maxWidth: '100%' }}>
-                        {seedResolveError}
-                      </div>
-                    )}
-                  </div>
-                )}
-
-                {clusterAlgorithm === 'greedy_weight_seed_guard' && (
-                  <div className="text-xs text-gray-600">
-                    Resolve the seed, adjust the blue radius, then preview the
-                    cluster.
-                  </div>
-                )}
-
-                {isGuidedSecondOrderAlgorithm && (
-                  <div className="czgen_info text-xs">
-                    This mode starts with the full seed region, ranks nearby
-                    connected cities by how much travel they share with it, and
-                    asks you which connected cities should contribute linked
-                    CBGs to the explicit simulation.
-                  </div>
-                )}
-
-                {clusterAlgorithm === 'mobility_prune' && (
-                  <div className="czgen_info text-xs">
-                    This mode grows a large mobility envelope, then prunes low
-                    seed-capture CBGs while preserving the seed CBGs' movement
-                    field.
-                  </div>
-                )}
-
-                {clusterAlgorithm === 'greedy_weight_seed_guard' && (
-                  <div className="czgen_panel w-full" style={{ padding: '12px 14px' }}>
-                    <button
-                      type="button"
-                      className="text-sm font-semibold text-left w-full"
-                      onClick={() => setShowAdvancedClustering((prev) => !prev)}
-                      disabled={loading}
-                    >
-                      Advanced Clustering {showAdvancedClustering ? 'v' : '>'}
-                    </button>
-                    {showAdvancedClustering && (
-                      <div className="mt-3 flex flex-col gap-3">
-                        <FormField
-                          label="Seed Guard Distance (km)"
-                          name="seed_guard_distance_km"
-                          type="number"
-                          value={seedGuardDistanceKm}
-                          min={0}
-                          max={500}
-                          onChange={(e) =>
-                            setSeedGuardDistanceKm(Number(e.target.value))
-                          }
-                          disabled={loading}
-                        />
-                        <div className="text-xs text-gray-600">
-                          Distant CBGs can still be added, but they will stop
-                          influencing later picks.
-                        </div>
-                      </div>
-                    )}
-                  </div>
-                )}
-
-                <div className="pt-1">
-                  <button
-                    type="submit"
-                    disabled={
-                      loading ||
-                      resolvingSeed ||
-                      seedEditLoading ||
-                      (seedGuardNeedsResolvedSeed && !setupSeedCbg)
-                    }
-                    className="czgen_btn czgen_btn--primary czgen_btn--full"
-                  >
-                    {loading
-                      ? isGuidedSecondOrderAlgorithm
-                        ? 'Loading Cities...'
-                        : 'Clustering...'
-                      : isGuidedSecondOrderAlgorithm
-                        ? 'Choose Connected Cities'
-                        : 'Preview CBGs'}
-                  </button>
-                </div>
-              </div>
-            </div>
+            <SetupSeedPanel
+              location={location}
+              onLocationChange={(value) => {
+                resetSeedPreview();
+                setLocation(value);
+              }}
+              loading={loading}
+              resolvingSeed={resolvingSeed}
+              seedEditLoading={seedEditLoading}
+              onResolveSeedPreview={resolveSeedPreview}
+              isTestLocationInput={isTestLocationInput}
+              clusterAlgorithm={clusterAlgorithm}
+              onClusterAlgorithmChange={setClusterAlgorithm}
+              onShowAlgorithmGuide={() => setShowAlgorithmGuide(true)}
+              mobilityPruneMinSeedCapturePct={
+                mobilityPruneMinSeedCapturePct
+              }
+              onMobilityPruneMinSeedCapturePctChange={
+                setMobilityPruneMinSeedCapturePct
+              }
+              isGuidedSecondOrderAlgorithm={isGuidedSecondOrderAlgorithm}
+              minPop={minPop}
+              onMinPopChange={setMinPop}
+              monthOptions={monthOptions}
+              availableMonthsLoading={availableMonthsLoading}
+              detectedStateAbbr={detectedStateAbbr}
+              startDate={startDate}
+              endDate={endDate}
+              onStartDateChange={setStartDate}
+              onEndDateChange={setEndDate}
+              description={description}
+              onDescriptionChange={setDescription}
+              setupSeedCbg={setupSeedCbg}
+              setupSeedLabel={setupSeedLabel}
+              setupSeedCount={setupSeedCount}
+              setupResolvedCityName={setupResolvedCityName}
+              seedGuardDistanceKm={seedGuardDistanceKm}
+              seedAdjustmentSummary={seedAdjustmentSummary}
+              seedEditMode={seedEditMode}
+              seedEditAction={seedEditAction}
+              onSeedEditActionChange={setSeedEditAction}
+              onFinishSeedEdit={finishSeedEdit}
+              onCancelSeedEdit={cancelSeedEdit}
+              onShowMoreSeedEditNeighbors={() => {
+                void showMoreSeedEditNeighbors();
+              }}
+              onBeginSeedEdit={() => {
+                void beginSeedEdit();
+              }}
+              onResetAdjustedSeed={() => {
+                void resetAdjustedSeed();
+              }}
+              seedEditError={seedEditError}
+              seedResolveError={seedResolveError}
+              showAdvancedClustering={showAdvancedClustering}
+              onToggleAdvancedClustering={() =>
+                setShowAdvancedClustering((prev) => !prev)
+              }
+              onSeedGuardDistanceChange={setSeedGuardDistanceKm}
+              seedGuardNeedsResolvedSeed={seedGuardNeedsResolvedSeed}
+            />
           </div>
         )}
 

--- a/src/app/cz-generation/page.tsx
+++ b/src/app/cz-generation/page.tsx
@@ -7,10 +7,8 @@ import {
   exportCzMapHtml,
   fetchCbgAtPoint,
   fetchCbgGeoJson,
-  fetchSecondOrderDestinations,
   finalizeConvenienceZone,
-  getClusteringProgressUrl,
-  startClusteringPreview
+  lookupLocation
 } from '@/features/cz-generation/api';
 import { CandidateAnalysisPanel } from '@/features/cz-generation/components/candidate-analysis-panel';
 import { ConnectedCitiesPanel } from '@/features/cz-generation/components/connected-cities-panel';
@@ -32,28 +30,22 @@ import {
   dedupeCbgList,
   endDateFromMonth,
   getLengthHours,
-  getPayloadErrorMessage,
-  getResponseErrorMessage,
-  isClusterAlgorithm,
-  isRecord,
   monthFromDate,
   monthFromEndDate,
-  readJsonObject,
   sameStringArray,
   startDateFromMonth
 } from '@/features/cz-generation/helpers';
 import { useCandidatePois } from '@/features/cz-generation/hooks/use-candidate-pois';
 import { useCzMetrics } from '@/features/cz-generation/hooks/use-cz-metrics';
+import { useGenerationPreviewSubmit } from '@/features/cz-generation/hooks/use-generation-preview-submit';
 import { useManualFrontierCandidates } from '@/features/cz-generation/hooks/use-manual-frontier-candidates';
 import { usePatternAvailability } from '@/features/cz-generation/hooks/use-pattern-availability';
 import { useSeedEditing } from '@/features/cz-generation/hooks/use-seed-editing';
 import type {
   ClusterAlgorithmMetadata,
-  ClusteringPreviewResponse,
   GuidedDestinationCandidate,
   GuidedSecondOrderMetadata,
   GuidedSelectionStyle,
-  LookupLocationResult,
   TraceCandidate,
   TraceLayerData,
   TracePayload
@@ -797,132 +789,6 @@ export default function CZGeneration() {
       });
   }, [cbgGeoJSON, focusedTraceCbg, showCandidatePanels]);
 
-  const lookupLocation = async (
-    query: string
-  ): Promise<LookupLocationResult | null> => {
-    const location = String(query ?? '').trim();
-    if (!location) {
-      return null;
-    }
-
-    const resp = await fetch('/api/lookup-location', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ location })
-    });
-    if (resp.status === 404) {
-      return null;
-    }
-
-    if (!resp.ok) {
-      const payload = await readJsonObject(resp);
-      throw new Error(
-        getResponseErrorMessage(
-          resp,
-          payload,
-          `Location lookup failed with status ${resp.status}`
-        )
-      );
-    }
-
-    return resp.json();
-  };
-
-  const waitForClusteringResult = useCallback(
-    (clusteringId: number): Promise<ClusteringPreviewResponse> =>
-      new Promise((resolve, reject) => {
-        let settled = false;
-        const eventSource = new EventSource(
-          getClusteringProgressUrl(clusteringId)
-        );
-        const timeout = window.setTimeout(
-          () => {
-            if (settled) {
-              return;
-            }
-            settled = true;
-            eventSource.close();
-            reject(
-              new Error(
-                'Timed out waiting for the clustering preview to finish.'
-              )
-            );
-          },
-          5 * 60 * 1000
-        );
-
-        const finish = (callback: () => void) => {
-          if (settled) {
-            return;
-          }
-          settled = true;
-          window.clearTimeout(timeout);
-          eventSource.close();
-          callback();
-        };
-
-        eventSource.onmessage = (event) => {
-          let payload: Record<string, unknown> | null = null;
-          try {
-            const parsed = JSON.parse(event.data);
-            payload = isRecord(parsed) ? parsed : null;
-          } catch {
-            finish(() =>
-              reject(
-                new Error(
-                  'Received an invalid clustering progress payload from the Algorithms service.'
-                )
-              )
-            );
-            return;
-          }
-
-          if (payload?.error) {
-            finish(() =>
-              reject(
-                new Error(
-                  getPayloadErrorMessage(
-                    payload,
-                    'Failed to cluster CBGs. Please try again.'
-                  )
-                )
-              )
-            );
-            return;
-          }
-
-          if (!payload?.done) {
-            return;
-          }
-
-          const result = isRecord(payload.result) ? payload.result : null;
-          if (!result) {
-            finish(() =>
-              reject(
-                new Error(
-                  'Clustering finished without returning the preview result payload.'
-                )
-              )
-            );
-            return;
-          }
-
-          finish(() => resolve(result as ClusteringPreviewResponse));
-        };
-
-        eventSource.onerror = () => {
-          finish(() =>
-            reject(
-              new Error(
-                'Lost connection to the Algorithms service while previewing CBGs.'
-              )
-            )
-          );
-        };
-      }),
-    []
-  );
-
   const resolveSeedPreview = async () => {
     const rawLocationInput = String(location ?? '').trim();
     if (!rawLocationInput) {
@@ -1073,317 +939,52 @@ export default function CZGeneration() {
     setSelectedGuidedDestinationIds(recommendedIds);
   };
 
-  const handleGenerateSubmit = async (
-    event: React.FormEvent<HTMLFormElement>
-  ) => {
-    event.preventDefault();
-    if (loading) {
-      return;
-    }
-
-    const rawLocationInput = String(location ?? '').trim();
-    const isTestMode = rawLocationInput.toUpperCase() === 'TEST';
-    setUseTestData(isTestMode);
-    setSeedEditMode(false);
-
-    const cachedSeedLookup =
-      resolvedSeedLookup?.query === rawLocationInput
-        ? resolvedSeedLookup
-        : null;
-    let coreCbg = setupSeedCbg || cachedSeedLookup?.cbg || null;
-    let resolvedSeedCbgs =
-      setupSeedCbgs.length > 0
-        ? setupSeedCbgs
-        : cachedSeedLookup?.seedCbgs ||
-          (setupSeedCbg ? [setupSeedCbg] : ([] as string[]));
-    let resolvedCityName =
-      setupResolvedCityName ||
-      cachedSeedLookup?.cityName ||
-      (isTestMode ? 'TEST' : rawLocationInput);
-
-    if (seedGuardNeedsResolvedSeed && !coreCbg) {
-      setError(
-        'Resolve the seed first so you can verify the seed guard radius before previewing.'
-      );
-      return;
-    }
-
-    if (!isTestMode && !coreCbg) {
-      try {
-        const resolved = await lookupLocation(rawLocationInput);
-        coreCbg = resolved?.cbg || null;
-        resolvedSeedCbgs = Array.isArray(resolved?.seed_cbgs)
-          ? resolved.seed_cbgs.filter(
-              (cbg): cbg is string => typeof cbg === 'string'
-            )
-          : coreCbg
-            ? [coreCbg]
-            : [];
-        resolvedCityName =
-          resolved?.city && resolved?.state
-            ? `${resolved.city}, ${resolved.state}`
-            : resolved?.city || resolved?.state || rawLocationInput;
-        if (coreCbg) {
-          setResolvedSeedLookup({
-            query: rawLocationInput,
-            cbg: coreCbg,
-            cityName: resolvedCityName,
-            seedName: resolved?.seed_name || coreCbg,
-            seedCbgs: resolvedSeedCbgs,
-            seedZip: resolved?.zip
-          });
-        }
-      } catch (err) {
-        setError(
-          err instanceof Error ? err.message : 'Failed to resolve location.'
-        );
-        return;
-      }
-    }
-
-    if (!isTestMode && !coreCbg) {
-      setError(
-        'Could not find location. Please try entering a 5-digit ZIP code (e.g. 21201 for Baltimore).'
-      );
-      return;
-    }
-
-    setError('');
-    setLoading(true);
-    setAlgorithmMetadata(null);
-    setGuidedMetadata(null);
-    setGuidedDestinations([]);
-    setGuidedSeedCbgs([]);
-    setSelectedGuidedDestinationIds([]);
-    setGuidedDestinationError('');
-
-    try {
-      if (isGuidedSecondOrderAlgorithm) {
-        setGuidedDestinationLoading(true);
-        const data = await fetchSecondOrderDestinations({
-          cbg: coreCbg,
-          seed_cbgs: resolvedSeedCbgs,
-          start_date: startDate,
-          use_test_data: isTestMode,
-          limit: 12
-        });
-
-        let seedGeoJson = setupSeedGeoJSON;
-        if (!seedGeoJson?.features?.length) {
-          const seedGeoData = await fetchCbgGeoJson(resolvedSeedCbgs, false);
-          if (!seedGeoData?.features?.length) {
-            throw new Error(
-              seedGeoData?.message ||
-                'Resolved the seed region, but could not load its map boundary.'
-            );
-          }
-          seedGeoJson = seedGeoData as GeoJSONData;
-          setSetupSeedGeoJSON(seedGeoJson);
-        }
-
-        const destinations = Array.isArray(data.destinations)
-          ? (data.destinations as GuidedDestinationCandidate[]).filter(
-              (destination) =>
-                Boolean(destination?.unit_id) &&
-                Array.isArray(destination?.cbgs)
-            )
-          : [];
-        const recommendedIds = Array.isArray(data.recommended_unit_ids)
-          ? (data.recommended_unit_ids as unknown[])
-              .filter((unitId): unitId is string => typeof unitId === 'string')
-              .filter((unitId) =>
-                destinations.some(
-                  (destination) => destination.unit_id === unitId
-                )
-              )
-          : destinations
-              .filter((destination) => destination.recommended)
-              .map((destination) => destination.unit_id);
-
-        const nextGuidedMetadata = {
-          ...(data as GuidedSecondOrderMetadata),
-          seed_cbg: String(data.seed_cbg || coreCbg || ''),
-          seed_cbgs: Array.isArray(data.seed_cbgs)
-            ? (data.seed_cbgs as unknown[]).filter(
-                (cbg): cbg is string => typeof cbg === 'string'
-              )
-            : resolvedSeedCbgs,
-          destinations,
-          recommended_unit_ids: recommendedIds
-        };
-        const initialSelectedCBGs = dedupeCbgList([
-          ...nextGuidedMetadata.seed_cbgs,
-          ...destinations
-            .filter((destination) =>
-              recommendedIds.includes(destination.unit_id)
-            )
-            .flatMap((destination) => destination.cbgs)
-        ]);
-
-        setGuidedMetadata(nextGuidedMetadata);
-        setGuidedDestinations(destinations);
-        setGuidedSeedCbgs(nextGuidedMetadata.seed_cbgs);
-        setSelectedGuidedDestinationIds(recommendedIds);
-        setSelectedCBGs(initialSelectedCBGs);
-        setSeedCBG(nextGuidedMetadata.seed_cbg);
-        setTotalPopulation(
-          Number(nextGuidedMetadata.seed_population ?? 0) +
-            destinations
-              .filter((destination) =>
-                recommendedIds.includes(destination.unit_id)
-              )
-              .reduce(
-                (sum, destination) => sum + Number(destination.population ?? 0),
-                0
-              )
-        );
-        setCityName(resolvedCityName);
-        setUseTestData(Boolean(data.use_test_data ?? isTestMode));
-        setGrowthTrace(null);
-        setTraceStepIndex(0);
-        setTraceEnabled(false);
-        setZoneEditMode(false);
-        setSelectedTraceCandidateCbg('');
-        setFocusedTraceCbg('');
-        setCbgGeoJSON(seedGeoJson);
-        const seedBounds = getBoundsForGeoJson(seedGeoJson);
-        if (seedBounds) {
-          setMapCenter([
-            (seedBounds[0][1] + seedBounds[1][1]) / 2,
-            (seedBounds[0][0] + seedBounds[1][0]) / 2
-          ]);
-        }
-        setPhase('edit');
-        return;
-      }
-
-      const clusterReq: Record<string, unknown> = {
-        min_pop: Number(minPop),
-        algorithm: clusterAlgorithm,
-        start_date: startDate,
-        use_test_data: isTestMode,
-        include_trace: true
-      };
-
-      if (clusterAlgorithm === 'greedy_weight_seed_guard') {
-        if (Number.isFinite(Number(seedGuardDistanceKm))) {
-          clusterReq.seed_guard_distance_km = Number(seedGuardDistanceKm);
-        }
-      }
-      if (clusterAlgorithm === 'mobility_prune') {
-        const minSeedCapture = Number(mobilityPruneMinSeedCapturePct) / 100;
-        if (Number.isFinite(minSeedCapture)) {
-          clusterReq.mobility_prune_min_seed_capture = Math.min(
-            1,
-            Math.max(0, minSeedCapture)
-          );
-        }
-      }
-
-      if (coreCbg) {
-        clusterReq.cbg = coreCbg;
-      }
-      if (resolvedSeedCbgs.length > 0) {
-        clusterReq.seed_cbgs = resolvedSeedCbgs;
-      }
-
-      const kickoffData = await startClusteringPreview(clusterReq);
-
-      let data = kickoffData;
-      if (!Array.isArray(data?.cluster)) {
-        const clusteringId = Number(data?.clustering_id);
-        if (Number.isInteger(clusteringId) && clusteringId > 0) {
-          data = await waitForClusteringResult(clusteringId);
-        }
-      }
-
-      if (!Array.isArray(data?.cluster)) {
-        throw new Error(
-          getPayloadErrorMessage(
-            kickoffData,
-            'The Algorithms service returned an unexpected clustering response.'
-          )
-        );
-      }
-
-      const cluster = data.cluster.filter(
-        (cbg: unknown): cbg is string => typeof cbg === 'string'
-      );
-      setSelectedCBGs(cluster);
-      setSeedCBG(data.seed_cbg || coreCbg || '');
-      setMapCenter(data.center || null);
-      setTotalPopulation(Number(data.size || 0));
-      setCityName(resolvedCityName);
-      setUseTestData(Boolean(data.use_test_data ?? isTestMode));
-      setAlgorithmMetadata(
-        data.algorithm_metadata || data.trace?.algorithm_metadata || null
-      );
-      const responseAlgorithm = isClusterAlgorithm(data.algorithm)
-        ? data.algorithm
-        : clusterAlgorithm;
-      if (isClusterAlgorithm(data.algorithm)) {
-        setClusterAlgorithm(responseAlgorithm);
-      }
-
-      if (
-        data.clustering_params &&
-        data.algorithm === 'greedy_weight_seed_guard'
-      ) {
-        const rawThreshold = Number(
-          data.clustering_params.seed_guard_distance_km
-        );
-        if (Number.isFinite(rawThreshold)) {
-          setSeedGuardDistanceKm(rawThreshold);
-        }
-      }
-      if (data.clustering_params && data.algorithm === 'mobility_prune') {
-        const rawMinSeedCapture = Number(
-          data.clustering_params.min_seed_capture
-        );
-        if (Number.isFinite(rawMinSeedCapture)) {
-          setMobilityPruneMinSeedCapturePct(
-            Math.round(Math.min(1, Math.max(0, rawMinSeedCapture)) * 100)
-          );
-        }
-      }
-
-      setGrowthTrace(data.trace || null);
-      setTraceStepIndex(0);
-      setTraceEnabled(
-        Boolean(data.trace?.steps?.length) &&
-          responseAlgorithm !== 'mobility_prune'
-      );
-      setZoneEditMode(false);
-
-      if (data.geojson || data.trace_geojson) {
-        setCbgGeoJSON(
-          mergeGeoJsonFeatures(data.geojson || null, data.trace_geojson || null)
-        );
-      }
-
-      setPhase('edit');
-    } catch (err) {
-      console.error(err);
-      setAlgorithmMetadata(null);
-      setGuidedMetadata(null);
-      setGuidedDestinations([]);
-      setGuidedSeedCbgs([]);
-      setSelectedGuidedDestinationIds([]);
-      setGuidedDestinationError(
-        err instanceof Error
-          ? err.message
-          : 'Failed to load connected city destinations.'
-      );
-      setError(
-        err instanceof Error
-          ? err.message
-          : 'Failed to cluster CBGs. Please try again.'
-      );
-    } finally {
-      setGuidedDestinationLoading(false);
-      setLoading(false);
-    }
-  };
+  const handleGenerateSubmit = useGenerationPreviewSubmit({
+    loading,
+    location,
+    setUseTestData,
+    setSeedEditMode,
+    resolvedSeedLookup,
+    setupSeedCbg,
+    setupSeedCbgs,
+    setupResolvedCityName,
+    seedGuardNeedsResolvedSeed,
+    setResolvedSeedLookup,
+    setError,
+    setLoading,
+    setAlgorithmMetadata,
+    setGuidedMetadata,
+    setGuidedDestinations,
+    setGuidedSeedCbgs,
+    setSelectedGuidedDestinationIds,
+    setGuidedDestinationError,
+    isGuidedSecondOrderAlgorithm,
+    setGuidedDestinationLoading,
+    startDate,
+    setupSeedGeoJSON,
+    loadSeedGeoJson,
+    setSetupSeedGeoJSON,
+    setSelectedCBGs,
+    setSeedCBG,
+    setTotalPopulation,
+    setCityName,
+    setGrowthTrace,
+    setTraceStepIndex,
+    setTraceEnabled,
+    setZoneEditMode,
+    setSelectedTraceCandidateCbg,
+    setFocusedTraceCbg,
+    setCbgGeoJSON,
+    setMapCenter,
+    setPhase,
+    minPop,
+    clusterAlgorithm,
+    seedGuardDistanceKm,
+    mobilityPruneMinSeedCapturePct,
+    setClusterAlgorithm,
+    setSeedGuardDistanceKm,
+    setMobilityPruneMinSeedCapturePct
+  });
 
   const finalizeCZ = async () => {
     if (selectedCBGs.length === 0) {

--- a/src/app/cz-generation/page.tsx
+++ b/src/app/cz-generation/page.tsx
@@ -14,6 +14,7 @@ import {
   startClusteringPreview
 } from '@/features/cz-generation/api';
 import { CandidateAnalysisPanel } from '@/features/cz-generation/components/candidate-analysis-panel';
+import { ConnectedCitiesPanel } from '@/features/cz-generation/components/connected-cities-panel';
 import { FrontierCandidatesPanel } from '@/features/cz-generation/components/frontier-candidates-panel';
 import { GuidedTermsHelpModal } from '@/features/cz-generation/components/guided-terms-help-modal';
 import {
@@ -2199,313 +2200,26 @@ export default function CZGeneration() {
               </div>
 
               {guidedSelectionMode && (
-                <div className="czgen_subpanel relative h-[calc(100vh-13rem)] min-h-[34rem] max-h-[48rem] w-[25rem] max-w-[25rem]">
-                  <div className="czgen_subpanel_header">
-                    <div className="flex items-start justify-between gap-3">
-                      <div className="min-w-0">
-                        <p className="czgen_subpanel_title">Connected Cities</p>
-                        <p className="czgen_subpanel_subtitle">
-                          Choose the connected cities whose linked CBGs should
-                          stay explicit in the simulation.
-                        </p>
-                      </div>
-                    </div>
-                    <div className="mt-3 flex flex-wrap gap-2">
-                      <button
-                        type="button"
-                        onClick={() => setShowGuidedSummaryPanel(true)}
-                        className="czgen_btn czgen_btn--sm"
-                      >
-                        Selection Summary
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => setShowGuidedTermsHelp(true)}
-                        className="czgen_btn czgen_btn--sm shrink-0"
-                      >
-                        How Ranking Works
-                      </button>
-                    </div>
-                    <div className="mt-3 text-xs" style={{ color: 'var(--color-text-muted)' }}>
-                      <span className="font-semibold" style={{ color: 'var(--color-text-main)' }}>Seed:</span>{' '}
-                      {guidedSeedLabel}
-                    </div>
-                  </div>
-                  <div className="czgen_subpanel_divider">
-                    <button
-                      type="button"
-                      onClick={selectRecommendedGuidedDestinations}
-                      disabled={guidedDestinationLoading || isFinalizing}
-                      className="czgen_btn czgen_btn--sm czgen_btn--primary"
-                    >
-                      Use Recommended
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => setSelectedGuidedDestinationIds([])}
-                      disabled={guidedDestinationLoading || isFinalizing}
-                      className="czgen_btn czgen_btn--sm"
-                    >
-                      Seed Only
-                    </button>
-                    <div className="w-full text-xs" style={{ color: 'var(--color-text-muted)' }}>
-                      {guidedDestinations.length} ranked cities. Click a city to
-                      include or remove its linked CBGs.
-                    </div>
-                  </div>
-                  <div className="czgen_subpanel_body">
-                    {guidedDestinationLoading ? (
-                      <div className="text-sm text-gray-500 px-2 py-2">
-                        Loading connected cities and linked CBGs...
-                      </div>
-                    ) : guidedDestinationError ? (
-                      <div className="text-sm text-red-700 px-2 py-2">
-                        {guidedDestinationError}
-                      </div>
-                    ) : guidedDestinations.length === 0 ? (
-                      <div className="text-sm text-gray-500 px-2 py-2">
-                        No significant outbound cities were found for this seed.
-                      </div>
-                    ) : (
-                      guidedDestinations.map((destination, index) => {
-                        const isSelected =
-                          selectedGuidedDestinationIds.includes(
-                            destination.unit_id
-                          );
-                        const style =
-                          guidedStyleByUnitId.get(destination.unit_id) ||
-                          GUIDED_SEED_STYLE;
-                        return (
-                          <button
-                            type="button"
-                            key={destination.unit_id}
-                            className={`text-left px-3.5 py-3 rounded border transition-colors ${
-                              isSelected
-                                ? 'bg-[#e0f2fe] border-[#0284c7]'
-                                : 'bg-white border-[#d1d5db] hover:border-[#70B4D4]'
-                            }`}
-                            onClick={() => toggleGuidedDestination(destination)}
-                          >
-                            <div className="flex items-start justify-between gap-3">
-                              <div className="flex items-center gap-2 text-base font-semibold leading-tight">
-                                <span
-                                  className="inline-block h-3 w-3 rounded-full border"
-                                  style={{
-                                    backgroundColor: style.fillColor,
-                                    borderColor: style.lineColor
-                                  }}
-                                />
-                                <span>
-                                  #{index + 1} {destination.label}
-                                </span>
-                              </div>
-                              {destination.recommended && (
-                                <span className="rounded-full bg-[#dbeafe] px-2 py-0.5 text-[11px] font-semibold text-[#1d4ed8]">
-                                  Recommended
-                                </span>
-                              )}
-                            </div>
-                            <div className="mt-3 grid grid-cols-2 gap-x-3 gap-y-2 text-xs text-gray-600">
-                              <div>
-                                <div className="font-semibold text-[#1f2937]">
-                                  Connection
-                                </div>
-                                <div>
-                                  {Number(destination.coupling ?? 0).toFixed(3)}
-                                </div>
-                              </div>
-                              <div>
-                                <div className="font-semibold text-[#1f2937]">
-                                  Trips Leaving Seed
-                                </div>
-                                <div>
-                                  {Number(
-                                    (destination.share_of_seed_external_outbound ??
-                                      0) * 100
-                                  ).toFixed(1)}
-                                  %
-                                </div>
-                              </div>
-                              <div>
-                                <div className="font-semibold text-[#1f2937]">
-                                  Linked CBGs
-                                </div>
-                                <div>
-                                  {Number(
-                                    destination.cbg_count ??
-                                      destination.cbgs.length
-                                  ).toLocaleString()}
-                                </div>
-                              </div>
-                              <div>
-                                <div className="font-semibold text-[#1f2937]">
-                                  Added Population
-                                </div>
-                                <div>
-                                  {Number(
-                                    destination.population ?? 0
-                                  ).toLocaleString()}
-                                </div>
-                              </div>
-                            </div>
-                            <div className="mt-3 text-xs text-gray-500">
-                              Linked CBG layer captures{' '}
-                              {Number(
-                                (destination.captured_bidirectional_flow_share ??
-                                  0) * 100
-                              ).toFixed(1)}
-                              % of this city&apos;s two-way seed connection.
-                            </div>
-                          </button>
-                        );
-                      })
-                    )}
-                  </div>
-                  <div
-                    className={`absolute inset-0 z-20 transition-transform duration-200 ease-out ${
-                      showGuidedSummaryPanel
-                        ? 'translate-x-0'
-                        : 'translate-x-full pointer-events-none'
-                    }`}
-                    style={{ background: 'var(--color-bg-ivory)' }}
-                    aria-hidden={!showGuidedSummaryPanel}
-                  >
-                    <div className="flex h-full flex-col">
-                      <div className="czgen_subpanel_header flex items-start justify-between gap-3">
-                        <div className="min-w-0">
-                          <p className="czgen_subpanel_title">Selection Summary</p>
-                          <p className="czgen_subpanel_subtitle">
-                            Guided metrics and the current explicit-zone summary.
-                          </p>
-                        </div>
-                        <button
-                          type="button"
-                          onClick={() => setShowGuidedSummaryPanel(false)}
-                          className="czgen_btn czgen_btn--sm shrink-0"
-                        >
-                          Close
-                        </button>
-                      </div>
-                      <div className="flex-1 overflow-y-auto px-4 py-4">
-                        <div className="rounded-lg border border-[#dbeafe] bg-[#f8fbff] px-3 py-3">
-                          <div className="text-[11px] font-semibold uppercase tracking-[0.14em] text-[#2563eb]">
-                            Seed Region
-                          </div>
-                          <div className="mt-1 text-sm font-semibold text-[#1f2937]">
-                            {guidedSeedLabel}
-                          </div>
-                          {guidedMetadata?.approximation_note && (
-                            <div className="mt-1 text-xs text-gray-600">
-                              {guidedMetadata.approximation_note}
-                            </div>
-                          )}
-                        </div>
-                        <div className="mt-4 grid grid-cols-2 gap-2">
-                          <div className="rounded-lg border border-[#dbeafe] bg-white px-3 py-2">
-                            <div className="text-[11px] font-semibold uppercase tracking-[0.12em] text-[#2563eb]">
-                              Selected
-                            </div>
-                            <div className="mt-1 text-lg font-semibold text-[#1f2937]">
-                              {selectedGuidedDestinationIds.length}
-                            </div>
-                            <div className="text-xs text-gray-500">cities</div>
-                          </div>
-                          <div className="rounded-lg border border-[#dbeafe] bg-white px-3 py-2">
-                            <div className="text-[11px] font-semibold uppercase tracking-[0.12em] text-[#2563eb]">
-                              Linked CBGs
-                            </div>
-                            <div className="mt-1 text-lg font-semibold text-[#1f2937]">
-                              {selectedCBGs.length}
-                            </div>
-                            <div className="text-xs text-gray-500">
-                              explicit units
-                            </div>
-                          </div>
-                          <div className="rounded-lg border border-[#dbeafe] bg-white px-3 py-2">
-                            <div className="text-[11px] font-semibold uppercase tracking-[0.12em] text-[#2563eb]">
-                              Explicit Pop
-                            </div>
-                            <div className="mt-1 text-lg font-semibold text-[#1f2937]">
-                              {Number(
-                                guidedSelectionSummary.selectedPopulation || 0
-                              ).toLocaleString()}
-                            </div>
-                            <div className="text-xs text-gray-500">
-                              residents
-                            </div>
-                          </div>
-                          <div className="rounded-lg border border-[#dbeafe] bg-white px-3 py-2">
-                            <div className="text-[11px] font-semibold uppercase tracking-[0.12em] text-[#2563eb]">
-                              Trips Leaving Seed Captured
-                            </div>
-                            <div className="mt-1 text-lg font-semibold text-[#1f2937]">
-                              {(
-                                guidedSelectionSummary.selectedLinkedOutboundShare *
-                                100
-                              ).toFixed(1)}
-                              %
-                            </div>
-                            <div className="text-xs text-gray-500">
-                              linked subset
-                            </div>
-                          </div>
-                          <div className="rounded-lg border border-[#dbeafe] bg-white px-3 py-2">
-                            <div className="text-[11px] font-semibold uppercase tracking-[0.12em] text-[#2563eb]">
-                              Seed Movement
-                            </div>
-                            <div className="mt-1 text-lg font-semibold text-[#1f2937]">
-                              {(
-                                guidedSelectionSummary.selectedSeedMovementShare *
-                                100
-                              ).toFixed(1)}
-                              %
-                            </div>
-                            <div className="text-xs text-gray-500">
-                              represented
-                            </div>
-                          </div>
-                        </div>
-                        <div className="mt-4 rounded-lg border border-[#e5e7eb] bg-white px-3 py-3 text-xs text-gray-700">
-                          <div className="font-semibold text-[#1f2937]">
-                            Selected Cities
-                          </div>
-                          <div className="mt-1">
-                            {guidedSelectedDestinations.length
-                              ? guidedSelectedDestinations
-                                  .map((destination) => destination.label)
-                                  .join(', ')
-                              : 'Seed only'}
-                          </div>
-                        </div>
-                        <div className="mt-3 rounded-lg border border-[#e5e7eb] bg-white px-3 py-3 text-xs text-gray-700">
-                          <span className="font-semibold text-[#1f2937]">
-                            Outside connections not modeled explicitly:
-                          </span>{' '}
-                          {(
-                            guidedSelectionSummary.externalRemainderShare * 100
-                          ).toFixed(1)}
-                          %
-                        </div>
-                        {guidedSelectionSummary.selectedPopulation >
-                          GUIDED_SOFT_EXPLICIT_POPULATION && (
-                          <div className="mt-3 text-xs text-amber-700">
-                            This selection is above the preferred
-                            explicit-population band of{' '}
-                            {GUIDED_SOFT_EXPLICIT_POPULATION.toLocaleString()}.
-                          </div>
-                        )}
-                        {guidedSelectionSummary.selectedPopulation >
-                          GUIDED_HARD_EXPLICIT_POPULATION && (
-                          <div className="mt-1 text-xs text-red-700">
-                            Finalize is disabled above{' '}
-                            {GUIDED_HARD_EXPLICIT_POPULATION.toLocaleString()}{' '}
-                            explicit residents.
-                          </div>
-                        )}
-                      </div>
-                    </div>
-                  </div>
-                </div>
+                <ConnectedCitiesPanel
+                  seedLabel={guidedSeedLabel}
+                  destinations={guidedDestinations}
+                  selectedDestinationIds={selectedGuidedDestinationIds}
+                  selectedDestinations={guidedSelectedDestinations}
+                  selectedCbgCount={selectedCBGs.length}
+                  metadata={guidedMetadata}
+                  selectionSummary={guidedSelectionSummary}
+                  styleByUnitId={guidedStyleByUnitId}
+                  loading={guidedDestinationLoading}
+                  error={guidedDestinationError}
+                  isFinalizing={isFinalizing}
+                  showSummary={showGuidedSummaryPanel}
+                  onShowSummary={() => setShowGuidedSummaryPanel(true)}
+                  onHideSummary={() => setShowGuidedSummaryPanel(false)}
+                  onShowTermsHelp={() => setShowGuidedTermsHelp(true)}
+                  onUseRecommended={selectRecommendedGuidedDestinations}
+                  onSeedOnly={() => setSelectedGuidedDestinationIds([])}
+                  onToggleDestination={toggleGuidedDestination}
+                />
               )}
 
               {showCandidatePanels && (

--- a/src/app/cz-generation/page.tsx
+++ b/src/app/cz-generation/page.tsx
@@ -14,6 +14,7 @@ import {
   startClusteringPreview
 } from '@/features/cz-generation/api';
 import { CandidateAnalysisPanel } from '@/features/cz-generation/components/candidate-analysis-panel';
+import { FrontierCandidatesPanel } from '@/features/cz-generation/components/frontier-candidates-panel';
 import {
   CBG_GEOJSON_REQUEST_CHUNK_SIZE,
   CLUSTER_ALGORITHM_MANUAL,
@@ -578,6 +579,11 @@ export default function CZGeneration() {
     if (fallbackCbg) {
       setFocusedTraceNonce((prev) => prev + 1);
     }
+  }, []);
+  const handleTraceCandidateSelect = useCallback((cbgId: string) => {
+    setSelectedTraceCandidateCbg(cbgId);
+    setFocusedTraceCbg(cbgId);
+    setFocusedTraceNonce((prev) => prev + 1);
   }, []);
   const {
     candidates: manualFrontierCandidates,
@@ -2665,65 +2671,14 @@ coupling =
               )}
 
               {showCandidatePanels && (
-                <div className="czgen_subpanel h-[calc(100vh-13rem)] min-h-136 max-h-192 w-88 max-w-88">
-                  <div className="czgen_subpanel_header">
-                    <p className="czgen_subpanel_title">Frontier Candidates ({displayCandidates.length})</p>
-                  </div>
-                  <div className="czgen_subpanel_body">
-                    {!traceLayer && manualFrontierLoading ? (
-                      <div className="text-sm text-gray-500 px-2 py-2">
-                        Loading frontier candidates...
-                      </div>
-                    ) : !traceLayer && manualFrontierError ? (
-                      <div className="text-sm text-red-700 px-2 py-2">
-                        {manualFrontierError}
-                      </div>
-                    ) : displayCandidates.length === 0 ? (
-                      <div className="text-sm text-gray-500 px-2 py-2">
-                        {traceLayer
-                          ? 'No candidates at this step.'
-                          : 'No frontier candidates for the current zone.'}
-                      </div>
-                    ) : (
-                      displayCandidates.map((candidate) => {
-                        const cbgId = normalizeCbgId(candidate?.cbg);
-                        const isActive =
-                          cbgId === normalizeCbgId(selectedTraceCandidateCbg);
-                        return (
-                          <button
-                            type="button"
-                            key={cbgId}
-                            className={`text-left px-4 py-4 rounded border transition-colors ${
-                              isActive
-                                ? 'bg-[#e0f2fe] border-[#0284c7]'
-                                : 'bg-white border-[#d1d5db] hover:border-[#70B4D4]'
-                            }`}
-                            onClick={() => {
-                              setSelectedTraceCandidateCbg(cbgId);
-                              setFocusedTraceCbg(cbgId);
-                              setFocusedTraceNonce((prev) => prev + 1);
-                            }}
-                          >
-                            <div className="text-base font-semibold leading-tight">
-                              #{candidate.rank ?? '?'} {cbgId}
-                            </div>
-                            <div className="text-base text-gray-700 mt-1">
-                              Score: {Number(candidate.score ?? 0).toFixed(4)}
-                            </div>
-                            <div className="text-base text-gray-600">
-                              To cluster:{' '}
-                              {Number(
-                                candidate.movement_to_cluster ?? 0
-                              ).toLocaleString(undefined, {
-                                maximumFractionDigits: 1
-                              })}
-                            </div>
-                          </button>
-                        );
-                      })
-                    )}
-                  </div>
-                </div>
+                <FrontierCandidatesPanel
+                  candidates={displayCandidates}
+                  hasTraceLayer={Boolean(traceLayer)}
+                  loading={manualFrontierLoading}
+                  error={manualFrontierError}
+                  selectedCbg={selectedTraceCandidateCbg}
+                  onSelectCbg={handleTraceCandidateSelect}
+                />
               )}
 
               {showCandidatePanels && (

--- a/src/app/cz-generation/page.tsx
+++ b/src/app/cz-generation/page.tsx
@@ -8,12 +8,10 @@ import {
   exportCzMapHtml,
   fetchCbgAtPoint,
   fetchCbgGeoJson,
-  fetchFrontierCandidates,
   fetchSecondOrderDestinations,
   finalizeConvenienceZone,
   getClusteringProgressUrl,
   startClusteringPreview,
-  type FrontierCandidatesResponse
 } from '@/features/cz-generation/api';
 import {
   CBG_GEOJSON_REQUEST_CHUNK_SIZE,
@@ -47,6 +45,7 @@ import {
 } from '@/features/cz-generation/helpers';
 import { useCandidatePois } from '@/features/cz-generation/hooks/use-candidate-pois';
 import { useCzMetrics } from '@/features/cz-generation/hooks/use-cz-metrics';
+import { useManualFrontierCandidates } from '@/features/cz-generation/hooks/use-manual-frontier-candidates';
 import { usePatternAvailability } from '@/features/cz-generation/hooks/use-pattern-availability';
 import type {
   ClusterAlgorithmMetadata,
@@ -329,11 +328,6 @@ export default function CZGeneration() {
     useState('');
   const [focusedTraceCbg, setFocusedTraceCbg] = useState('');
   const [focusedTraceNonce, setFocusedTraceNonce] = useState(0);
-  const [manualFrontierCandidates, setManualFrontierCandidates] = useState<
-    TraceCandidate[]
-  >([]);
-  const [manualFrontierLoading, setManualFrontierLoading] = useState(false);
-  const [manualFrontierError, setManualFrontierError] = useState('');
   const [savingHtmlMap, setSavingHtmlMap] = useState(false);
   const [zoneEditMode, setZoneEditMode] = useState(false);
   const [finalizeProgress, setFinalizeProgress] = useState(0);
@@ -577,6 +571,30 @@ export default function CZGeneration() {
   const manualEditPanelsActive = hasGenerated && (!growthTrace || zoneEditMode);
   const showCandidatePanels =
     !guidedSelectionMode && (Boolean(traceLayer) || manualEditPanelsActive);
+  const handleManualFrontierFallback = useCallback((fallbackCbg: string) => {
+    setSelectedTraceCandidateCbg(fallbackCbg);
+    setFocusedTraceCbg(fallbackCbg);
+    if (fallbackCbg) {
+      setFocusedTraceNonce((prev) => prev + 1);
+    }
+  }, []);
+  const {
+    candidates: manualFrontierCandidates,
+    loading: manualFrontierLoading,
+    error: manualFrontierError
+  } = useManualFrontierCandidates({
+    enabled: !guidedSelectionMode && manualEditPanelsActive,
+    seedCbg: seedCBG,
+    cbgs: selectedCBGs,
+    clusterAlgorithm,
+    minPop,
+    startDate,
+    useTestData,
+    seedGuardDistanceKm,
+    mobilityPruneMinSeedCapturePct,
+    selectedCbg: selectedTraceCandidateCbg,
+    onFallbackCbg: handleManualFrontierFallback
+  });
   const candidatePoiCluster = useMemo(
     () =>
       traceLayer
@@ -891,111 +909,6 @@ export default function CZGeneration() {
         );
       });
   }, [cbgGeoJSON, focusedTraceCbg, showCandidatePanels]);
-
-  useEffect(() => {
-    if (
-      guidedSelectionMode ||
-      !manualEditPanelsActive ||
-      !seedCBG ||
-      !selectedCBGs.length
-    ) {
-      setManualFrontierCandidates([]);
-      setManualFrontierError('');
-      setManualFrontierLoading(false);
-      return;
-    }
-
-    let cancelled = false;
-    setManualFrontierLoading(true);
-    setManualFrontierError('');
-
-    const req: Record<string, unknown> = {
-      seed_cbg: seedCBG,
-      cbg_list: selectedCBGs,
-      algorithm: clusterAlgorithm,
-      min_pop: Number(minPop),
-      start_date: startDate,
-      use_test_data: useTestData,
-      limit: 2000
-    };
-
-    if (clusterAlgorithm === 'greedy_weight_seed_guard') {
-      if (Number.isFinite(Number(seedGuardDistanceKm))) {
-        req.seed_guard_distance_km = Number(seedGuardDistanceKm);
-      }
-    }
-    if (clusterAlgorithm === 'mobility_prune') {
-      const minSeedCapture = Number(mobilityPruneMinSeedCapturePct) / 100;
-      if (Number.isFinite(minSeedCapture)) {
-        req.mobility_prune_min_seed_capture = Math.min(
-          1,
-          Math.max(0, minSeedCapture)
-        );
-      }
-    }
-
-    fetchFrontierCandidates(req)
-      .then((data: FrontierCandidatesResponse) => {
-        if (cancelled) {
-          return;
-        }
-        const nextCandidates = Array.isArray(data?.candidates)
-          ? data.candidates
-          : [];
-        setManualFrontierCandidates(nextCandidates);
-
-        const selectedNow = normalizeCbgId(selectedTraceCandidateCbg);
-        const selectedStillValid =
-          (selectedNow && selectedCBGs.includes(selectedNow)) ||
-          nextCandidates.some(
-            (candidate: TraceCandidate) =>
-              normalizeCbgId(candidate?.cbg) === selectedNow
-          );
-
-        if (!selectedStillValid) {
-          const fallbackCbg = normalizeCbgId(
-            nextCandidates[0]?.cbg || selectedCBGs[0] || ''
-          );
-          setSelectedTraceCandidateCbg(fallbackCbg);
-          setFocusedTraceCbg(fallbackCbg);
-          if (fallbackCbg) {
-            setFocusedTraceNonce((prev) => prev + 1);
-          }
-        }
-      })
-      .catch((err) => {
-        if (cancelled) {
-          return;
-        }
-        setManualFrontierCandidates([]);
-        setManualFrontierError(
-          err instanceof Error
-            ? err.message
-            : 'Failed to load frontier candidates.'
-        );
-      })
-      .finally(() => {
-        if (!cancelled) {
-          setManualFrontierLoading(false);
-        }
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [
-    clusterAlgorithm,
-    guidedSelectionMode,
-    manualEditPanelsActive,
-    minPop,
-    mobilityPruneMinSeedCapturePct,
-    seedCBG,
-    seedGuardDistanceKm,
-    selectedCBGs,
-    selectedTraceCandidateCbg,
-    startDate,
-    useTestData
-  ]);
 
   const lookupLocation = async (
     query: string
@@ -1756,8 +1669,6 @@ export default function CZGeneration() {
         setTraceStepIndex(0);
         setTraceEnabled(false);
         setZoneEditMode(false);
-        setManualFrontierCandidates([]);
-        setManualFrontierError('');
         setSelectedTraceCandidateCbg('');
         setFocusedTraceCbg('');
         setCbgGeoJSON(seedGeoJson);
@@ -1869,8 +1780,6 @@ export default function CZGeneration() {
           responseAlgorithm !== 'mobility_prune'
       );
       setZoneEditMode(false);
-      setManualFrontierCandidates([]);
-      setManualFrontierError('');
 
       if (data.geojson || data.trace_geojson) {
         setCbgGeoJSON(

--- a/src/app/cz-generation/page.tsx
+++ b/src/app/cz-generation/page.tsx
@@ -11,7 +11,6 @@ import {
   fetchCbgGeoJson,
   fetchCzMetrics,
   fetchFrontierCandidates,
-  fetchPatternAvailability,
   fetchSecondOrderDestinations,
   finalizeConvenienceZone,
   getClusteringProgressUrl,
@@ -48,6 +47,7 @@ import {
   sameStringArray,
   startDateFromMonth
 } from '@/features/cz-generation/helpers';
+import { usePatternAvailability } from '@/features/cz-generation/hooks/use-pattern-availability';
 import type {
   ClusterAlgorithmMetadata,
   ClusteringPreviewResponse,
@@ -295,8 +295,6 @@ export default function CZGeneration() {
   const [seedResolveError, setSeedResolveError] = useState('');
   const [startDate, setStartDate] = useState('2019-01-01');
   const [endDate, setEndDate] = useState('2019-02-01');
-  const [availableMonths, setAvailableMonths] = useState<string[]>([]);
-  const [availableMonthsLoading, setAvailableMonthsLoading] = useState(false);
   const [description, setDescription] = useState('');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
@@ -718,51 +716,8 @@ export default function CZGeneration() {
   const detectedStateAbbr = getStateFromCBG(
     seedStateCbg ? [seedStateCbg] : null
   );
-
-  useEffect(() => {
-    if (!detectedStateAbbr) {
-      setAvailableMonths([]);
-      setAvailableMonthsLoading(false);
-      return undefined;
-    }
-
-    const controller = new AbortController();
-    setAvailableMonthsLoading(true);
-
-    fetchPatternAvailability(
-      {
-        state: detectedStateAbbr,
-        startDate: '2018-01-01',
-        endDate: '2025-12-31'
-      },
-      controller.signal
-    )
-      .then(async (resp) => {
-        const months = Array.isArray(resp?.data?.available_months)
-          ? resp.data.available_months.filter(
-              (m): m is string => typeof m === 'string'
-            )
-          : [];
-        setAvailableMonths(months);
-      })
-      .catch((err) => {
-        if ((err as Error).name === 'AbortError') {
-          return;
-        }
-        console.warn('Failed to load available months:', err);
-        setAvailableMonths([]);
-      })
-      .finally(() => {
-        setAvailableMonthsLoading(false);
-      });
-
-    return () => controller.abort();
-  }, [detectedStateAbbr]);
-
-  const monthOptions = useMemo(
-    () => [...availableMonths].sort(),
-    [availableMonths]
-  );
+  const { availableMonths, availableMonthsLoading, monthOptions } =
+    usePatternAvailability(detectedStateAbbr);
 
   useEffect(() => {
     if (availableMonths.length === 0) return;

--- a/src/app/cz-generation/page.tsx
+++ b/src/app/cz-generation/page.tsx
@@ -19,22 +19,18 @@ import { GeneratedActionBar } from '@/features/cz-generation/components/generate
 import { GuidedTermsHelpModal } from '@/features/cz-generation/components/guided-terms-help-modal';
 import { SetupSeedPanel } from '@/features/cz-generation/components/setup-seed-panel';
 import {
-  CBG_GEOJSON_REQUEST_CHUNK_SIZE,
   CLUSTER_ALGORITHM_MANUAL,
   CLUSTER_ALGORITHM_OPTIONS,
   EMPTY_LIST,
   GUIDED_HARD_EXPLICIT_POPULATION,
   GUIDED_REGION_PALETTE,
   GUIDED_SEED_STYLE,
-  INITIAL_SEED_EDIT_NEIGHBOR_RINGS,
   type ClusterAlgorithm
 } from '@/features/cz-generation/constants';
 import {
   clampIndex,
   dedupeCbgList,
   endDateFromMonth,
-  filterGeoJsonByCbgs,
-  getCbgIdsFromGeoJson,
   getLengthHours,
   getPayloadErrorMessage,
   getResponseErrorMessage,
@@ -50,6 +46,7 @@ import { useCandidatePois } from '@/features/cz-generation/hooks/use-candidate-p
 import { useCzMetrics } from '@/features/cz-generation/hooks/use-cz-metrics';
 import { useManualFrontierCandidates } from '@/features/cz-generation/hooks/use-manual-frontier-candidates';
 import { usePatternAvailability } from '@/features/cz-generation/hooks/use-pattern-availability';
+import { useSeedEditing } from '@/features/cz-generation/hooks/use-seed-editing';
 import type {
   ClusterAlgorithmMetadata,
   ClusteringPreviewResponse,
@@ -57,8 +54,6 @@ import type {
   GuidedSecondOrderMetadata,
   GuidedSelectionStyle,
   LookupLocationResult,
-  ResolvedSeedLookup,
-  SeedEditAction,
   TraceCandidate,
   TraceLayerData,
   TracePayload
@@ -183,30 +178,40 @@ export default function CZGeneration() {
   const [seedGuardDistanceKm, setSeedGuardDistanceKm] = useState(20);
   const [mobilityPruneMinSeedCapturePct, setMobilityPruneMinSeedCapturePct] =
     useState(80);
-  const [setupSeedCbg, setSetupSeedCbg] = useState('');
-  const [setupSeedLabel, setSetupSeedLabel] = useState('');
-  const [setupSeedCount, setSetupSeedCount] = useState(0);
-  const [setupSeedCbgs, setSetupSeedCbgs] = useState<string[]>([]);
-  const [resolvedSetupSeedCbgs, setResolvedSetupSeedCbgs] = useState<string[]>(
-    []
-  );
-  const [setupSeedGeoJSON, setSetupSeedGeoJSON] = useState<GeoJSONData | null>(
-    null
-  );
-  const [seedEditGeoJSON, setSeedEditGeoJSON] = useState<GeoJSONData | null>(
-    null
-  );
-  const [seedEditMode, setSeedEditMode] = useState(false);
-  const [seedEditAction, setSeedEditAction] = useState<SeedEditAction>('add');
-  const [seedEditLoading, setSeedEditLoading] = useState(false);
-  const [seedEditError, setSeedEditError] = useState('');
-  const [seedEditStartCbgs, setSeedEditStartCbgs] = useState<string[]>([]);
-  const [seedEditNeighborRings, setSeedEditNeighborRings] = useState(0);
-  const [setupResolvedCityName, setSetupResolvedCityName] = useState('');
-  const [resolvedSeedLookup, setResolvedSeedLookup] =
-    useState<ResolvedSeedLookup | null>(null);
+  const {
+    setupSeedCbg,
+    setupSeedLabel,
+    setupSeedCount,
+    setupSeedCbgs,
+    resolvedSetupSeedCbgs,
+    setupSeedGeoJSON,
+    seedEditMode,
+    seedEditAction,
+    seedEditLoading,
+    seedEditError,
+    setupResolvedCityName,
+    resolvedSeedLookup,
+    seedResolveError,
+    seedAdjustmentSummary,
+    activeSetupSeedGeoJSON,
+    seedStateCbg: editedSeedStateCbg,
+    setSetupSeedGeoJSON,
+    setSeedEditMode,
+    setSeedEditAction,
+    setResolvedSeedLookup,
+    setSeedResolveError,
+    resetSeedPreview,
+    loadSeedGeoJson,
+    beginSeedEdit,
+    updateEditableSeedSelection,
+    finishSeedEdit,
+    cancelSeedEdit,
+    resetAdjustedSeed,
+    showMoreSeedEditNeighbors,
+    applyResolvedSeedPreview,
+    clearSeedPreviewWithError
+  } = useSeedEditing();
   const [resolvingSeed, setResolvingSeed] = useState(false);
-  const [seedResolveError, setSeedResolveError] = useState('');
   const [startDate, setStartDate] = useState('2019-01-01');
   const [endDate, setEndDate] = useState('2019-02-01');
   const [description, setDescription] = useState('');
@@ -257,25 +262,6 @@ export default function CZGeneration() {
     String(location ?? '')
       .trim()
       .toUpperCase() === 'TEST';
-  const seedAdjustmentSummary = useMemo(() => {
-    const resolvedSet = new Set(resolvedSetupSeedCbgs);
-    const currentSet = new Set(setupSeedCbgs);
-    const addedCount = setupSeedCbgs.filter(
-      (cbg) => !resolvedSet.has(cbg)
-    ).length;
-    const removedCount = resolvedSetupSeedCbgs.filter(
-      (cbg) => !currentSet.has(cbg)
-    ).length;
-
-    return {
-      addedCount,
-      removedCount,
-      hasChanges: addedCount > 0 || removedCount > 0
-    };
-  }, [resolvedSetupSeedCbgs, setupSeedCbgs]);
-  const activeSetupSeedGeoJSON = seedEditMode
-    ? seedEditGeoJSON || setupSeedGeoJSON
-    : setupSeedGeoJSON;
   const traceSteps = growthTrace?.steps ?? [];
   const mobilityPruneMetadata =
     hasGenerated &&
@@ -664,27 +650,8 @@ export default function CZGeneration() {
   const seedGuardNeedsResolvedSeed =
     clusterAlgorithm === 'greedy_weight_seed_guard' && !isTestLocationInput;
 
-  const resetSeedPreview = useCallback(() => {
-    setSetupSeedCbg('');
-    setSetupSeedLabel('');
-    setSetupSeedCount(0);
-    setSetupSeedCbgs([]);
-    setResolvedSetupSeedCbgs([]);
-    setSetupSeedGeoJSON(null);
-    setSeedEditGeoJSON(null);
-    setSeedEditMode(false);
-    setSeedEditAction('add');
-    setSeedEditLoading(false);
-    setSeedEditError('');
-    setSeedEditStartCbgs([]);
-    setSeedEditNeighborRings(0);
-    setSetupResolvedCityName('');
-    setResolvedSeedLookup(null);
-    setSeedResolveError('');
-  }, []);
-
   const seedStateCbg =
-    setupSeedCbg || setupSeedCbgs[0] || seedCBG || selectedCBGs[0] || '';
+    editedSeedStateCbg || seedCBG || selectedCBGs[0] || '';
   const detectedStateAbbr = getStateFromCBG(
     seedStateCbg ? [seedStateCbg] : null
   );
@@ -956,293 +923,6 @@ export default function CZGeneration() {
     []
   );
 
-  const loadSeedGeoJson = useCallback(
-    async (seedCbgs: string[], includeNeighbors: boolean) => {
-      const normalizedSeedCbgs = dedupeCbgList(seedCbgs);
-      if (!normalizedSeedCbgs.length) {
-        throw new Error('Select at least one seed CBG.');
-      }
-
-      let mergedGeoJson: GeoJSONData | null = null;
-      for (
-        let index = 0;
-        index < normalizedSeedCbgs.length;
-        index += CBG_GEOJSON_REQUEST_CHUNK_SIZE
-      ) {
-        const chunk = normalizedSeedCbgs.slice(
-          index,
-          index + CBG_GEOJSON_REQUEST_CHUNK_SIZE
-        );
-        const seedGeoJson = await fetchCbgGeoJson(chunk, includeNeighbors);
-        if (!seedGeoJson?.features?.length) {
-          throw new Error(
-            seedGeoJson?.message ||
-              'Resolved the seed CBGs, but could not load their map boundary.'
-          );
-        }
-
-        mergedGeoJson = mergeGeoJsonFeatures(
-          mergedGeoJson,
-          seedGeoJson as GeoJSONData
-        );
-      }
-
-      if (!mergedGeoJson?.features?.length) {
-        throw new Error(
-          'Resolved the seed CBGs, but could not load their map boundary.'
-        );
-      }
-
-      return mergedGeoJson;
-    },
-    []
-  );
-
-  const loadSeedEditGeoJson = useCallback(
-    async (seedCbgs: string[], neighborRings: number) => {
-      const rings = Math.max(1, Math.floor(neighborRings));
-      let queryCbgs = dedupeCbgList(seedCbgs);
-      let mergedGeoJson: GeoJSONData | null = null;
-
-      for (let ringIndex = 0; ringIndex < rings; ringIndex += 1) {
-        const ringGeoJson = await loadSeedGeoJson(queryCbgs, true);
-        const nextMergedGeoJson = mergeGeoJsonFeatures(
-          mergedGeoJson,
-          ringGeoJson
-        );
-        const nextQueryCbgs = getCbgIdsFromGeoJson(nextMergedGeoJson);
-
-        mergedGeoJson = nextMergedGeoJson;
-        if (sameStringArray(nextQueryCbgs, queryCbgs)) {
-          break;
-        }
-        queryCbgs = nextQueryCbgs;
-      }
-
-      return mergeGeoJsonFeatures(setupSeedGeoJSON, mergedGeoJson);
-    },
-    [loadSeedGeoJson, setupSeedGeoJSON]
-  );
-
-  const refreshSeedEditGeoJson = useCallback(
-    async (seedCbgs: string[], neighborRings: number) => {
-      const editGeoJson = await loadSeedEditGeoJson(seedCbgs, neighborRings);
-      setSeedEditGeoJSON(editGeoJson);
-      setSeedEditNeighborRings(
-        Math.max(
-          1,
-          Math.floor(neighborRings || INITIAL_SEED_EDIT_NEIGHBOR_RINGS)
-        )
-      );
-    },
-    [loadSeedEditGeoJson]
-  );
-
-  const commitSetupSeedCbgs = useCallback(
-    (nextSeedCbgs: string[]) => {
-      const normalizedSeedCbgs = dedupeCbgList(nextSeedCbgs);
-      if (!normalizedSeedCbgs.length) {
-        setSeedEditError('Keep at least one CBG in the seed area.');
-        return null;
-      }
-
-      const currentAnchor = normalizeCbgId(setupSeedCbg);
-      const nextAnchor = normalizedSeedCbgs.includes(currentAnchor)
-        ? currentAnchor
-        : normalizedSeedCbgs[0];
-      const sourceGeoJson = seedEditGeoJSON || setupSeedGeoJSON;
-      const selectedGeoJson = filterGeoJsonByCbgs(
-        sourceGeoJson,
-        normalizedSeedCbgs
-      );
-
-      setSetupSeedCbgs(normalizedSeedCbgs);
-      setSetupSeedCount(normalizedSeedCbgs.length);
-      setSetupSeedCbg(nextAnchor);
-      setSeedEditError('');
-      if (selectedGeoJson) {
-        setSetupSeedGeoJSON(selectedGeoJson);
-      }
-      setResolvedSeedLookup((prev) =>
-        prev
-          ? {
-              ...prev,
-              cbg: nextAnchor,
-              seedCbgs: normalizedSeedCbgs
-            }
-          : prev
-      );
-
-      return normalizedSeedCbgs;
-    },
-    [seedEditGeoJSON, setupSeedCbg, setupSeedGeoJSON]
-  );
-
-  const beginSeedEdit = useCallback(async () => {
-    if (!setupSeedCbgs.length) {
-      return;
-    }
-
-    setSeedEditMode(true);
-    setSeedEditAction('add');
-    setSeedEditStartCbgs(setupSeedCbgs);
-    setSeedEditError('');
-    setSeedEditLoading(true);
-    try {
-      await refreshSeedEditGeoJson(
-        setupSeedCbgs,
-        INITIAL_SEED_EDIT_NEIGHBOR_RINGS
-      );
-    } catch (err) {
-      setSeedEditError(
-        err instanceof Error
-          ? err.message
-          : 'Could not load nearby CBGs for seed adjustment.'
-      );
-    } finally {
-      setSeedEditLoading(false);
-    }
-  }, [refreshSeedEditGeoJson, setupSeedCbgs]);
-
-  const updateEditableSeedSelection = useCallback(
-    async (cbgIds: string[]) => {
-      const normalizedClickedCbgs = dedupeCbgList(cbgIds);
-      if (!normalizedClickedCbgs.length) {
-        return;
-      }
-
-      const clickedSet = new Set(normalizedClickedCbgs);
-      const currentSet = new Set(setupSeedCbgs);
-      const nextSeedCbgs =
-        seedEditAction === 'add'
-          ? dedupeCbgList([...setupSeedCbgs, ...normalizedClickedCbgs])
-          : setupSeedCbgs.filter((cbg) => !clickedSet.has(cbg));
-
-      if (seedEditAction === 'add' && nextSeedCbgs.length === currentSet.size) {
-        return;
-      }
-
-      if (seedEditAction === 'remove' && nextSeedCbgs.length === 0) {
-        setSeedEditError('Keep at least one CBG in the seed area.');
-        return;
-      }
-
-      const committedSeedCbgs = commitSetupSeedCbgs(nextSeedCbgs);
-      if (
-        !committedSeedCbgs ||
-        sameStringArray(committedSeedCbgs, setupSeedCbgs)
-      ) {
-        return;
-      }
-
-      setSeedEditLoading(true);
-      try {
-        await refreshSeedEditGeoJson(
-          committedSeedCbgs,
-          seedEditNeighborRings || INITIAL_SEED_EDIT_NEIGHBOR_RINGS
-        );
-      } catch (err) {
-        setSeedEditError(
-          err instanceof Error
-            ? err.message
-            : 'Could not refresh nearby CBGs after updating the seed area.'
-        );
-      } finally {
-        setSeedEditLoading(false);
-      }
-    },
-    [
-      commitSetupSeedCbgs,
-      refreshSeedEditGeoJson,
-      seedEditAction,
-      seedEditNeighborRings,
-      setupSeedCbgs
-    ]
-  );
-
-  const finishSeedEdit = useCallback(() => {
-    setSeedEditMode(false);
-    setSeedEditGeoJSON(null);
-    setSeedEditStartCbgs([]);
-    setSeedEditError('');
-  }, []);
-
-  const cancelSeedEdit = useCallback(() => {
-    const committedSeedCbgs = commitSetupSeedCbgs(seedEditStartCbgs);
-    if (committedSeedCbgs) {
-      setSeedEditMode(false);
-      setSeedEditGeoJSON(null);
-      setSeedEditStartCbgs([]);
-      setSeedEditError('');
-    }
-  }, [commitSetupSeedCbgs, seedEditStartCbgs]);
-
-  const resetAdjustedSeed = useCallback(async () => {
-    const committedSeedCbgs = commitSetupSeedCbgs(resolvedSetupSeedCbgs);
-    if (!committedSeedCbgs) {
-      return;
-    }
-
-    setSeedEditLoading(true);
-    try {
-      if (seedEditMode) {
-        await refreshSeedEditGeoJson(
-          committedSeedCbgs,
-          seedEditNeighborRings || INITIAL_SEED_EDIT_NEIGHBOR_RINGS
-        );
-      } else {
-        const seedGeoJson = await loadSeedGeoJson(committedSeedCbgs, false);
-        setSetupSeedGeoJSON(seedGeoJson);
-      }
-      setSeedEditError('');
-    } catch (err) {
-      setSeedEditError(
-        err instanceof Error
-          ? err.message
-          : 'Could not reset the seed area boundary.'
-      );
-    } finally {
-      setSeedEditLoading(false);
-    }
-  }, [
-    commitSetupSeedCbgs,
-    loadSeedGeoJson,
-    refreshSeedEditGeoJson,
-    resolvedSetupSeedCbgs,
-    seedEditNeighborRings,
-    seedEditMode
-  ]);
-
-  const showMoreSeedEditNeighbors = useCallback(async () => {
-    if (!seedEditMode || !setupSeedCbgs.length) {
-      return;
-    }
-
-    const nextNeighborRings = Math.max(
-      seedEditNeighborRings + 1,
-      INITIAL_SEED_EDIT_NEIGHBOR_RINGS + 1
-    );
-
-    setSeedEditLoading(true);
-    setSeedEditError('');
-    try {
-      await refreshSeedEditGeoJson(setupSeedCbgs, nextNeighborRings);
-    } catch (err) {
-      setSeedEditError(
-        err instanceof Error
-          ? err.message
-          : 'Could not load a wider nearby area.'
-      );
-    } finally {
-      setSeedEditLoading(false);
-    }
-  }, [
-    refreshSeedEditGeoJson,
-    seedEditMode,
-    seedEditNeighborRings,
-    setupSeedCbgs
-  ]);
-
   const resolveSeedPreview = async () => {
     const rawLocationInput = String(location ?? '').trim();
     if (!rawLocationInput) {
@@ -1277,48 +957,21 @@ export default function CZGeneration() {
       }
 
       const seedGeoJson = await loadSeedGeoJson(normalizedSeedCbgs, false);
-
-      setSetupSeedCbg(coreCbg);
-      setSetupSeedLabel(locationData?.seed_name || coreCbg);
-      setSetupSeedCount(normalizedSeedCbgs.length);
-      setSetupSeedCbgs(normalizedSeedCbgs);
-      setResolvedSetupSeedCbgs(normalizedSeedCbgs);
-      setSetupSeedGeoJSON(seedGeoJson);
-      setSeedEditGeoJSON(null);
-      setSeedEditMode(false);
-      setSeedEditAction('add');
-      setSeedEditError('');
-      setSeedEditStartCbgs([]);
-      setSeedEditNeighborRings(0);
       const cityName =
         locationData?.city && locationData?.state
           ? `${locationData.city}, ${locationData.state}`
           : locationData?.city || locationData?.state || rawLocationInput;
-      setSetupResolvedCityName(cityName);
-      setResolvedSeedLookup({
+      applyResolvedSeedPreview({
         query: rawLocationInput,
-        cbg: coreCbg,
+        coreCbg,
         cityName,
         seedName: locationData?.seed_name || coreCbg,
         seedCbgs: normalizedSeedCbgs,
+        seedGeoJson,
         seedZip: locationData?.zip
       });
     } catch (err) {
-      setSetupSeedCbg('');
-      setSetupSeedLabel('');
-      setSetupSeedCount(0);
-      setSetupSeedCbgs([]);
-      setResolvedSetupSeedCbgs([]);
-      setSetupSeedGeoJSON(null);
-      setSeedEditGeoJSON(null);
-      setSeedEditMode(false);
-      setSeedEditAction('add');
-      setSeedEditError('');
-      setSeedEditStartCbgs([]);
-      setSeedEditNeighborRings(0);
-      setSetupResolvedCityName('');
-      setResolvedSeedLookup(null);
-      setSeedResolveError(
+      clearSeedPreviewWithError(
         err instanceof Error ? err.message : 'Failed to resolve the seed CBG.'
       );
     } finally {
@@ -1525,6 +1178,7 @@ export default function CZGeneration() {
             );
           }
           seedGeoJson = seedGeoData as GeoJSONData;
+          setSetupSeedGeoJSON(seedGeoJson);
         }
 
         const destinations = Array.isArray(data.destinations)

--- a/src/app/cz-generation/page.tsx
+++ b/src/app/cz-generation/page.tsx
@@ -16,6 +16,7 @@ import {
 import { CandidateAnalysisPanel } from '@/features/cz-generation/components/candidate-analysis-panel';
 import { ConnectedCitiesPanel } from '@/features/cz-generation/components/connected-cities-panel';
 import { FrontierCandidatesPanel } from '@/features/cz-generation/components/frontier-candidates-panel';
+import { GeneratedActionBar } from '@/features/cz-generation/components/generated-action-bar';
 import { GuidedTermsHelpModal } from '@/features/cz-generation/components/guided-terms-help-modal';
 import {
   CBG_GEOJSON_REQUEST_CHUNK_SIZE,
@@ -25,7 +26,6 @@ import {
   GUIDED_HARD_EXPLICIT_POPULATION,
   GUIDED_REGION_PALETTE,
   GUIDED_SEED_STYLE,
-  GUIDED_SOFT_EXPLICIT_POPULATION,
   INITIAL_SEED_EDIT_NEIGHBOR_RINGS,
   type ClusterAlgorithm
 } from '@/features/cz-generation/constants';
@@ -2246,460 +2246,49 @@ export default function CZGeneration() {
               )}
             </div>
 
-            <div
-              className={`czgen_actionbar ${
-                guidedSelectionMode
-                  ? 'flex-col xl:flex-row xl:items-start xl:justify-between'
-                  : 'items-start justify-between'
-              }`}
-            >
-              {guidedSelectionMode ? (
-                <div className="min-w-0 flex-1">
-                  <div className="text-sm font-semibold text-[#1f2937]">
-                    Ready to Generate
-                  </div>
-                  <div className="mt-1 text-sm text-gray-700">
-                    {selectedGuidedDestinationIds.length
-                      ? `Selected ${selectedGuidedDestinationIds.length} cities and ${selectedCBGs.length} linked CBGs: ${guidedSelectedDestinationSummary}.`
-                      : `Seed only is selected right now. The explicit layer contains ${selectedCBGs.length} seed CBGs.`}
-                  </div>
-                  <div className="mt-3 flex flex-wrap gap-2 text-xs text-gray-700">
-                    <div className="rounded-full border border-[#dbeafe] bg-white px-3 py-1">
-                      <span className="font-semibold text-[#1f2937]">
-                        Trips Leaving Seed Captured (linked CBGs):
-                      </span>{' '}
-                      {(
-                        guidedSelectionSummary.selectedLinkedOutboundShare * 100
-                      ).toFixed(1)}
-                      %
-                    </div>
-                    <div className="rounded-full border border-[#dbeafe] bg-white px-3 py-1">
-                      <span className="font-semibold text-[#1f2937]">
-                        Explicit Pop:
-                      </span>{' '}
-                      {Number(
-                        guidedSelectionSummary.selectedPopulation ?? 0
-                      ).toLocaleString()}
-                    </div>
-                  </div>
-                  {guidedSelectionSummary.selectedPopulation >
-                  GUIDED_HARD_EXPLICIT_POPULATION ? (
-                    <div className="mt-3 text-xs text-red-700">
-                      Finalize is disabled above{' '}
-                      {GUIDED_HARD_EXPLICIT_POPULATION.toLocaleString()}{' '}
-                      explicit residents.
-                    </div>
-                  ) : guidedSelectionSummary.selectedPopulation >
-                    GUIDED_SOFT_EXPLICIT_POPULATION ? (
-                    <div className="mt-3 text-xs text-amber-700">
-                      This selection is above the preferred explicit-population
-                      band of {GUIDED_SOFT_EXPLICIT_POPULATION.toLocaleString()}
-                      .
-                    </div>
-                  ) : (
-                    <div className="mt-3 text-xs text-gray-600">
-                      Choose connected cities on the right. The map updates as
-                      you change the explicit linked CBG layer.
-                    </div>
-                  )}
-                </div>
-              ) : (
-                <>
-                  <div>
-                    {mobilityPruneMetadata ? (
-                      <>
-                        <div className="text-sm font-semibold mb-2">
-                          Mobility Prune Summary
-                        </div>
-                        <div className="flex flex-wrap gap-2 text-xs text-gray-700">
-                          <div className="rounded-full border border-[#dbeafe] bg-white px-3 py-1">
-                            <span className="font-semibold text-[#1f2937]">
-                              Final Zone:
-                            </span>{' '}
-                            {selectedCBGs.length} CBGs, pop{' '}
-                            {Number(totalPopulation || 0).toLocaleString()}
-                          </div>
-                          <div className="rounded-full border border-[#dbeafe] bg-white px-3 py-1">
-                            <span className="font-semibold text-[#1f2937]">
-                              Seed Pop:
-                            </span>{' '}
-                            {Number(
-                              mobilityPruneMetadata.seed_population ?? 0
-                            ).toLocaleString()}
-                          </div>
-                          <div className="rounded-full border border-[#dbeafe] bg-white px-3 py-1">
-                            <span className="font-semibold text-[#1f2937]">
-                              Envelope:
-                            </span>{' '}
-                            {Number(
-                              mobilityPruneMetadata.initial_cbg_count ?? 0
-                            ).toLocaleString()}{' '}
-                            CBGs, pop{' '}
-                            {Number(
-                              mobilityPruneMetadata.initial_population ?? 0
-                            ).toLocaleString()}
-                          </div>
-                          <div className="rounded-full border border-[#dbeafe] bg-white px-3 py-1">
-                            <span className="font-semibold text-[#1f2937]">
-                              Envelope Target:
-                            </span>{' '}
-                            {Number(
-                              mobilityPruneMetadata.envelope_population_target ??
-                                0
-                            ).toLocaleString()}
-                          </div>
-                          <div className="rounded-full border border-[#dbeafe] bg-white px-3 py-1">
-                            <span className="font-semibold text-[#1f2937]">
-                              Pruned:
-                            </span>{' '}
-                            {Number(
-                              mobilityPruneMetadata.removed_cbg_count ?? 0
-                            ).toLocaleString()}{' '}
-                            CBGs, pop{' '}
-                            {Number(
-                              mobilityPruneMetadata.population_reduced ?? 0
-                            ).toLocaleString()}
-                          </div>
-                          <div className="rounded-full border border-[#dbeafe] bg-white px-3 py-1">
-                            <span className="font-semibold text-[#1f2937]">
-                              Minimum Seed Capture:
-                            </span>{' '}
-                            {Number(
-                              (mobilityPruneMetadata.min_seed_capture ?? 0) *
-                                100
-                            ).toFixed(0)}
-                            %
-                          </div>
-                          <div className="rounded-full border border-[#dbeafe] bg-white px-3 py-1">
-                            <span className="font-semibold text-[#1f2937]">
-                              Seed Capture:
-                            </span>{' '}
-                            {Number(
-                              (mobilityPruneMetadata.final_seed_capture_share ??
-                                0) * 100
-                            ).toFixed(1)}
-                            %
-                          </div>
-                        </div>
-                        {showTraceControls &&
-                          growthTrace?.supports_stepwise &&
-                          traceSteps.length > 0 && (
-                            <div className="mt-3 border-t border-[#dbeafe] pt-3">
-                              <label className="flex items-center gap-2 text-xs">
-                                <input
-                                  type="checkbox"
-                                  checked={traceEnabled}
-                                  onChange={(e) =>
-                                    setTraceEnabled(e.target.checked)
-                                  }
-                                />
-                                Show pruning trace heat map
-                              </label>
-                              {traceEnabled && (
-                                <>
-                                  <div className="mt-2 text-xs text-gray-600">
-                                    Step{' '}
-                                    {Math.min(traceStepIndex, maxTraceStep) + 1}{' '}
-                                    of {traceSteps.length}
-                                  </div>
-                                  <div className="mt-2 flex gap-2">
-                                    <button
-                                      type="button"
-                                      className="czgen_btn czgen_btn--sm"
-                                      disabled={traceStepIndex <= 0}
-                                      onClick={() =>
-                                        jumpToTraceStep(traceStepIndex - 1)
-                                      }
-                                    >
-                                      Previous Step
-                                    </button>
-                                    <button
-                                      type="button"
-                                      className="czgen_btn czgen_btn--sm"
-                                      disabled={traceStepIndex >= maxTraceStep}
-                                      onClick={() =>
-                                        jumpToTraceStep(traceStepIndex + 1)
-                                      }
-                                    >
-                                      Next Step
-                                    </button>
-                                  </div>
-                                </>
-                              )}
-                            </div>
-                          )}
-                      </>
-                    ) : showTraceControls ? (
-                      <>
-                        <div className="text-sm font-semibold mb-2">
-                          Trace Controls
-                        </div>
-                        {growthTrace?.supports_stepwise &&
-                        traceSteps.length > 0 ? (
-                          <>
-                            <label className="flex items-center gap-2 text-xs mb-2">
-                              <input
-                                type="checkbox"
-                                checked={traceEnabled}
-                                onChange={(e) =>
-                                  setTraceEnabled(e.target.checked)
-                                }
-                              />
-                              Show frontier heat map
-                            </label>
-                            <div className="text-xs text-gray-600">
-                              Step {Math.min(traceStepIndex, maxTraceStep) + 1}{' '}
-                              of {traceSteps.length}
-                            </div>
-                            <div className="mt-2 flex gap-2">
-                              <button
-                                type="button"
-                                className="czgen_btn czgen_btn--sm"
-                                disabled={!traceEnabled || traceStepIndex <= 0}
-                                onClick={() =>
-                                  jumpToTraceStep(traceStepIndex - 1)
-                                }
-                              >
-                                Previous Step
-                              </button>
-                              <button
-                                type="button"
-                                className="czgen_btn czgen_btn--sm"
-                                disabled={
-                                  !traceEnabled ||
-                                  traceStepIndex >= maxTraceStep
-                                }
-                                onClick={() =>
-                                  jumpToTraceStep(traceStepIndex + 1)
-                                }
-                              >
-                                Next Step
-                              </button>
-                            </div>
-                          </>
-                        ) : (
-                          <div className="text-xs text-gray-600">
-                            {growthTrace?.note ||
-                              'This algorithm does not expose a step-by-step greedy expansion trace.'}
-                          </div>
-                        )}
-                      </>
-                    ) : zoneMetricsLoading ? (
-                      <>
-                        <div className="text-sm font-semibold mb-2">
-                          Zone Metrics (Live)
-                        </div>
-                        <div className="text-xs text-gray-600">
-                          Computing CZI...
-                        </div>
-                      </>
-                    ) : zoneMetricsError ? (
-                      <>
-                        <div className="text-sm font-semibold mb-2">
-                          Zone Metrics (Live)
-                        </div>
-                        <div className="text-xs text-red-700">
-                          {zoneMetricsError}
-                        </div>
-                      </>
-                    ) : zoneMetrics ? (
-                      <>
-                        <div className="text-sm font-semibold mb-2">
-                          Zone Metrics (Live)
-                        </div>
-                        <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-gray-700">
-                          <div>
-                            <span className="font-semibold">CBGs:</span>{' '}
-                            {zoneMetrics.cbg_count ?? selectedCBGs.length}
-                          </div>
-                          <div>
-                            <span className="font-semibold">CZI:</span>{' '}
-                            {Number(zoneMetrics.czi ?? 0).toFixed(4)}
-                          </div>
-                          <div>
-                            <span className="font-semibold">Inside:</span>{' '}
-                            {Number(
-                              zoneMetrics.movement_inside ?? 0
-                            ).toLocaleString(undefined, {
-                              maximumFractionDigits: 1
-                            })}
-                          </div>
-                          <div>
-                            <span className="font-semibold">Boundary:</span>{' '}
-                            {Number(
-                              zoneMetrics.movement_boundary ?? 0
-                            ).toLocaleString(undefined, {
-                              maximumFractionDigits: 1
-                            })}
-                          </div>
-                        </div>
-                        <div className="mt-1 text-xs text-gray-600">
-                          Click CBGs on the map to add or remove them. Frontier
-                          candidates update automatically.
-                        </div>
-                      </>
-                    ) : (
-                      <>
-                        <div className="text-sm font-semibold mb-2">
-                          Zone Metrics (Live)
-                        </div>
-                        <div className="text-xs text-gray-600">
-                          No metrics available.
-                        </div>
-                      </>
-                    )}
-                  </div>
-
-                  {clusterAlgorithm === 'greedy_weight_seed_guard' &&
-                    manualEditPanelsActive && (
-                      <div className="min-w-[15rem] max-w-[18rem] flex flex-col gap-1">
-                        <label
-                          htmlFor="seed_guard_distance_live"
-                          className="text-sm font-semibold"
-                        >
-                          Seed Guard Radius (km)
-                        </label>
-                        <input
-                          id="seed_guard_distance_live"
-                          className="formfield"
-                          type="number"
-                          min={0}
-                          max={500}
-                          value={seedGuardDistanceKm}
-                          onChange={(e) =>
-                            setSeedGuardDistanceKm(Number(e.target.value))
-                          }
-                          disabled={loading || isFinalizing}
-                        />
-                        <div className="text-xs text-gray-600">
-                          Blue ring shows the seed guard radius and updates live
-                          as you change it.
-                        </div>
-                      </div>
-                    )}
-
-                  {algorithmMetadata && !algorithmMetadata.bounded_envelope && (
-                    <div className="min-w-[16rem] max-w-[22rem] flex flex-col gap-1 text-xs text-gray-700">
-                      <div className="text-sm font-semibold text-[#1f2937]">
-                        Hierarchy Summary
-                      </div>
-                      <div>
-                        <span className="font-semibold">Seed:</span>{' '}
-                        {algorithmMetadata.seed_zip_codes?.length
-                          ? algorithmMetadata.seed_zip_codes.join(', ')
-                          : `${algorithmMetadata.seed_cbgs?.length ?? 0} seed CBGs`}
-                      </div>
-                      <div>
-                        <span className="font-semibold">Core:</span>{' '}
-                        {algorithmMetadata.core_cluster?.length ?? 0} CBGs
-                        {algorithmMetadata.core_population !== undefined
-                          ? `, pop ${Number(
-                              algorithmMetadata.core_population
-                            ).toLocaleString()}`
-                          : ''}
-                      </div>
-                      <div>
-                        <span className="font-semibold">Satellites:</span>{' '}
-                        {algorithmMetadata.selected_satellites?.length ?? 0}
-                      </div>
-                      {algorithmMetadata.selected_satellites &&
-                        algorithmMetadata.selected_satellites.length > 0 && (
-                          <div>
-                            <span className="font-semibold">Selected:</span>{' '}
-                            {algorithmMetadata.selected_satellites
-                              .map(
-                                (item) =>
-                                  item.label || item.unit_id || 'Unknown'
-                              )
-                              .join(', ')}
-                          </div>
-                        )}
-                      {algorithmMetadata.external_pressure_share !==
-                        undefined && (
-                        <div>
-                          <span className="font-semibold">
-                            External Pressure:
-                          </span>{' '}
-                          {Number(
-                            (algorithmMetadata.external_pressure_share ?? 0) *
-                              100
-                          ).toFixed(1)}
-                          %
-                        </div>
-                      )}
-                      {algorithmMetadata.population_target_met !==
-                        undefined && (
-                        <div>
-                          <span className="font-semibold">
-                            Population Target:
-                          </span>{' '}
-                          {algorithmMetadata.population_target_met
-                            ? 'Met'
-                            : 'Not met'}
-                        </div>
-                      )}
-                    </div>
-                  )}
-                </>
-              )}
-
-              <div
-                className={`flex flex-wrap items-center gap-2 ${
-                  guidedSelectionMode ? 'xl:justify-end' : ''
-                }`}
-              >
-                {growthTrace && !zoneEditMode && (
-                  <button
-                    type="button"
-                    onClick={() => {
-                      setZoneEditMode(true);
-                      setTraceEnabled(false);
-                    }}
-                    disabled={loading || isFinalizing}
-                    className="czgen_btn"
-                  >
-                    Edit Zone
-                  </button>
-                )}
-                {growthTrace && zoneEditMode && (
-                  <button
-                    type="button"
-                    onClick={() => {
-                      setZoneEditMode(false);
-                      setTraceEnabled(Boolean(growthTrace?.steps?.length));
-                    }}
-                    disabled={loading || isFinalizing}
-                    className="czgen_btn"
-                  >
-                    Trace View
-                  </button>
-                )}
-                <button
-                  type="button"
-                  onClick={saveCZHtmlMap}
-                  disabled={loading || isFinalizing || savingHtmlMap}
-                  className="czgen_btn"
-                >
-                  {savingHtmlMap ? 'Saving HTML Map...' : 'Save HTML Map'}
-                </button>
-                <button
-                  type="button"
-                  onClick={finalizeCZ}
-                  disabled={
-                    loading ||
-                    isFinalizing ||
-                    (guidedSelectionMode &&
-                      guidedSelectionSummary.selectedPopulation >
-                        GUIDED_HARD_EXPLICIT_POPULATION)
-                  }
-                  className="czgen_btn czgen_btn--primary"
-                >
-                  {isFinalizing
-                    ? 'Generating Patterns...'
-                    : 'Finalize & Generate'}
-                </button>
-              </div>
-            </div>
+            <GeneratedActionBar
+              guidedSelectionMode={guidedSelectionMode}
+              selectedGuidedDestinationCount={
+                selectedGuidedDestinationIds.length
+              }
+              selectedCbgCount={selectedCBGs.length}
+              guidedSelectedDestinationSummary={
+                guidedSelectedDestinationSummary
+              }
+              guidedSelectionSummary={guidedSelectionSummary}
+              mobilityPruneMetadata={mobilityPruneMetadata}
+              totalPopulation={totalPopulation}
+              showTraceControls={showTraceControls}
+              growthTrace={growthTrace}
+              traceStepCount={traceSteps.length}
+              traceEnabled={traceEnabled}
+              traceStepIndex={traceStepIndex}
+              maxTraceStep={maxTraceStep}
+              onTraceEnabledChange={setTraceEnabled}
+              onJumpTraceStep={jumpToTraceStep}
+              zoneMetricsLoading={zoneMetricsLoading}
+              zoneMetricsError={zoneMetricsError}
+              zoneMetrics={zoneMetrics}
+              clusterAlgorithm={clusterAlgorithm}
+              manualEditPanelsActive={manualEditPanelsActive}
+              seedGuardDistanceKm={seedGuardDistanceKm}
+              onSeedGuardDistanceChange={setSeedGuardDistanceKm}
+              loading={loading}
+              isFinalizing={isFinalizing}
+              algorithmMetadata={algorithmMetadata}
+              zoneEditMode={zoneEditMode}
+              onEnterZoneEditMode={() => {
+                setZoneEditMode(true);
+                setTraceEnabled(false);
+              }}
+              onEnterTraceView={() => {
+                setZoneEditMode(false);
+                setTraceEnabled(Boolean(growthTrace?.steps?.length));
+              }}
+              onSaveHtmlMap={saveCZHtmlMap}
+              savingHtmlMap={savingHtmlMap}
+              onFinalize={finalizeCZ}
+            />
           </div>
         ) : (
           <div className="w-full flex flex-col gap-4 lg:flex-row lg:items-stretch" data-aos="fade-up" data-aos-once="true" data-aos-delay="80">

--- a/src/app/cz-generation/page.tsx
+++ b/src/app/cz-generation/page.tsx
@@ -9,7 +9,6 @@ import {
   fetchCandidatePois,
   fetchCbgAtPoint,
   fetchCbgGeoJson,
-  fetchCzMetrics,
   fetchFrontierCandidates,
   fetchSecondOrderDestinations,
   finalizeConvenienceZone,
@@ -47,6 +46,7 @@ import {
   sameStringArray,
   startDateFromMonth
 } from '@/features/cz-generation/helpers';
+import { useCzMetrics } from '@/features/cz-generation/hooks/use-cz-metrics';
 import { usePatternAvailability } from '@/features/cz-generation/hooks/use-pattern-availability';
 import type {
   ClusterAlgorithmMetadata,
@@ -60,8 +60,7 @@ import type {
   SeedEditAction,
   TraceCandidate,
   TraceLayerData,
-  TracePayload,
-  ZoneMetrics
+  TracePayload
 } from '@/features/cz-generation/types';
 import { useSession } from '@/lib/auth-client';
 import {
@@ -337,13 +336,8 @@ export default function CZGeneration() {
   >([]);
   const [manualFrontierLoading, setManualFrontierLoading] = useState(false);
   const [manualFrontierError, setManualFrontierError] = useState('');
-  const [zoneMetrics, setZoneMetrics] = useState<ZoneMetrics | null>(null);
-  const [zoneMetricsLoading, setZoneMetricsLoading] = useState(false);
-  const [zoneMetricsError, setZoneMetricsError] = useState('');
   const [savingHtmlMap, setSavingHtmlMap] = useState(false);
   const [zoneEditMode, setZoneEditMode] = useState(false);
-  const [_cziMetrics, setCziMetrics] = useState<ZoneMetrics | null>(null);
-  const [_cziLoading, setCziLoading] = useState(false);
   const [finalizeProgress, setFinalizeProgress] = useState(0);
   const [finalizeStatusMessage, setFinalizeStatusMessage] = useState('');
   const hasGenerated = phase === 'edit' || phase === 'finalizing';
@@ -585,6 +579,27 @@ export default function CZGeneration() {
   const manualEditPanelsActive = hasGenerated && (!growthTrace || zoneEditMode);
   const showCandidatePanels =
     !guidedSelectionMode && (Boolean(traceLayer) || manualEditPanelsActive);
+  const { metrics: _cziMetrics, loading: _cziLoading } = useCzMetrics({
+    enabled: hasGenerated,
+    seedCbg: seedCBG,
+    cbgs: selectedCBGs,
+    startDate,
+    useTestData,
+    debounceMs: 180,
+    warnMessage: 'Failed to compute CZI metrics:'
+  });
+  const {
+    metrics: zoneMetrics,
+    loading: zoneMetricsLoading,
+    error: zoneMetricsError
+  } = useCzMetrics({
+    enabled: !guidedSelectionMode && manualEditPanelsActive,
+    seedCbg: seedCBG,
+    cbgs: selectedCBGs,
+    startDate,
+    useTestData,
+    errorMessage: 'Failed to compute zone metrics.'
+  });
   const displayCandidates = traceLayer
     ? activeTraceCandidates
     : manualEditPanelsActive
@@ -862,44 +877,6 @@ export default function CZGeneration() {
   }, [cbgGeoJSON, focusedTraceCbg, showCandidatePanels]);
 
   useEffect(() => {
-    if (!hasGenerated || !seedCBG || selectedCBGs.length === 0) {
-      setCziMetrics(null);
-      setCziLoading(false);
-      return;
-    }
-
-    let cancelled = false;
-    const timer = setTimeout(async () => {
-      setCziLoading(true);
-      try {
-        const data = await fetchCzMetrics({
-          seed_cbg: seedCBG,
-          cbg_list: selectedCBGs,
-          start_date: startDate,
-          use_test_data: useTestData
-        });
-        if (!cancelled) {
-          setCziMetrics(data);
-        }
-      } catch (err) {
-        if (!cancelled) {
-          setCziMetrics(null);
-        }
-        console.warn('Failed to compute CZI metrics:', err);
-      } finally {
-        if (!cancelled) {
-          setCziLoading(false);
-        }
-      }
-    }, 180);
-
-    return () => {
-      cancelled = true;
-      clearTimeout(timer);
-    };
-  }, [hasGenerated, seedCBG, selectedCBGs, startDate, useTestData]);
-
-  useEffect(() => {
     if (!showCandidatePanels || !selectedTraceCandidateCbg) {
       return;
     }
@@ -1065,62 +1042,6 @@ export default function CZGeneration() {
     seedGuardDistanceKm,
     selectedCBGs,
     selectedTraceCandidateCbg,
-    startDate,
-    useTestData
-  ]);
-
-  useEffect(() => {
-    if (
-      guidedSelectionMode ||
-      !manualEditPanelsActive ||
-      !seedCBG ||
-      !selectedCBGs.length
-    ) {
-      setZoneMetrics(null);
-      setZoneMetricsError('');
-      setZoneMetricsLoading(false);
-      return;
-    }
-
-    let cancelled = false;
-    setZoneMetricsLoading(true);
-    setZoneMetricsError('');
-
-    fetchCzMetrics({
-      seed_cbg: seedCBG,
-      cbg_list: selectedCBGs,
-      start_date: startDate,
-      use_test_data: useTestData
-    })
-      .then((data) => {
-        if (cancelled) {
-          return;
-        }
-        setZoneMetrics(data || null);
-      })
-      .catch((err) => {
-        if (cancelled) {
-          return;
-        }
-        setZoneMetrics(null);
-        setZoneMetricsError(
-          err instanceof Error ? err.message : 'Failed to compute zone metrics.'
-        );
-      })
-      .finally(() => {
-        if (!cancelled) {
-          setZoneMetricsLoading(false);
-        }
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [
-    guidedSelectionMode,
-    manualEditPanelsActive,
-    seedCBG,
-    selectedCBGs,
     startDate,
     useTestData
   ]);
@@ -1886,8 +1807,6 @@ export default function CZGeneration() {
         setZoneEditMode(false);
         setManualFrontierCandidates([]);
         setManualFrontierError('');
-        setZoneMetrics(null);
-        setZoneMetricsError('');
         setCandidatePois([]);
         setCandidatePoiError('');
         setSelectedTraceCandidateCbg('');
@@ -2003,8 +1922,6 @@ export default function CZGeneration() {
       setZoneEditMode(false);
       setManualFrontierCandidates([]);
       setManualFrontierError('');
-      setZoneMetrics(null);
-      setZoneMetricsError('');
       setCandidatePois([]);
       setCandidatePoiError('');
 

--- a/src/app/cz-generation/page.tsx
+++ b/src/app/cz-generation/page.tsx
@@ -6,7 +6,6 @@ import { Info } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   exportCzMapHtml,
-  fetchCandidatePois,
   fetchCbgAtPoint,
   fetchCbgGeoJson,
   fetchFrontierCandidates,
@@ -46,6 +45,7 @@ import {
   sameStringArray,
   startDateFromMonth
 } from '@/features/cz-generation/helpers';
+import { useCandidatePois } from '@/features/cz-generation/hooks/use-candidate-pois';
 import { useCzMetrics } from '@/features/cz-generation/hooks/use-cz-metrics';
 import { usePatternAvailability } from '@/features/cz-generation/hooks/use-pattern-availability';
 import type {
@@ -55,7 +55,6 @@ import type {
   GuidedSecondOrderMetadata,
   GuidedSelectionStyle,
   LookupLocationResult,
-  PoiAnalysis,
   ResolvedSeedLookup,
   SeedEditAction,
   TraceCandidate,
@@ -83,6 +82,8 @@ const InteractiveMap = dynamic(() => import('@/components/interactive-map'), {
   ssr: false
 });
 const CBGMap = dynamic(() => import('@/components/cbg-map'), { ssr: false });
+
+const EMPTY_CBG_LIST: string[] = [];
 
 type FormFieldProps = {
   label: string;
@@ -328,9 +329,6 @@ export default function CZGeneration() {
     useState('');
   const [focusedTraceCbg, setFocusedTraceCbg] = useState('');
   const [focusedTraceNonce, setFocusedTraceNonce] = useState(0);
-  const [candidatePois, setCandidatePois] = useState<PoiAnalysis[]>([]);
-  const [candidatePoiLoading, setCandidatePoiLoading] = useState(false);
-  const [candidatePoiError, setCandidatePoiError] = useState('');
   const [manualFrontierCandidates, setManualFrontierCandidates] = useState<
     TraceCandidate[]
   >([]);
@@ -579,6 +577,27 @@ export default function CZGeneration() {
   const manualEditPanelsActive = hasGenerated && (!growthTrace || zoneEditMode);
   const showCandidatePanels =
     !guidedSelectionMode && (Boolean(traceLayer) || manualEditPanelsActive);
+  const candidatePoiCluster = useMemo(
+    () =>
+      traceLayer
+        ? Array.isArray(activeTraceStep?.cluster_before)
+          ? activeTraceStep.cluster_before
+          : EMPTY_CBG_LIST
+        : selectedCBGs,
+    [activeTraceStep, selectedCBGs, traceLayer]
+  );
+  const {
+    pois: candidatePois,
+    loading: candidatePoiLoading,
+    error: candidatePoiError
+  } = useCandidatePois({
+    enabled: showCandidatePanels,
+    seedCbg: seedCBG,
+    candidateCbg: selectedTraceCandidateCbg,
+    clusterCbgs: candidatePoiCluster,
+    startDate,
+    useTestData
+  });
   const { metrics: _cziMetrics, loading: _cziLoading } = useCzMetrics({
     enabled: hasGenerated,
     seedCbg: seedCBG,
@@ -826,9 +845,6 @@ export default function CZGeneration() {
       if (!manualEditPanelsActive) {
         setSelectedTraceCandidateCbg('');
         setFocusedTraceCbg('');
-        setCandidatePois([]);
-        setCandidatePoiError('');
-        setCandidatePoiLoading(false);
       }
       return;
     }
@@ -875,71 +891,6 @@ export default function CZGeneration() {
         );
       });
   }, [cbgGeoJSON, focusedTraceCbg, showCandidatePanels]);
-
-  useEffect(() => {
-    if (!showCandidatePanels || !selectedTraceCandidateCbg) {
-      return;
-    }
-
-    const poiCluster = traceLayer
-      ? Array.isArray(activeTraceStep?.cluster_before)
-        ? activeTraceStep.cluster_before
-        : []
-      : selectedCBGs;
-    if (!poiCluster.length) {
-      setCandidatePois([]);
-      setCandidatePoiError('');
-      return;
-    }
-
-    let cancelled = false;
-    setCandidatePoiLoading(true);
-    setCandidatePoiError('');
-
-    fetchCandidatePois({
-      seed_cbg: seedCBG,
-      candidate_cbg: selectedTraceCandidateCbg,
-      cluster_cbgs: poiCluster,
-      start_date: startDate,
-      use_test_data: useTestData,
-      limit: 8
-    })
-      .then((data) => {
-        if (cancelled) {
-          return;
-        }
-        setCandidatePois(
-          Array.isArray(data?.pois) ? (data.pois as PoiAnalysis[]) : []
-        );
-      })
-      .catch((err) => {
-        if (cancelled) {
-          return;
-        }
-        setCandidatePois([]);
-        setCandidatePoiError(
-          err instanceof Error ? err.message : 'Failed to load POI analysis.'
-        );
-      })
-      .finally(() => {
-        if (!cancelled) {
-          setCandidatePoiLoading(false);
-        }
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [
-    activeTraceStep,
-    seedCBG,
-    selectedCBGs,
-    selectedTraceCandidateCbg,
-    showCandidatePanels,
-    startDate,
-    traceLayer,
-    useTestData
-  ]);
 
   useEffect(() => {
     if (
@@ -1807,8 +1758,6 @@ export default function CZGeneration() {
         setZoneEditMode(false);
         setManualFrontierCandidates([]);
         setManualFrontierError('');
-        setCandidatePois([]);
-        setCandidatePoiError('');
         setSelectedTraceCandidateCbg('');
         setFocusedTraceCbg('');
         setCbgGeoJSON(seedGeoJson);
@@ -1922,8 +1871,6 @@ export default function CZGeneration() {
       setZoneEditMode(false);
       setManualFrontierCandidates([]);
       setManualFrontierError('');
-      setCandidatePois([]);
-      setCandidatePoiError('');
 
       if (data.geojson || data.trace_geojson) {
         setCbgGeoJSON(

--- a/src/components/dmp-selector.tsx
+++ b/src/components/dmp-selector.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { ChevronRight, Upload } from 'lucide-react';
 import '@/styles/dmp-selector.css';
 import useSimSettings from '@/stores/simsettings';
@@ -48,7 +48,9 @@ export default function DmpSelector() {
   const currentUser = useAuthStore((s) => s.user);
 
   const [expanded, setExpanded] = useState(false);
-  const [selectedVariant, setSelectedVariant] = useState<string>(variants[0] ?? '');
+  const [selectedVariant, setSelectedVariant] = useState<string>(
+    variants[0] ?? ''
+  );
   const [matrices, setMatrices] = useState<MatrixListItem[]>([]);
   const [loadingMatrices, setLoadingMatrices] = useState(true);
   const [newVariantName, setNewVariantName] = useState('');
@@ -62,11 +64,7 @@ export default function DmpSelector() {
     }
   }, [variants, selectedVariant]);
 
-  useEffect(() => {
-    fetchMatrices();
-  }, []);
-
-  async function fetchMatrices() {
+  const fetchMatrices = useCallback(async () => {
     setLoadingMatrices(true);
     try {
       const res = await fetch('/api/dmp/matrices');
@@ -93,7 +91,11 @@ export default function DmpSelector() {
     } finally {
       setLoadingMatrices(false);
     }
-  }
+  }, [setSettings]);
+
+  useEffect(() => {
+    fetchMatrices();
+  }, [fetchMatrices]);
 
   // ── Variants ─────────────────────────────────────────────
 
@@ -112,7 +114,11 @@ export default function DmpSelector() {
   }
 
   function removeVariant(name: string) {
-    if (variants.length <= 1 || (BUILT_IN_VARIANTS as readonly string[]).includes(name)) return;
+    if (
+      variants.length <= 1 ||
+      (BUILT_IN_VARIANTS as readonly string[]).includes(name)
+    )
+      return;
     const nextVariants = variants.filter((v) => v !== name);
     const updated = { ...matrixByVariant };
     delete updated[name];
@@ -186,7 +192,11 @@ export default function DmpSelector() {
         const res = await fetch('/api/dmp/matrices', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ name: name.trim(), description: description.trim(), content })
+          body: JSON.stringify({
+            name: name.trim(),
+            description: description.trim(),
+            content
+          })
         });
         if (!res.ok) {
           const json = await res.json().catch(() => ({}));
@@ -221,9 +231,12 @@ export default function DmpSelector() {
   }
 
   async function deleteMatrix(matrix: MatrixListItem) {
-    if (!window.confirm(`Delete "${matrix.name}"? This cannot be undone.`)) return;
+    if (!window.confirm(`Delete "${matrix.name}"? This cannot be undone.`))
+      return;
     try {
-      const res = await fetch(`/api/dmp/matrices/${matrix.id}`, { method: 'DELETE' });
+      const res = await fetch(`/api/dmp/matrices/${matrix.id}`, {
+        method: 'DELETE'
+      });
       if (!res.ok) {
         const json = await res.json().catch(() => ({}));
         alert(json.message ?? 'Delete failed.');
@@ -263,209 +276,251 @@ export default function DmpSelector() {
       </button>
 
       <div className={`dmps_body_wrapper${expanded ? ' is-open' : ''}`}>
-      <div className="dmps_body_inner">
-      <div className="dmps_body">
-        {/* ── Left: Variants ── */}
-        <div className="dmps_panel">
-          <div className="dmps_panel_header">
-            <span>Variants</span>
-          </div>
+        <div className="dmps_body_inner">
+          <div className="dmps_body">
+            {/* ── Left: Variants ── */}
+            <div className="dmps_panel">
+              <div className="dmps_panel_header">
+                <span>Variants</span>
+              </div>
 
-          <ul className="dmps_list">
-            {variants.length === 0 && (
-              <li className="dmps_list_empty">No variants added.</li>
-            )}
-            {variants.map((v) => {
-              const isBuiltIn = (BUILT_IN_VARIANTS as readonly string[]).includes(v);
-              return (
-                <li key={v}>
-                  <button
-                    type="button"
-                    className={`dmps_variant_row${v === selectedVariant ? ' is-selected' : ''}`}
-                    onClick={() => setSelectedVariant(v)}
-                  >
-                    <span className="dmps_variant_dot" />
-                    <span className="dmps_variant_name">{v}</span>
-                    {isBuiltIn && (
-                      <span className="dmps_badge dmps_badge--default">Default</span>
-                    )}
-                    {!isBuiltIn && matrixByVariant[v] != null && (
-                      <span className="dmps_variant_badge">✓</span>
-                    )}
-                  </button>
-                </li>
-              );
-            })}
-          </ul>
+              <ul className="dmps_list">
+                {variants.length === 0 && (
+                  <li className="dmps_list_empty">No variants added.</li>
+                )}
+                {variants.map((v) => {
+                  const isBuiltIn = (
+                    BUILT_IN_VARIANTS as readonly string[]
+                  ).includes(v);
+                  return (
+                    <li key={v}>
+                      <button
+                        type="button"
+                        className={`dmps_variant_row${v === selectedVariant ? ' is-selected' : ''}`}
+                        onClick={() => setSelectedVariant(v)}
+                      >
+                        <span className="dmps_variant_dot" />
+                        <span className="dmps_variant_name">{v}</span>
+                        {isBuiltIn && (
+                          <span className="dmps_badge dmps_badge--default">
+                            Default
+                          </span>
+                        )}
+                        {!isBuiltIn && matrixByVariant[v] != null && (
+                          <span className="dmps_variant_badge">✓</span>
+                        )}
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
 
-          <div className="dmps_adder">
-            <input
-              className="dmps_adder_input"
-              placeholder="New variant…"
-              maxLength={32}
-              value={newVariantName}
-              onChange={(e) => setNewVariantName(e.target.value)}
-              onKeyDown={(e) => { if (e.key === 'Enter') addVariant(); }}
-            />
-            <button
-              type="button"
-              className="dmps_icon_btn"
-              title="Add variant"
-              onClick={addVariant}
-              disabled={
-                !newVariantName.trim() ||
-                variants.includes(newVariantName.trim()) ||
-                variants.length >= 8
-              }
-            >
-              +
-            </button>
-            <button
-              type="button"
-              className="dmps_icon_btn dmps_icon_btn--danger"
-              title="Remove selected variant"
-              onClick={() => removeVariant(selectedVariant)}
-              disabled={
-                variants.length <= 1 ||
-                (BUILT_IN_VARIANTS as readonly string[]).includes(selectedVariant)
-              }
-            >
-              −
-            </button>
-          </div>
-        </div>
-
-        {/* ── Right: Matrices ── */}
-        <div className="dmps_panel">
-          <div className="dmps_panel_header">
-            <span>Matrices</span>
-            <div className="dmps_panel_header_actions">
-              {currentUser && (
+              <div className="dmps_adder">
+                <input
+                  className="dmps_adder_input"
+                  placeholder="New variant…"
+                  maxLength={32}
+                  value={newVariantName}
+                  onChange={(e) => setNewVariantName(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') addVariant();
+                  }}
+                />
                 <button
                   type="button"
-                  className="dmps_upload_btn"
-                  onClick={openUpload}
+                  className="dmps_icon_btn"
+                  title="Add variant"
+                  onClick={addVariant}
+                  disabled={
+                    !newVariantName.trim() ||
+                    variants.includes(newVariantName.trim()) ||
+                    variants.length >= 8
+                  }
                 >
-                  <Upload size={11} aria-hidden="true" />
-                  Upload
+                  +
                 </button>
+                <button
+                  type="button"
+                  className="dmps_icon_btn dmps_icon_btn--danger"
+                  title="Remove selected variant"
+                  onClick={() => removeVariant(selectedVariant)}
+                  disabled={
+                    variants.length <= 1 ||
+                    (BUILT_IN_VARIANTS as readonly string[]).includes(
+                      selectedVariant
+                    )
+                  }
+                >
+                  −
+                </button>
+              </div>
+            </div>
+
+            {/* ── Right: Matrices ── */}
+            <div className="dmps_panel">
+              <div className="dmps_panel_header">
+                <span>Matrices</span>
+                <div className="dmps_panel_header_actions">
+                  {currentUser && (
+                    <button
+                      type="button"
+                      className="dmps_upload_btn"
+                      onClick={openUpload}
+                    >
+                      <Upload size={11} aria-hidden="true" />
+                      Upload
+                    </button>
+                  )}
+                </div>
+              </div>
+
+              <ul className="dmps_list">
+                {loadingMatrices && (
+                  <li className="dmps_list_empty">Loading…</li>
+                )}
+                {!loadingMatrices && matrices.length === 0 && (
+                  <li className="dmps_list_empty">No matrices found.</li>
+                )}
+                {matrices.map((m) => {
+                  const isAssigned = m.id === assignedMatrixId;
+                  return (
+                    <li key={m.id}>
+                      <div
+                        className={`dmps_matrix_row${isAssigned ? ' is-assigned' : ''}`}
+                        title={`Assign "${m.name}" to ${selectedVariant || 'selected variant'}`}
+                      >
+                        <button
+                          type="button"
+                          className="dmps_matrix_select"
+                          onClick={() => assignMatrix(m.id)}
+                        >
+                          <div className="dmps_matrix_info">
+                            <div className="dmps_matrix_name">{m.name}</div>
+                            <div className="dmps_matrix_desc">
+                              {m.description}
+                            </div>
+                            <div className="dmps_matrix_meta">
+                              {m.is_default && (
+                                <span className="dmps_badge dmps_badge--default">
+                                  Built-in
+                                </span>
+                              )}
+                              {m.is_owner && (
+                                <span className="dmps_badge dmps_badge--mine">
+                                  Yours
+                                </span>
+                              )}
+                              {m.user && !m.is_default && (
+                                <span
+                                  style={{
+                                    fontSize: '10px',
+                                    color: 'var(--color-text-muted)'
+                                  }}
+                                >
+                                  {m.user.name}
+                                </span>
+                              )}
+                            </div>
+                          </div>
+                        </button>
+                        <div className="dmps_matrix_actions">
+                          {m.is_owner && !m.is_default && (
+                            <>
+                              <button
+                                type="button"
+                                className="dmps_icon_btn"
+                                title="Edit matrix"
+                                onClick={() => openEdit(m)}
+                              >
+                                ✎
+                              </button>
+                              <button
+                                type="button"
+                                className="dmps_icon_btn dmps_icon_btn--danger"
+                                title="Delete matrix"
+                                onClick={() => deleteMatrix(m)}
+                              >
+                                ✕
+                              </button>
+                            </>
+                          )}
+                        </div>
+                      </div>
+                    </li>
+                  );
+                })}
+              </ul>
+
+              {!currentUser && (
+                <p className="dmps_hint">Log in to upload your own matrices.</p>
               )}
             </div>
           </div>
-
-          <ul className="dmps_list">
-            {loadingMatrices && (
-              <li className="dmps_list_empty">Loading…</li>
-            )}
-            {!loadingMatrices && matrices.length === 0 && (
-              <li className="dmps_list_empty">No matrices found.</li>
-            )}
-            {matrices.map((m) => {
-              const isAssigned = m.id === assignedMatrixId;
-              return (
-                <li key={m.id}>
-                  <button
-                    type="button"
-                    className={`dmps_matrix_row${isAssigned ? ' is-assigned' : ''}`}
-                    onClick={() => assignMatrix(m.id)}
-                    title={`Assign "${m.name}" to ${selectedVariant || 'selected variant'}`}
-                  >
-                    <div className="dmps_matrix_info">
-                      <div className="dmps_matrix_name">{m.name}</div>
-                      <div className="dmps_matrix_desc">{m.description}</div>
-                      <div className="dmps_matrix_meta">
-                        {m.is_default && (
-                          <span className="dmps_badge dmps_badge--default">Built-in</span>
-                        )}
-                        {m.is_owner && (
-                          <span className="dmps_badge dmps_badge--mine">Yours</span>
-                        )}
-                        {m.user && !m.is_default && (
-                          <span style={{ fontSize: '10px', color: 'var(--color-text-muted)' }}>
-                            {m.user.name}
-                          </span>
-                        )}
-                      </div>
-                    </div>
-                    <div
-                      className="dmps_matrix_actions"
-                      onClick={(e) => e.stopPropagation()}
-                      onKeyDown={(e) => e.stopPropagation()}
-                    >
-                      {m.is_owner && !m.is_default && (
-                        <>
-                          <button
-                            type="button"
-                            className="dmps_icon_btn"
-                            title="Edit matrix"
-                            onClick={() => openEdit(m)}
-                          >
-                            ✎
-                          </button>
-                          <button
-                            type="button"
-                            className="dmps_icon_btn dmps_icon_btn--danger"
-                            title="Delete matrix"
-                            onClick={() => deleteMatrix(m)}
-                          >
-                            ✕
-                          </button>
-                        </>
-                      )}
-                    </div>
-                  </button>
-                </li>
-              );
-            })}
-          </ul>
-
-          {!currentUser && (
-            <p className="dmps_hint">Log in to upload your own matrices.</p>
-          )}
         </div>
-      </div>
-      </div>
       </div>
 
       {/* ── Dialog ── */}
       {dialog.mode && (
-        <div className="dmps_overlay" onClick={closeDialog}>
+        <div className="dmps_overlay">
+          <button
+            type="button"
+            className="dmps_overlay_backdrop"
+            aria-label="Close matrix dialog"
+            onClick={closeDialog}
+          />
           <div
             className="dmps_dialog"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="dmps-dialog-title"
             onClick={(e) => e.stopPropagation()}
             onKeyDown={(e) => e.stopPropagation()}
           >
-            <div className="dmps_dialog_title">
+            <div className="dmps_dialog_title" id="dmps-dialog-title">
               {dialog.mode === 'upload' ? 'Upload Matrix' : 'Edit Matrix'}
             </div>
 
             <div className="dmps_dialog_field">
-              <label className="dmps_dialog_label">Title</label>
+              <label className="dmps_dialog_label" htmlFor="dmps-dialog-name">
+                Title
+              </label>
               <input
+                id="dmps-dialog-name"
                 className="dmps_dialog_input"
                 maxLength={100}
                 placeholder="e.g. Custom Delta High Severity"
                 value={dialog.name}
-                onChange={(e) => setDialog((d) => ({ ...d, name: e.target.value }))}
+                onChange={(e) =>
+                  setDialog((d) => ({ ...d, name: e.target.value }))
+                }
               />
             </div>
 
             <div className="dmps_dialog_field">
-              <label className="dmps_dialog_label">Description</label>
+              <label
+                className="dmps_dialog_label"
+                htmlFor="dmps-dialog-description"
+              >
+                Description
+              </label>
               <textarea
+                id="dmps-dialog-description"
                 className="dmps_dialog_textarea"
                 maxLength={500}
                 placeholder="Brief description of this matrix set…"
                 value={dialog.description}
-                onChange={(e) => setDialog((d) => ({ ...d, description: e.target.value }))}
+                onChange={(e) =>
+                  setDialog((d) => ({ ...d, description: e.target.value }))
+                }
               />
             </div>
 
             <div className="dmps_dialog_field">
-              <label className="dmps_dialog_label">
+              <label className="dmps_dialog_label" htmlFor="dmps-dialog-file">
                 {dialog.mode === 'edit' ? 'Replace CSV (optional)' : 'CSV File'}
               </label>
               <input
+                id="dmps-dialog-file"
                 ref={fileInputRef}
                 type="file"
                 accept=".csv,text/csv"
@@ -482,7 +537,7 @@ export default function DmpSelector() {
                 </button>
                 <span className="dmps_file_name">
                   {dialog.content
-                    ? `${dialog.content.split('\n').filter(l => l.trim() && !l.trim().startsWith('#')).length} data rows loaded`
+                    ? `${dialog.content.split('\n').filter((l) => l.trim() && !l.trim().startsWith('#')).length} data rows loaded`
                     : 'No file chosen'}
                 </span>
               </div>
@@ -507,7 +562,11 @@ export default function DmpSelector() {
                 onClick={submitDialog}
                 disabled={dialog.saving}
               >
-                {dialog.saving ? 'Saving…' : dialog.mode === 'upload' ? 'Upload' : 'Save'}
+                {dialog.saving
+                  ? 'Saving…'
+                  : dialog.mode === 'upload'
+                    ? 'Upload'
+                    : 'Save'}
               </button>
             </div>
           </div>

--- a/src/features/cz-generation/api.ts
+++ b/src/features/cz-generation/api.ts
@@ -1,0 +1,245 @@
+import type { GeoJSONData, LatLng } from '@/lib/cz-geo';
+import { getResponseErrorMessage, readJsonObject } from './helpers';
+import type {
+  ClusteringPreviewResponse,
+  GuidedSecondOrderMetadata,
+  PoiAnalysis,
+  TraceCandidate,
+  ZoneMetrics
+} from './types';
+
+const DEFAULT_ALGORITHMS_URL = 'http://localhost:1880/';
+
+type QueryValue = string | number | boolean | null | undefined;
+
+type JsonObject = Record<string, unknown>;
+
+export type PatternAvailabilityResponse = {
+  data?: {
+    available_months?: unknown[];
+    required_months?: unknown[];
+    missing_months?: unknown[];
+    has_any_data?: boolean;
+    has_coverage?: boolean;
+  };
+};
+
+export type CbgAtPointResponse = {
+  cbg?: string;
+  population?: number;
+};
+
+export type CandidatePoisResponse = {
+  pois?: PoiAnalysis[];
+};
+
+export type FrontierCandidatesResponse = {
+  candidates?: TraceCandidate[];
+};
+
+export type FinalizeConvenienceZoneResponse = {
+  id?: number;
+  message?: string;
+};
+
+export type ExportedMapHtml = {
+  blob: Blob;
+  filename: string;
+};
+
+function algorithmsUrl(path: string, query?: Record<string, QueryValue>) {
+  const url = new URL(
+    path,
+    process.env.NEXT_PUBLIC_ALG_URL || DEFAULT_ALGORITHMS_URL
+  );
+  for (const [key, value] of Object.entries(query ?? {})) {
+    if (value !== null && value !== undefined) {
+      url.searchParams.set(key, String(value));
+    }
+  }
+  return url.toString();
+}
+
+async function requestAlgorithmsJson<T>(
+  path: string,
+  options: {
+    method?: 'GET' | 'POST';
+    query?: Record<string, QueryValue>;
+    body?: JsonObject;
+    signal?: AbortSignal;
+    errorMessage: string;
+  }
+): Promise<T> {
+  const response = await fetch(algorithmsUrl(path, options.query), {
+    method: options.method ?? 'GET',
+    signal: options.signal,
+    headers: options.body ? { 'Content-Type': 'application/json' } : undefined,
+    body: options.body ? JSON.stringify(options.body) : undefined
+  });
+  const data = await readJsonObject(response);
+
+  if (!response.ok) {
+    throw new Error(
+      getResponseErrorMessage(response, data, options.errorMessage)
+    );
+  }
+
+  return data as T;
+}
+
+export function getClusteringProgressUrl(clusteringId: number) {
+  return algorithmsUrl(`clustering-progress/${clusteringId}`);
+}
+
+export async function fetchPatternAvailability(
+  request: {
+    state: string;
+    startDate: string;
+    endDate: string;
+  },
+  signal?: AbortSignal
+) {
+  return requestAlgorithmsJson<PatternAvailabilityResponse>(
+    'pattern-availability',
+    {
+      query: {
+        state: request.state,
+        start_date: request.startDate,
+        end_date: request.endDate
+      },
+      signal,
+      errorMessage: 'Failed to load pattern availability.'
+    }
+  );
+}
+
+export async function fetchCbgGeoJson(
+  cbgs: string[],
+  includeNeighbors: boolean,
+  signal?: AbortSignal
+) {
+  return requestAlgorithmsJson<GeoJSONData & { message?: string }>(
+    'cbg-geojson',
+    {
+      query: {
+        cbgs: cbgs.join(','),
+        include_neighbors: includeNeighbors
+      },
+      signal,
+      errorMessage: 'Failed to load CBG geometry.'
+    }
+  );
+}
+
+export async function fetchCbgAtPoint(latlng: LatLng, stateFips: string) {
+  return requestAlgorithmsJson<CbgAtPointResponse>('cbg-at-point', {
+    query: {
+      latitude: latlng.lat,
+      longitude: latlng.lng,
+      state_fips: stateFips
+    },
+    errorMessage: 'Failed to resolve clicked map location to CBG.'
+  });
+}
+
+export async function fetchCzMetrics(body: {
+  seed_cbg: string;
+  cbg_list: string[];
+  start_date: string;
+  use_test_data: boolean;
+}) {
+  return requestAlgorithmsJson<ZoneMetrics>('cz-metrics', {
+    method: 'POST',
+    body,
+    errorMessage: 'Failed to compute zone metrics.'
+  });
+}
+
+export async function fetchCandidatePois(body: {
+  seed_cbg: string;
+  candidate_cbg: string;
+  cluster_cbgs: string[];
+  start_date: string;
+  use_test_data: boolean;
+  limit: number;
+}) {
+  return requestAlgorithmsJson<CandidatePoisResponse>('candidate-pois', {
+    method: 'POST',
+    body,
+    errorMessage: 'Failed to load POI analysis.'
+  });
+}
+
+export async function fetchFrontierCandidates(body: JsonObject) {
+  return requestAlgorithmsJson<FrontierCandidatesResponse>(
+    'frontier-candidates',
+    {
+      method: 'POST',
+      body,
+      errorMessage: 'Failed to load frontier candidates.'
+    }
+  );
+}
+
+export async function fetchSecondOrderDestinations(body: JsonObject) {
+  return requestAlgorithmsJson<
+    GuidedSecondOrderMetadata & {
+      use_test_data?: boolean;
+      recommended_unit_ids?: unknown[];
+    }
+  >('second-order-destinations', {
+    method: 'POST',
+    body,
+    errorMessage: 'Failed to load connected city destinations.'
+  });
+}
+
+export async function startClusteringPreview(body: JsonObject) {
+  return requestAlgorithmsJson<ClusteringPreviewResponse>('cluster-cbgs', {
+    method: 'POST',
+    body,
+    errorMessage: 'Failed to cluster CBGs. Please try again.'
+  });
+}
+
+export async function finalizeConvenienceZone(body: JsonObject) {
+  return requestAlgorithmsJson<FinalizeConvenienceZoneResponse>('finalize-cz', {
+    method: 'POST',
+    body,
+    errorMessage: 'Failed to create convenience zone. Please try again.'
+  });
+}
+
+export async function exportCzMapHtml(body: {
+  cbg_list: string[];
+  name: string;
+}) {
+  const response = await fetch(algorithmsUrl('export-cz-map-html'), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body)
+  });
+
+  if (!response.ok) {
+    const errorData = await readJsonObject(response);
+    throw new Error(
+      getResponseErrorMessage(
+        response,
+        errorData,
+        'Failed to export the CZ HTML map.'
+      )
+    );
+  }
+
+  const blob = await response.blob();
+  const disposition = response.headers.get('content-disposition') || '';
+  const filenameMatch = disposition.match(/filename="?([^"]+)"?/);
+  const safeName =
+    body.name.replace(/[^A-Za-z0-9._-]+/g, '-').replace(/^-+|-+$/g, '') ||
+    'cz-map';
+
+  return {
+    blob,
+    filename: filenameMatch?.[1] || `${safeName}.html`
+  };
+}

--- a/src/features/cz-generation/api.ts
+++ b/src/features/cz-generation/api.ts
@@ -3,6 +3,7 @@ import { getResponseErrorMessage, readJsonObject } from './helpers';
 import type {
   ClusteringPreviewResponse,
   GuidedSecondOrderMetadata,
+  LookupLocationResult,
   PoiAnalysis,
   TraceCandidate,
   ZoneMetrics
@@ -140,6 +141,37 @@ export async function fetchCbgAtPoint(latlng: LatLng, stateFips: string) {
     },
     errorMessage: 'Failed to resolve clicked map location to CBG.'
   });
+}
+
+export async function lookupLocation(
+  query: string
+): Promise<LookupLocationResult | null> {
+  const location = String(query ?? '').trim();
+  if (!location) {
+    return null;
+  }
+
+  const response = await fetch('/api/lookup-location', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ location })
+  });
+  if (response.status === 404) {
+    return null;
+  }
+
+  const data = await readJsonObject(response);
+  if (!response.ok) {
+    throw new Error(
+      getResponseErrorMessage(
+        response,
+        data,
+        `Location lookup failed with status ${response.status}`
+      )
+    );
+  }
+
+  return data as LookupLocationResult;
 }
 
 export async function fetchCzMetrics(body: {

--- a/src/features/cz-generation/components/algorithm-guide-modal.tsx
+++ b/src/features/cz-generation/components/algorithm-guide-modal.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import {
+  CLUSTER_ALGORITHM_MANUAL,
+  CLUSTER_ALGORITHM_OPTIONS
+} from '@/features/cz-generation/constants';
+
+type AlgorithmGuideModalProps = {
+  open: boolean;
+  onClose: () => void;
+};
+
+export function AlgorithmGuideModal({
+  open,
+  onClose
+}: AlgorithmGuideModalProps) {
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <div
+      className="czgen_modal_overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="algorithm-guide-title"
+      tabIndex={-1}
+      onClick={(event) => {
+        if (event.target === event.currentTarget) {
+          onClose();
+        }
+      }}
+      onKeyDown={(event) => {
+        if (event.key === 'Escape') {
+          onClose();
+        }
+      }}
+    >
+      <div className="czgen_modal" style={{ width: 'min(34rem, 92vw)' }}>
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <p id="algorithm-guide-title" className="czgen_modal_title">
+              Algorithm Guide
+            </p>
+            <p className="czgen_modal_subtitle">
+              Start with Mobility Prune unless the zone needs manual city
+              selection or diagnostic tracing.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="czgen_btn czgen_btn--sm"
+            style={{ flexShrink: 0 }}
+          >
+            Close
+          </button>
+        </div>
+        <div className="mt-4 flex flex-col gap-3">
+          {CLUSTER_ALGORITHM_OPTIONS.map((option) => {
+            const manual = CLUSTER_ALGORITHM_MANUAL[option.value];
+            return (
+              <div
+                key={option.value}
+                className="border-l-4 px-3 py-2 text-sm"
+                style={{
+                  borderColor: 'var(--color-primary-blue-soft)',
+                  background: 'var(--color-bg-surface)',
+                  color: 'var(--color-text-muted)',
+                  borderRadius: '0 8px 8px 0'
+                }}
+              >
+                <div
+                  className="flex flex-wrap items-center gap-2 font-semibold"
+                  style={{ color: 'var(--color-text-main)' }}
+                >
+                  <span>{option.label}</span>
+                  {manual.recommended && (
+                    <span
+                      className="rounded-full px-2 py-0.5 text-[11px] font-semibold"
+                      style={{
+                        background: 'rgba(22,163,74,0.1)',
+                        color: '#166534'
+                      }}
+                    >
+                      default
+                    </span>
+                  )}
+                </div>
+                <div className="mt-1">{manual.summary}</div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/cz-generation/components/candidate-analysis-panel.tsx
+++ b/src/features/cz-generation/components/candidate-analysis-panel.tsx
@@ -1,0 +1,164 @@
+'use client';
+
+import type {
+  PoiAnalysis,
+  TraceCandidate
+} from '@/features/cz-generation/types';
+
+type CandidateAnalysisPanelProps = {
+  selectedCbg: string;
+  population: unknown;
+  status: string;
+  candidate: TraceCandidate | null;
+  pois: PoiAnalysis[];
+  poisLoading: boolean;
+  poisError: string;
+};
+
+export function CandidateAnalysisPanel({
+  selectedCbg,
+  population,
+  status,
+  candidate,
+  pois,
+  poisLoading,
+  poisError
+}: CandidateAnalysisPanelProps) {
+  return (
+    <div className="czgen_subpanel h-[calc(100vh-13rem)] min-h-136 max-h-192 w-88 max-w-88">
+      <div className="czgen_subpanel_header">
+        <p className="czgen_subpanel_title">CBG Analysis</p>
+      </div>
+      <div
+        className="px-4 py-3 border-b text-sm space-y-1"
+        style={{ borderColor: 'var(--color-border-subtle)' }}
+      >
+        <div>
+          <span className="font-semibold">CBG:</span> {selectedCbg || 'N/A'}
+        </div>
+        <div>
+          <span className="font-semibold">Population:</span>{' '}
+          {String(population ?? 'N/A')}
+        </div>
+        <div>
+          <span className="font-semibold">Status:</span> {status}
+        </div>
+        {candidate && (
+          <>
+            <div>
+              <span className="font-semibold">Rank:</span> #
+              {candidate.rank ?? '?'}
+            </div>
+            <div>
+              <span className="font-semibold">Score:</span>{' '}
+              {Number(candidate.score ?? 0).toFixed(4)}
+            </div>
+            <div>
+              <span className="font-semibold">To Cluster:</span>{' '}
+              {Number(candidate.movement_to_cluster ?? 0).toLocaleString(
+                undefined,
+                {
+                  maximumFractionDigits: 1
+                }
+              )}
+            </div>
+            {candidate.movement_to_full_cluster !== undefined && (
+              <div>
+                <span className="font-semibold">To Full Cluster:</span>{' '}
+                {Number(
+                  candidate.movement_to_full_cluster ?? 0
+                ).toLocaleString(undefined, {
+                  maximumFractionDigits: 1
+                })}
+              </div>
+            )}
+            <div>
+              <span className="font-semibold">To Outside:</span>{' '}
+              {Number(candidate.movement_to_outside ?? 0).toLocaleString(
+                undefined,
+                {
+                  maximumFractionDigits: 1
+                }
+              )}
+            </div>
+            {candidate.seed_distance_km !== undefined && (
+              <div>
+                <span className="font-semibold">Seed Distance:</span>{' '}
+                {Number(candidate.seed_distance_km ?? 0).toFixed(2)} km
+              </div>
+            )}
+            {candidate.movement_contributes_after_selection !== undefined && (
+              <div>
+                <span className="font-semibold">Contributes After Add:</span>{' '}
+                {candidate.movement_contributes_after_selection ? 'Yes' : 'No'}
+              </div>
+            )}
+            {candidate.seed_movement_loss !== undefined && (
+              <div>
+                <span className="font-semibold">Seed Movement Lost:</span>{' '}
+                {Number(candidate.seed_movement_loss ?? 0).toLocaleString(
+                  undefined,
+                  {
+                    maximumFractionDigits: 1
+                  }
+                )}
+              </div>
+            )}
+            {candidate.seed_capture_after !== undefined && (
+              <div>
+                <span className="font-semibold">
+                  Seed Capture After Selection:
+                </span>{' '}
+                {(Number(candidate.seed_capture_after ?? 0) * 100).toFixed(1)}%
+              </div>
+            )}
+            {candidate.czi_after !== undefined && (
+              <div>
+                <span className="font-semibold">
+                  Zone CZI After Selection:
+                </span>{' '}
+                {Number(candidate.czi_after ?? 0).toFixed(4)}
+              </div>
+            )}
+          </>
+        )}
+      </div>
+      <div className="czgen_subpanel_header">
+        <p className="czgen_subpanel_title" style={{ fontSize: '13px' }}>
+          Top POIs From Current Cluster
+        </p>
+      </div>
+      <div className="czgen_subpanel_body" style={{ padding: '12px 16px' }}>
+        {poisLoading ? (
+          <div className="text-sm text-gray-500">Loading POI analysis...</div>
+        ) : poisError ? (
+          <div className="text-sm text-red-700">{poisError}</div>
+        ) : pois.length === 0 ? (
+          <div className="text-sm text-gray-500">
+            No cluster-to-POI flow found for this CBG.
+          </div>
+        ) : (
+          <div className="flex flex-col gap-2">
+            {pois.map((poi) => (
+              <div
+                key={`${poi.placekey || poi.location_name}-${poi.rank}`}
+                className="text-sm leading-snug"
+              >
+                <div className="font-medium">
+                  {poi.rank}. {poi.location_name || 'Unknown POI'}
+                </div>
+                <div className="text-gray-600">
+                  Flow:{' '}
+                  {Number(poi.cluster_flow ?? 0).toLocaleString(undefined, {
+                    maximumFractionDigits: 1
+                  })}{' '}
+                  ({Number((poi.flow_share ?? 0) * 100).toFixed(1)}%)
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/features/cz-generation/components/connected-cities-panel.tsx
+++ b/src/features/cz-generation/components/connected-cities-panel.tsx
@@ -8,17 +8,9 @@ import {
 import type {
   GuidedDestinationCandidate,
   GuidedSecondOrderMetadata,
+  GuidedSelectionSummary,
   GuidedSelectionStyle
 } from '@/features/cz-generation/types';
-
-type GuidedSelectionSummary = {
-  selectedLinkedOutboundFlow: number;
-  selectedLinkedOutboundShare: number;
-  selectedExternalBidirectionalShare: number;
-  selectedSeedMovementShare: number;
-  externalRemainderShare: number;
-  selectedPopulation: number;
-};
 
 type ConnectedCitiesPanelProps = {
   seedLabel: string;

--- a/src/features/cz-generation/components/connected-cities-panel.tsx
+++ b/src/features/cz-generation/components/connected-cities-panel.tsx
@@ -1,0 +1,359 @@
+'use client';
+
+import {
+  GUIDED_HARD_EXPLICIT_POPULATION,
+  GUIDED_SEED_STYLE,
+  GUIDED_SOFT_EXPLICIT_POPULATION
+} from '@/features/cz-generation/constants';
+import type {
+  GuidedDestinationCandidate,
+  GuidedSecondOrderMetadata,
+  GuidedSelectionStyle
+} from '@/features/cz-generation/types';
+
+type GuidedSelectionSummary = {
+  selectedLinkedOutboundFlow: number;
+  selectedLinkedOutboundShare: number;
+  selectedExternalBidirectionalShare: number;
+  selectedSeedMovementShare: number;
+  externalRemainderShare: number;
+  selectedPopulation: number;
+};
+
+type ConnectedCitiesPanelProps = {
+  seedLabel: string;
+  destinations: GuidedDestinationCandidate[];
+  selectedDestinationIds: string[];
+  selectedDestinations: GuidedDestinationCandidate[];
+  selectedCbgCount: number;
+  metadata: GuidedSecondOrderMetadata | null;
+  selectionSummary: GuidedSelectionSummary;
+  styleByUnitId: Map<string, GuidedSelectionStyle>;
+  loading: boolean;
+  error: string;
+  isFinalizing: boolean;
+  showSummary: boolean;
+  onShowSummary: () => void;
+  onHideSummary: () => void;
+  onShowTermsHelp: () => void;
+  onUseRecommended: () => void;
+  onSeedOnly: () => void;
+  onToggleDestination: (destination: GuidedDestinationCandidate) => void;
+};
+
+export function ConnectedCitiesPanel({
+  seedLabel,
+  destinations,
+  selectedDestinationIds,
+  selectedDestinations,
+  selectedCbgCount,
+  metadata,
+  selectionSummary,
+  styleByUnitId,
+  loading,
+  error,
+  isFinalizing,
+  showSummary,
+  onShowSummary,
+  onHideSummary,
+  onShowTermsHelp,
+  onUseRecommended,
+  onSeedOnly,
+  onToggleDestination
+}: ConnectedCitiesPanelProps) {
+  return (
+    <div className="czgen_subpanel relative h-[calc(100vh-13rem)] min-h-[34rem] max-h-[48rem] w-[25rem] max-w-[25rem]">
+      <div className="czgen_subpanel_header">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <p className="czgen_subpanel_title">Connected Cities</p>
+            <p className="czgen_subpanel_subtitle">
+              Choose the connected cities whose linked CBGs should stay explicit
+              in the simulation.
+            </p>
+          </div>
+        </div>
+        <div className="mt-3 flex flex-wrap gap-2">
+          <button
+            type="button"
+            onClick={onShowSummary}
+            className="czgen_btn czgen_btn--sm"
+          >
+            Selection Summary
+          </button>
+          <button
+            type="button"
+            onClick={onShowTermsHelp}
+            className="czgen_btn czgen_btn--sm shrink-0"
+          >
+            How Ranking Works
+          </button>
+        </div>
+        <div
+          className="mt-3 text-xs"
+          style={{ color: 'var(--color-text-muted)' }}
+        >
+          <span
+            className="font-semibold"
+            style={{ color: 'var(--color-text-main)' }}
+          >
+            Seed:
+          </span>{' '}
+          {seedLabel}
+        </div>
+      </div>
+      <div className="czgen_subpanel_divider">
+        <button
+          type="button"
+          onClick={onUseRecommended}
+          disabled={loading || isFinalizing}
+          className="czgen_btn czgen_btn--sm czgen_btn--primary"
+        >
+          Use Recommended
+        </button>
+        <button
+          type="button"
+          onClick={onSeedOnly}
+          disabled={loading || isFinalizing}
+          className="czgen_btn czgen_btn--sm"
+        >
+          Seed Only
+        </button>
+        <div
+          className="w-full text-xs"
+          style={{ color: 'var(--color-text-muted)' }}
+        >
+          {destinations.length} ranked cities. Click a city to include or
+          remove its linked CBGs.
+        </div>
+      </div>
+      <div className="czgen_subpanel_body">
+        {loading ? (
+          <div className="text-sm text-gray-500 px-2 py-2">
+            Loading connected cities and linked CBGs...
+          </div>
+        ) : error ? (
+          <div className="text-sm text-red-700 px-2 py-2">{error}</div>
+        ) : destinations.length === 0 ? (
+          <div className="text-sm text-gray-500 px-2 py-2">
+            No significant outbound cities were found for this seed.
+          </div>
+        ) : (
+          destinations.map((destination, index) => {
+            const isSelected = selectedDestinationIds.includes(
+              destination.unit_id
+            );
+            const style =
+              styleByUnitId.get(destination.unit_id) || GUIDED_SEED_STYLE;
+
+            return (
+              <button
+                type="button"
+                key={destination.unit_id}
+                className={`text-left px-3.5 py-3 rounded border transition-colors ${
+                  isSelected
+                    ? 'bg-[#e0f2fe] border-[#0284c7]'
+                    : 'bg-white border-[#d1d5db] hover:border-[#70B4D4]'
+                }`}
+                onClick={() => onToggleDestination(destination)}
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div className="flex items-center gap-2 text-base font-semibold leading-tight">
+                    <span
+                      className="inline-block h-3 w-3 rounded-full border"
+                      style={{
+                        backgroundColor: style.fillColor,
+                        borderColor: style.lineColor
+                      }}
+                    />
+                    <span>
+                      #{index + 1} {destination.label}
+                    </span>
+                  </div>
+                  {destination.recommended && (
+                    <span className="rounded-full bg-[#dbeafe] px-2 py-0.5 text-[11px] font-semibold text-[#1d4ed8]">
+                      Recommended
+                    </span>
+                  )}
+                </div>
+                <div className="mt-3 grid grid-cols-2 gap-x-3 gap-y-2 text-xs text-gray-600">
+                  <div>
+                    <div className="font-semibold text-[#1f2937]">
+                      Connection
+                    </div>
+                    <div>{Number(destination.coupling ?? 0).toFixed(3)}</div>
+                  </div>
+                  <div>
+                    <div className="font-semibold text-[#1f2937]">
+                      Trips Leaving Seed
+                    </div>
+                    <div>
+                      {Number(
+                        (destination.share_of_seed_external_outbound ?? 0) *
+                          100
+                      ).toFixed(1)}
+                      %
+                    </div>
+                  </div>
+                  <div>
+                    <div className="font-semibold text-[#1f2937]">
+                      Linked CBGs
+                    </div>
+                    <div>
+                      {Number(
+                        destination.cbg_count ?? destination.cbgs.length
+                      ).toLocaleString()}
+                    </div>
+                  </div>
+                  <div>
+                    <div className="font-semibold text-[#1f2937]">
+                      Added Population
+                    </div>
+                    <div>
+                      {Number(destination.population ?? 0).toLocaleString()}
+                    </div>
+                  </div>
+                </div>
+                <div className="mt-3 text-xs text-gray-500">
+                  Linked CBG layer captures{' '}
+                  {Number(
+                    (destination.captured_bidirectional_flow_share ?? 0) * 100
+                  ).toFixed(1)}
+                  % of this city&apos;s two-way seed connection.
+                </div>
+              </button>
+            );
+          })
+        )}
+      </div>
+      <div
+        className={`absolute inset-0 z-20 transition-transform duration-200 ease-out ${
+          showSummary ? 'translate-x-0' : 'translate-x-full pointer-events-none'
+        }`}
+        style={{ background: 'var(--color-bg-ivory)' }}
+        aria-hidden={!showSummary}
+      >
+        <div className="flex h-full flex-col">
+          <div className="czgen_subpanel_header flex items-start justify-between gap-3">
+            <div className="min-w-0">
+              <p className="czgen_subpanel_title">Selection Summary</p>
+              <p className="czgen_subpanel_subtitle">
+                Guided metrics and the current explicit-zone summary.
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={onHideSummary}
+              className="czgen_btn czgen_btn--sm shrink-0"
+            >
+              Close
+            </button>
+          </div>
+          <div className="flex-1 overflow-y-auto px-4 py-4">
+            <div className="rounded-lg border border-[#dbeafe] bg-[#f8fbff] px-3 py-3">
+              <div className="text-[11px] font-semibold uppercase tracking-[0.14em] text-[#2563eb]">
+                Seed Region
+              </div>
+              <div className="mt-1 text-sm font-semibold text-[#1f2937]">
+                {seedLabel}
+              </div>
+              {metadata?.approximation_note && (
+                <div className="mt-1 text-xs text-gray-600">
+                  {metadata.approximation_note}
+                </div>
+              )}
+            </div>
+            <div className="mt-4 grid grid-cols-2 gap-2">
+              <div className="rounded-lg border border-[#dbeafe] bg-white px-3 py-2">
+                <div className="text-[11px] font-semibold uppercase tracking-[0.12em] text-[#2563eb]">
+                  Selected
+                </div>
+                <div className="mt-1 text-lg font-semibold text-[#1f2937]">
+                  {selectedDestinationIds.length}
+                </div>
+                <div className="text-xs text-gray-500">cities</div>
+              </div>
+              <div className="rounded-lg border border-[#dbeafe] bg-white px-3 py-2">
+                <div className="text-[11px] font-semibold uppercase tracking-[0.12em] text-[#2563eb]">
+                  Linked CBGs
+                </div>
+                <div className="mt-1 text-lg font-semibold text-[#1f2937]">
+                  {selectedCbgCount}
+                </div>
+                <div className="text-xs text-gray-500">explicit units</div>
+              </div>
+              <div className="rounded-lg border border-[#dbeafe] bg-white px-3 py-2">
+                <div className="text-[11px] font-semibold uppercase tracking-[0.12em] text-[#2563eb]">
+                  Explicit Pop
+                </div>
+                <div className="mt-1 text-lg font-semibold text-[#1f2937]">
+                  {Number(
+                    selectionSummary.selectedPopulation || 0
+                  ).toLocaleString()}
+                </div>
+                <div className="text-xs text-gray-500">residents</div>
+              </div>
+              <div className="rounded-lg border border-[#dbeafe] bg-white px-3 py-2">
+                <div className="text-[11px] font-semibold uppercase tracking-[0.12em] text-[#2563eb]">
+                  Trips Leaving Seed Captured
+                </div>
+                <div className="mt-1 text-lg font-semibold text-[#1f2937]">
+                  {(
+                    selectionSummary.selectedLinkedOutboundShare * 100
+                  ).toFixed(1)}
+                  %
+                </div>
+                <div className="text-xs text-gray-500">linked subset</div>
+              </div>
+              <div className="rounded-lg border border-[#dbeafe] bg-white px-3 py-2">
+                <div className="text-[11px] font-semibold uppercase tracking-[0.12em] text-[#2563eb]">
+                  Seed Movement
+                </div>
+                <div className="mt-1 text-lg font-semibold text-[#1f2937]">
+                  {(selectionSummary.selectedSeedMovementShare * 100).toFixed(
+                    1
+                  )}
+                  %
+                </div>
+                <div className="text-xs text-gray-500">represented</div>
+              </div>
+            </div>
+            <div className="mt-4 rounded-lg border border-[#e5e7eb] bg-white px-3 py-3 text-xs text-gray-700">
+              <div className="font-semibold text-[#1f2937]">
+                Selected Cities
+              </div>
+              <div className="mt-1">
+                {selectedDestinations.length
+                  ? selectedDestinations
+                      .map((destination) => destination.label)
+                      .join(', ')
+                  : 'Seed only'}
+              </div>
+            </div>
+            <div className="mt-3 rounded-lg border border-[#e5e7eb] bg-white px-3 py-3 text-xs text-gray-700">
+              <span className="font-semibold text-[#1f2937]">
+                Outside connections not modeled explicitly:
+              </span>{' '}
+              {(selectionSummary.externalRemainderShare * 100).toFixed(1)}%
+            </div>
+            {selectionSummary.selectedPopulation >
+              GUIDED_SOFT_EXPLICIT_POPULATION && (
+              <div className="mt-3 text-xs text-amber-700">
+                This selection is above the preferred explicit-population band
+                of {GUIDED_SOFT_EXPLICIT_POPULATION.toLocaleString()}.
+              </div>
+            )}
+            {selectionSummary.selectedPopulation >
+              GUIDED_HARD_EXPLICIT_POPULATION && (
+              <div className="mt-1 text-xs text-red-700">
+                Finalize is disabled above{' '}
+                {GUIDED_HARD_EXPLICIT_POPULATION.toLocaleString()} explicit
+                residents.
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/cz-generation/components/finalizing-progress-modal.tsx
+++ b/src/features/cz-generation/components/finalizing-progress-modal.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+type FinalizingProgressModalProps = {
+  open: boolean;
+  progress: number;
+  statusMessage: string;
+};
+
+export function FinalizingProgressModal({
+  open,
+  progress,
+  statusMessage
+}: FinalizingProgressModalProps) {
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <div
+      className="czgen_modal_overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-live="polite"
+    >
+      <div className="czgen_modal">
+        <p className="czgen_modal_title">Generating convenience zone</p>
+        <p className="czgen_modal_subtitle">
+          {statusMessage || 'Preparing movement patterns...'}
+        </p>
+        <div className="czgen_progress_track">
+          <div
+            className="czgen_progress_fill"
+            style={{
+              width: `${Math.max(2, Math.min(100, progress))}%`
+            }}
+          />
+        </div>
+        <div
+          className="mt-2 text-right text-xs font-medium"
+          style={{ color: 'var(--color-text-muted)' }}
+        >
+          {progress}%
+        </div>
+        <p
+          className="mt-3 text-xs"
+          style={{ color: 'var(--color-text-muted)' }}
+        >
+          This can take a few minutes. You&apos;ll be taken to the simulator
+          automatically once generation is complete.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/features/cz-generation/components/frontier-candidates-panel.tsx
+++ b/src/features/cz-generation/components/frontier-candidates-panel.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import type { TraceCandidate } from '@/features/cz-generation/types';
+import { normalizeCbgId } from '@/lib/cz-geo';
+
+type FrontierCandidatesPanelProps = {
+  candidates: TraceCandidate[];
+  hasTraceLayer: boolean;
+  loading: boolean;
+  error: string;
+  selectedCbg: string;
+  onSelectCbg: (cbgId: string) => void;
+};
+
+export function FrontierCandidatesPanel({
+  candidates,
+  hasTraceLayer,
+  loading,
+  error,
+  selectedCbg,
+  onSelectCbg
+}: FrontierCandidatesPanelProps) {
+  return (
+    <div className="czgen_subpanel h-[calc(100vh-13rem)] min-h-136 max-h-192 w-88 max-w-88">
+      <div className="czgen_subpanel_header">
+        <p className="czgen_subpanel_title">
+          Frontier Candidates ({candidates.length})
+        </p>
+      </div>
+      <div className="czgen_subpanel_body">
+        {!hasTraceLayer && loading ? (
+          <div className="text-sm text-gray-500 px-2 py-2">
+            Loading frontier candidates...
+          </div>
+        ) : !hasTraceLayer && error ? (
+          <div className="text-sm text-red-700 px-2 py-2">{error}</div>
+        ) : candidates.length === 0 ? (
+          <div className="text-sm text-gray-500 px-2 py-2">
+            {hasTraceLayer
+              ? 'No candidates at this step.'
+              : 'No frontier candidates for the current zone.'}
+          </div>
+        ) : (
+          candidates.map((candidate) => {
+            const cbgId = normalizeCbgId(candidate?.cbg);
+            const isActive = cbgId === normalizeCbgId(selectedCbg);
+
+            return (
+              <button
+                type="button"
+                key={cbgId}
+                className={`text-left px-4 py-4 rounded border transition-colors ${
+                  isActive
+                    ? 'bg-[#e0f2fe] border-[#0284c7]'
+                    : 'bg-white border-[#d1d5db] hover:border-[#70B4D4]'
+                }`}
+                onClick={() => onSelectCbg(cbgId)}
+              >
+                <div className="text-base font-semibold leading-tight">
+                  #{candidate.rank ?? '?'} {cbgId}
+                </div>
+                <div className="text-base text-gray-700 mt-1">
+                  Score: {Number(candidate.score ?? 0).toFixed(4)}
+                </div>
+                <div className="text-base text-gray-600">
+                  To cluster:{' '}
+                  {Number(candidate.movement_to_cluster ?? 0).toLocaleString(
+                    undefined,
+                    {
+                      maximumFractionDigits: 1
+                    }
+                  )}
+                </div>
+              </button>
+            );
+          })
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/features/cz-generation/components/generated-action-bar.tsx
+++ b/src/features/cz-generation/components/generated-action-bar.tsx
@@ -1,0 +1,643 @@
+'use client';
+
+import {
+  GUIDED_HARD_EXPLICIT_POPULATION,
+  GUIDED_SOFT_EXPLICIT_POPULATION,
+  type ClusterAlgorithm
+} from '@/features/cz-generation/constants';
+import type {
+  ClusterAlgorithmMetadata,
+  GuidedSelectionSummary,
+  TracePayload,
+  ZoneMetrics
+} from '@/features/cz-generation/types';
+
+type GeneratedActionBarProps = {
+  guidedSelectionMode: boolean;
+  selectedGuidedDestinationCount: number;
+  selectedCbgCount: number;
+  guidedSelectedDestinationSummary: string;
+  guidedSelectionSummary: GuidedSelectionSummary;
+  mobilityPruneMetadata: ClusterAlgorithmMetadata | null;
+  totalPopulation: number;
+  showTraceControls: boolean;
+  growthTrace: TracePayload | null;
+  traceStepCount: number;
+  traceEnabled: boolean;
+  traceStepIndex: number;
+  maxTraceStep: number;
+  onTraceEnabledChange: (enabled: boolean) => void;
+  onJumpTraceStep: (index: number) => void;
+  zoneMetricsLoading: boolean;
+  zoneMetricsError: string;
+  zoneMetrics: ZoneMetrics | null;
+  clusterAlgorithm: ClusterAlgorithm;
+  manualEditPanelsActive: boolean;
+  seedGuardDistanceKm: number;
+  onSeedGuardDistanceChange: (value: number) => void;
+  loading: boolean;
+  isFinalizing: boolean;
+  algorithmMetadata: ClusterAlgorithmMetadata | null;
+  zoneEditMode: boolean;
+  onEnterZoneEditMode: () => void;
+  onEnterTraceView: () => void;
+  onSaveHtmlMap: () => void;
+  savingHtmlMap: boolean;
+  onFinalize: () => void;
+};
+
+export function GeneratedActionBar({
+  guidedSelectionMode,
+  selectedGuidedDestinationCount,
+  selectedCbgCount,
+  guidedSelectedDestinationSummary,
+  guidedSelectionSummary,
+  mobilityPruneMetadata,
+  totalPopulation,
+  showTraceControls,
+  growthTrace,
+  traceStepCount,
+  traceEnabled,
+  traceStepIndex,
+  maxTraceStep,
+  onTraceEnabledChange,
+  onJumpTraceStep,
+  zoneMetricsLoading,
+  zoneMetricsError,
+  zoneMetrics,
+  clusterAlgorithm,
+  manualEditPanelsActive,
+  seedGuardDistanceKm,
+  onSeedGuardDistanceChange,
+  loading,
+  isFinalizing,
+  algorithmMetadata,
+  zoneEditMode,
+  onEnterZoneEditMode,
+  onEnterTraceView,
+  onSaveHtmlMap,
+  savingHtmlMap,
+  onFinalize
+}: GeneratedActionBarProps) {
+  return (
+    <div
+      className={`czgen_actionbar ${
+        guidedSelectionMode
+          ? 'flex-col xl:flex-row xl:items-start xl:justify-between'
+          : 'items-start justify-between'
+      }`}
+    >
+      {guidedSelectionMode ? (
+        <GuidedActionSummary
+          selectedGuidedDestinationCount={selectedGuidedDestinationCount}
+          selectedCbgCount={selectedCbgCount}
+          guidedSelectedDestinationSummary={guidedSelectedDestinationSummary}
+          guidedSelectionSummary={guidedSelectionSummary}
+        />
+      ) : (
+        <>
+          <div>
+            {mobilityPruneMetadata ? (
+              <MobilityPruneSummary
+                metadata={mobilityPruneMetadata}
+                selectedCbgCount={selectedCbgCount}
+                totalPopulation={totalPopulation}
+                showTraceControls={showTraceControls}
+                growthTrace={growthTrace}
+                traceStepCount={traceStepCount}
+                traceEnabled={traceEnabled}
+                traceStepIndex={traceStepIndex}
+                maxTraceStep={maxTraceStep}
+                onTraceEnabledChange={onTraceEnabledChange}
+                onJumpTraceStep={onJumpTraceStep}
+              />
+            ) : showTraceControls ? (
+              <TraceControls
+                title="Trace Controls"
+                checkboxLabel="Show frontier heat map"
+                growthTrace={growthTrace}
+                traceStepCount={traceStepCount}
+                traceEnabled={traceEnabled}
+                traceStepIndex={traceStepIndex}
+                maxTraceStep={maxTraceStep}
+                requireTraceEnabledForStepButtons={true}
+                onTraceEnabledChange={onTraceEnabledChange}
+                onJumpTraceStep={onJumpTraceStep}
+              />
+            ) : (
+              <ZoneMetricsSummary
+                loading={zoneMetricsLoading}
+                error={zoneMetricsError}
+                metrics={zoneMetrics}
+                selectedCbgCount={selectedCbgCount}
+              />
+            )}
+          </div>
+
+          {clusterAlgorithm === 'greedy_weight_seed_guard' &&
+            manualEditPanelsActive && (
+              <div className="min-w-[15rem] max-w-[18rem] flex flex-col gap-1">
+                <label
+                  htmlFor="seed_guard_distance_live"
+                  className="text-sm font-semibold"
+                >
+                  Seed Guard Radius (km)
+                </label>
+                <input
+                  id="seed_guard_distance_live"
+                  className="formfield"
+                  type="number"
+                  min={0}
+                  max={500}
+                  value={seedGuardDistanceKm}
+                  onChange={(event) =>
+                    onSeedGuardDistanceChange(Number(event.target.value))
+                  }
+                  disabled={loading || isFinalizing}
+                />
+                <div className="text-xs text-gray-600">
+                  Blue ring shows the seed guard radius and updates live as you
+                  change it.
+                </div>
+              </div>
+            )}
+
+          {algorithmMetadata && !algorithmMetadata.bounded_envelope && (
+            <HierarchySummary metadata={algorithmMetadata} />
+          )}
+        </>
+      )}
+
+      <div
+        className={`flex flex-wrap items-center gap-2 ${
+          guidedSelectionMode ? 'xl:justify-end' : ''
+        }`}
+      >
+        {growthTrace && !zoneEditMode && (
+          <button
+            type="button"
+            onClick={onEnterZoneEditMode}
+            disabled={loading || isFinalizing}
+            className="czgen_btn"
+          >
+            Edit Zone
+          </button>
+        )}
+        {growthTrace && zoneEditMode && (
+          <button
+            type="button"
+            onClick={onEnterTraceView}
+            disabled={loading || isFinalizing}
+            className="czgen_btn"
+          >
+            Trace View
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={onSaveHtmlMap}
+          disabled={loading || isFinalizing || savingHtmlMap}
+          className="czgen_btn"
+        >
+          {savingHtmlMap ? 'Saving HTML Map...' : 'Save HTML Map'}
+        </button>
+        <button
+          type="button"
+          onClick={onFinalize}
+          disabled={
+            loading ||
+            isFinalizing ||
+            (guidedSelectionMode &&
+              guidedSelectionSummary.selectedPopulation >
+                GUIDED_HARD_EXPLICIT_POPULATION)
+          }
+          className="czgen_btn czgen_btn--primary"
+        >
+          {isFinalizing ? 'Generating Patterns...' : 'Finalize & Generate'}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+type GuidedActionSummaryProps = {
+  selectedGuidedDestinationCount: number;
+  selectedCbgCount: number;
+  guidedSelectedDestinationSummary: string;
+  guidedSelectionSummary: GuidedSelectionSummary;
+};
+
+function GuidedActionSummary({
+  selectedGuidedDestinationCount,
+  selectedCbgCount,
+  guidedSelectedDestinationSummary,
+  guidedSelectionSummary
+}: GuidedActionSummaryProps) {
+  return (
+    <div className="min-w-0 flex-1">
+      <div className="text-sm font-semibold text-[#1f2937]">
+        Ready to Generate
+      </div>
+      <div className="mt-1 text-sm text-gray-700">
+        {selectedGuidedDestinationCount
+          ? `Selected ${selectedGuidedDestinationCount} cities and ${selectedCbgCount} linked CBGs: ${guidedSelectedDestinationSummary}.`
+          : `Seed only is selected right now. The explicit layer contains ${selectedCbgCount} seed CBGs.`}
+      </div>
+      <div className="mt-3 flex flex-wrap gap-2 text-xs text-gray-700">
+        <div className="rounded-full border border-[#dbeafe] bg-white px-3 py-1">
+          <span className="font-semibold text-[#1f2937]">
+            Trips Leaving Seed Captured (linked CBGs):
+          </span>{' '}
+          {(
+            guidedSelectionSummary.selectedLinkedOutboundShare * 100
+          ).toFixed(1)}
+          %
+        </div>
+        <div className="rounded-full border border-[#dbeafe] bg-white px-3 py-1">
+          <span className="font-semibold text-[#1f2937]">Explicit Pop:</span>{' '}
+          {Number(
+            guidedSelectionSummary.selectedPopulation ?? 0
+          ).toLocaleString()}
+        </div>
+      </div>
+      {guidedSelectionSummary.selectedPopulation >
+      GUIDED_HARD_EXPLICIT_POPULATION ? (
+        <div className="mt-3 text-xs text-red-700">
+          Finalize is disabled above{' '}
+          {GUIDED_HARD_EXPLICIT_POPULATION.toLocaleString()} explicit residents.
+        </div>
+      ) : guidedSelectionSummary.selectedPopulation >
+        GUIDED_SOFT_EXPLICIT_POPULATION ? (
+        <div className="mt-3 text-xs text-amber-700">
+          This selection is above the preferred explicit-population band of{' '}
+          {GUIDED_SOFT_EXPLICIT_POPULATION.toLocaleString()}.
+        </div>
+      ) : (
+        <div className="mt-3 text-xs text-gray-600">
+          Choose connected cities on the right. The map updates as you change
+          the explicit linked CBG layer.
+        </div>
+      )}
+    </div>
+  );
+}
+
+type MobilityPruneSummaryProps = {
+  metadata: ClusterAlgorithmMetadata;
+  selectedCbgCount: number;
+  totalPopulation: number;
+  showTraceControls: boolean;
+  growthTrace: TracePayload | null;
+  traceStepCount: number;
+  traceEnabled: boolean;
+  traceStepIndex: number;
+  maxTraceStep: number;
+  onTraceEnabledChange: (enabled: boolean) => void;
+  onJumpTraceStep: (index: number) => void;
+};
+
+function MobilityPruneSummary({
+  metadata,
+  selectedCbgCount,
+  totalPopulation,
+  showTraceControls,
+  growthTrace,
+  traceStepCount,
+  traceEnabled,
+  traceStepIndex,
+  maxTraceStep,
+  onTraceEnabledChange,
+  onJumpTraceStep
+}: MobilityPruneSummaryProps) {
+  return (
+    <>
+      <div className="text-sm font-semibold mb-2">Mobility Prune Summary</div>
+      <div className="flex flex-wrap gap-2 text-xs text-gray-700">
+        <div className="rounded-full border border-[#dbeafe] bg-white px-3 py-1">
+          <span className="font-semibold text-[#1f2937]">Final Zone:</span>{' '}
+          {selectedCbgCount} CBGs, pop{' '}
+          {Number(totalPopulation || 0).toLocaleString()}
+        </div>
+        <div className="rounded-full border border-[#dbeafe] bg-white px-3 py-1">
+          <span className="font-semibold text-[#1f2937]">Seed Pop:</span>{' '}
+          {Number(metadata.seed_population ?? 0).toLocaleString()}
+        </div>
+        <div className="rounded-full border border-[#dbeafe] bg-white px-3 py-1">
+          <span className="font-semibold text-[#1f2937]">Envelope:</span>{' '}
+          {Number(metadata.initial_cbg_count ?? 0).toLocaleString()} CBGs, pop{' '}
+          {Number(metadata.initial_population ?? 0).toLocaleString()}
+        </div>
+        <div className="rounded-full border border-[#dbeafe] bg-white px-3 py-1">
+          <span className="font-semibold text-[#1f2937]">
+            Envelope Target:
+          </span>{' '}
+          {Number(metadata.envelope_population_target ?? 0).toLocaleString()}
+        </div>
+        <div className="rounded-full border border-[#dbeafe] bg-white px-3 py-1">
+          <span className="font-semibold text-[#1f2937]">Pruned:</span>{' '}
+          {Number(metadata.removed_cbg_count ?? 0).toLocaleString()} CBGs, pop{' '}
+          {Number(metadata.population_reduced ?? 0).toLocaleString()}
+        </div>
+        <div className="rounded-full border border-[#dbeafe] bg-white px-3 py-1">
+          <span className="font-semibold text-[#1f2937]">
+            Minimum Seed Capture:
+          </span>{' '}
+          {Number((metadata.min_seed_capture ?? 0) * 100).toFixed(0)}%
+        </div>
+        <div className="rounded-full border border-[#dbeafe] bg-white px-3 py-1">
+          <span className="font-semibold text-[#1f2937]">Seed Capture:</span>{' '}
+          {Number((metadata.final_seed_capture_share ?? 0) * 100).toFixed(1)}%
+        </div>
+      </div>
+      {showTraceControls &&
+        growthTrace?.supports_stepwise &&
+        traceStepCount > 0 && (
+          <div className="mt-3 border-t border-[#dbeafe] pt-3">
+            <TraceControls
+              checkboxLabel="Show pruning trace heat map"
+              growthTrace={growthTrace}
+              traceStepCount={traceStepCount}
+              traceEnabled={traceEnabled}
+              traceStepIndex={traceStepIndex}
+              maxTraceStep={maxTraceStep}
+              onTraceEnabledChange={onTraceEnabledChange}
+              onJumpTraceStep={onJumpTraceStep}
+            />
+          </div>
+        )}
+    </>
+  );
+}
+
+type TraceControlsProps = {
+  title?: string;
+  checkboxLabel: string;
+  growthTrace: TracePayload | null;
+  traceStepCount: number;
+  traceEnabled: boolean;
+  traceStepIndex: number;
+  maxTraceStep: number;
+  requireTraceEnabledForStepButtons?: boolean;
+  onTraceEnabledChange: (enabled: boolean) => void;
+  onJumpTraceStep: (index: number) => void;
+};
+
+function TraceControls({
+  title,
+  checkboxLabel,
+  growthTrace,
+  traceStepCount,
+  traceEnabled,
+  traceStepIndex,
+  maxTraceStep,
+  requireTraceEnabledForStepButtons = false,
+  onTraceEnabledChange,
+  onJumpTraceStep
+}: TraceControlsProps) {
+  if (!growthTrace?.supports_stepwise || traceStepCount === 0) {
+    return (
+      <>
+        {title && <div className="text-sm font-semibold mb-2">{title}</div>}
+        <div className="text-xs text-gray-600">
+          {growthTrace?.note ||
+            'This algorithm does not expose a step-by-step greedy expansion trace.'}
+        </div>
+      </>
+    );
+  }
+
+  return (
+    <>
+      {title && <div className="text-sm font-semibold mb-2">{title}</div>}
+      <label
+        className={`flex items-center gap-2 text-xs ${
+          title ? 'mb-2' : ''
+        }`}
+      >
+        <input
+          type="checkbox"
+          checked={traceEnabled}
+          onChange={(event) => onTraceEnabledChange(event.target.checked)}
+        />
+        {checkboxLabel}
+      </label>
+      {traceEnabled && !requireTraceEnabledForStepButtons && (
+        <>
+          <TraceStepIndicator
+            traceStepIndex={traceStepIndex}
+            maxTraceStep={maxTraceStep}
+            traceStepCount={traceStepCount}
+          />
+          <TraceStepButtons
+            traceEnabled={traceEnabled}
+            traceStepIndex={traceStepIndex}
+            maxTraceStep={maxTraceStep}
+            requireTraceEnabled={requireTraceEnabledForStepButtons}
+            onJumpTraceStep={onJumpTraceStep}
+          />
+        </>
+      )}
+      {requireTraceEnabledForStepButtons && (
+        <>
+          <TraceStepIndicator
+            traceStepIndex={traceStepIndex}
+            maxTraceStep={maxTraceStep}
+            traceStepCount={traceStepCount}
+          />
+          <TraceStepButtons
+            traceEnabled={traceEnabled}
+            traceStepIndex={traceStepIndex}
+            maxTraceStep={maxTraceStep}
+            requireTraceEnabled={requireTraceEnabledForStepButtons}
+            onJumpTraceStep={onJumpTraceStep}
+          />
+        </>
+      )}
+    </>
+  );
+}
+
+type TraceStepIndicatorProps = {
+  traceStepIndex: number;
+  maxTraceStep: number;
+  traceStepCount: number;
+};
+
+function TraceStepIndicator({
+  traceStepIndex,
+  maxTraceStep,
+  traceStepCount
+}: TraceStepIndicatorProps) {
+  return (
+    <div className="mt-2 text-xs text-gray-600">
+      Step {Math.min(traceStepIndex, maxTraceStep) + 1} of {traceStepCount}
+    </div>
+  );
+}
+
+type TraceStepButtonsProps = {
+  traceEnabled: boolean;
+  traceStepIndex: number;
+  maxTraceStep: number;
+  requireTraceEnabled: boolean;
+  onJumpTraceStep: (index: number) => void;
+};
+
+function TraceStepButtons({
+  traceEnabled,
+  traceStepIndex,
+  maxTraceStep,
+  requireTraceEnabled,
+  onJumpTraceStep
+}: TraceStepButtonsProps) {
+  return (
+    <div className="mt-2 flex gap-2">
+      <button
+        type="button"
+        className="czgen_btn czgen_btn--sm"
+        disabled={
+          (requireTraceEnabled && !traceEnabled) || traceStepIndex <= 0
+        }
+        onClick={() => onJumpTraceStep(traceStepIndex - 1)}
+      >
+        Previous Step
+      </button>
+      <button
+        type="button"
+        className="czgen_btn czgen_btn--sm"
+        disabled={
+          (requireTraceEnabled && !traceEnabled) ||
+          traceStepIndex >= maxTraceStep
+        }
+        onClick={() => onJumpTraceStep(traceStepIndex + 1)}
+      >
+        Next Step
+      </button>
+    </div>
+  );
+}
+
+type ZoneMetricsSummaryProps = {
+  loading: boolean;
+  error: string;
+  metrics: ZoneMetrics | null;
+  selectedCbgCount: number;
+};
+
+function ZoneMetricsSummary({
+  loading,
+  error,
+  metrics,
+  selectedCbgCount
+}: ZoneMetricsSummaryProps) {
+  if (loading) {
+    return (
+      <>
+        <div className="text-sm font-semibold mb-2">Zone Metrics (Live)</div>
+        <div className="text-xs text-gray-600">Computing CZI...</div>
+      </>
+    );
+  }
+
+  if (error) {
+    return (
+      <>
+        <div className="text-sm font-semibold mb-2">Zone Metrics (Live)</div>
+        <div className="text-xs text-red-700">{error}</div>
+      </>
+    );
+  }
+
+  if (!metrics) {
+    return (
+      <>
+        <div className="text-sm font-semibold mb-2">Zone Metrics (Live)</div>
+        <div className="text-xs text-gray-600">No metrics available.</div>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <div className="text-sm font-semibold mb-2">Zone Metrics (Live)</div>
+      <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-gray-700">
+        <div>
+          <span className="font-semibold">CBGs:</span>{' '}
+          {metrics.cbg_count ?? selectedCbgCount}
+        </div>
+        <div>
+          <span className="font-semibold">CZI:</span>{' '}
+          {Number(metrics.czi ?? 0).toFixed(4)}
+        </div>
+        <div>
+          <span className="font-semibold">Inside:</span>{' '}
+          {Number(metrics.movement_inside ?? 0).toLocaleString(undefined, {
+            maximumFractionDigits: 1
+          })}
+        </div>
+        <div>
+          <span className="font-semibold">Boundary:</span>{' '}
+          {Number(metrics.movement_boundary ?? 0).toLocaleString(undefined, {
+            maximumFractionDigits: 1
+          })}
+        </div>
+      </div>
+      <div className="mt-1 text-xs text-gray-600">
+        Click CBGs on the map to add or remove them. Frontier candidates update
+        automatically.
+      </div>
+    </>
+  );
+}
+
+type HierarchySummaryProps = {
+  metadata: ClusterAlgorithmMetadata;
+};
+
+function HierarchySummary({ metadata }: HierarchySummaryProps) {
+  return (
+    <div className="min-w-[16rem] max-w-[22rem] flex flex-col gap-1 text-xs text-gray-700">
+      <div className="text-sm font-semibold text-[#1f2937]">
+        Hierarchy Summary
+      </div>
+      <div>
+        <span className="font-semibold">Seed:</span>{' '}
+        {metadata.seed_zip_codes?.length
+          ? metadata.seed_zip_codes.join(', ')
+          : `${metadata.seed_cbgs?.length ?? 0} seed CBGs`}
+      </div>
+      <div>
+        <span className="font-semibold">Core:</span>{' '}
+        {metadata.core_cluster?.length ?? 0} CBGs
+        {metadata.core_population !== undefined
+          ? `, pop ${Number(metadata.core_population).toLocaleString()}`
+          : ''}
+      </div>
+      <div>
+        <span className="font-semibold">Satellites:</span>{' '}
+        {metadata.selected_satellites?.length ?? 0}
+      </div>
+      {metadata.selected_satellites &&
+        metadata.selected_satellites.length > 0 && (
+          <div>
+            <span className="font-semibold">Selected:</span>{' '}
+            {metadata.selected_satellites
+              .map((item) => item.label || item.unit_id || 'Unknown')
+              .join(', ')}
+          </div>
+        )}
+      {metadata.external_pressure_share !== undefined && (
+        <div>
+          <span className="font-semibold">External Pressure:</span>{' '}
+          {Number((metadata.external_pressure_share ?? 0) * 100).toFixed(1)}%
+        </div>
+      )}
+      {metadata.population_target_met !== undefined && (
+        <div>
+          <span className="font-semibold">Population Target:</span>{' '}
+          {metadata.population_target_met ? 'Met' : 'Not met'}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/features/cz-generation/components/generated-zone-workspace.tsx
+++ b/src/features/cz-generation/components/generated-zone-workspace.tsx
@@ -1,0 +1,289 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+import { CandidateAnalysisPanel } from '@/features/cz-generation/components/candidate-analysis-panel';
+import { ConnectedCitiesPanel } from '@/features/cz-generation/components/connected-cities-panel';
+import { FrontierCandidatesPanel } from '@/features/cz-generation/components/frontier-candidates-panel';
+import { GeneratedActionBar } from '@/features/cz-generation/components/generated-action-bar';
+import type { ClusterAlgorithm } from '@/features/cz-generation/constants';
+import type {
+  ClusterAlgorithmMetadata,
+  GuidedDestinationCandidate,
+  GuidedSecondOrderMetadata,
+  GuidedSelectionStyle,
+  GuidedSelectionSummary,
+  PoiAnalysis,
+  TraceCandidate,
+  TraceLayerData,
+  TracePayload,
+  ZoneMetrics
+} from '@/features/cz-generation/types';
+import type { GeoJSONData, LatLng } from '@/lib/cz-geo';
+
+const CBGMap = dynamic(() => import('@/components/cbg-map'), { ssr: false });
+
+type GeneratedZoneWorkspaceProps = {
+  cbgGeoJSON: GeoJSONData | null;
+  selectedCBGs: string[];
+  seedCBG: string;
+  mapSeedCbgIds: string[];
+  seedGuardDistanceKm: number;
+  clusterAlgorithm: ClusterAlgorithm;
+  activeMapTraceLayer: TraceLayerData | null;
+  guidedSelectionStyleByCbg: Map<string, GuidedSelectionStyle> | null;
+  manualEditPanelsActive: boolean;
+  guidedSelectionMode: boolean;
+  focusedTraceCbg: string;
+  focusedTraceNonce: number;
+  onCBGClick: (cbgId: string, properties: Record<string, unknown>) => void;
+  onMapBackgroundClick: (latlng: LatLng) => void;
+  onTraceCbgInspect: (cbgId: string) => void;
+  guidedSeedLabel: string;
+  guidedDestinations: GuidedDestinationCandidate[];
+  selectedGuidedDestinationIds: string[];
+  guidedSelectedDestinations: GuidedDestinationCandidate[];
+  guidedMetadata: GuidedSecondOrderMetadata | null;
+  guidedSelectionSummary: GuidedSelectionSummary;
+  guidedStyleByUnitId: Map<string, GuidedSelectionStyle>;
+  guidedDestinationLoading: boolean;
+  guidedDestinationError: string;
+  isFinalizing: boolean;
+  showGuidedSummaryPanel: boolean;
+  onShowGuidedSummary: () => void;
+  onHideGuidedSummary: () => void;
+  onShowGuidedTermsHelp: () => void;
+  onUseRecommendedGuidedDestinations: () => void;
+  onSeedOnlyGuidedDestinations: () => void;
+  onToggleGuidedDestination: (destination: GuidedDestinationCandidate) => void;
+  showCandidatePanels: boolean;
+  displayCandidates: TraceCandidate[];
+  traceLayer: TraceLayerData | null;
+  manualFrontierLoading: boolean;
+  manualFrontierError: string;
+  selectedTraceCandidateCbg: string;
+  onTraceCandidateSelect: (cbgId: string) => void;
+  selectedTracePopulation: unknown;
+  selectedAnalysisStatus: string;
+  selectedAnalysisCandidate: TraceCandidate | null;
+  candidatePois: PoiAnalysis[];
+  candidatePoiLoading: boolean;
+  candidatePoiError: string;
+  guidedSelectedDestinationSummary: string;
+  mobilityPruneMetadata: ClusterAlgorithmMetadata | null;
+  totalPopulation: number;
+  showTraceControls: boolean;
+  growthTrace: TracePayload | null;
+  traceStepCount: number;
+  traceEnabled: boolean;
+  traceStepIndex: number;
+  maxTraceStep: number;
+  onTraceEnabledChange: (enabled: boolean) => void;
+  onJumpTraceStep: (index: number) => void;
+  zoneMetricsLoading: boolean;
+  zoneMetricsError: string;
+  zoneMetrics: ZoneMetrics | null;
+  loading: boolean;
+  algorithmMetadata: ClusterAlgorithmMetadata | null;
+  zoneEditMode: boolean;
+  onEnterZoneEditMode: () => void;
+  onEnterTraceView: () => void;
+  onSaveHtmlMap: () => void;
+  savingHtmlMap: boolean;
+  onFinalize: () => void;
+  onSeedGuardDistanceChange: (value: number) => void;
+};
+
+export function GeneratedZoneWorkspace({
+  cbgGeoJSON,
+  selectedCBGs,
+  seedCBG,
+  mapSeedCbgIds,
+  seedGuardDistanceKm,
+  clusterAlgorithm,
+  activeMapTraceLayer,
+  guidedSelectionStyleByCbg,
+  manualEditPanelsActive,
+  guidedSelectionMode,
+  focusedTraceCbg,
+  focusedTraceNonce,
+  onCBGClick,
+  onMapBackgroundClick,
+  onTraceCbgInspect,
+  guidedSeedLabel,
+  guidedDestinations,
+  selectedGuidedDestinationIds,
+  guidedSelectedDestinations,
+  guidedMetadata,
+  guidedSelectionSummary,
+  guidedStyleByUnitId,
+  guidedDestinationLoading,
+  guidedDestinationError,
+  isFinalizing,
+  showGuidedSummaryPanel,
+  onShowGuidedSummary,
+  onHideGuidedSummary,
+  onShowGuidedTermsHelp,
+  onUseRecommendedGuidedDestinations,
+  onSeedOnlyGuidedDestinations,
+  onToggleGuidedDestination,
+  showCandidatePanels,
+  displayCandidates,
+  traceLayer,
+  manualFrontierLoading,
+  manualFrontierError,
+  selectedTraceCandidateCbg,
+  onTraceCandidateSelect,
+  selectedTracePopulation,
+  selectedAnalysisStatus,
+  selectedAnalysisCandidate,
+  candidatePois,
+  candidatePoiLoading,
+  candidatePoiError,
+  guidedSelectedDestinationSummary,
+  mobilityPruneMetadata,
+  totalPopulation,
+  showTraceControls,
+  growthTrace,
+  traceStepCount,
+  traceEnabled,
+  traceStepIndex,
+  maxTraceStep,
+  onTraceEnabledChange,
+  onJumpTraceStep,
+  zoneMetricsLoading,
+  zoneMetricsError,
+  zoneMetrics,
+  loading,
+  algorithmMetadata,
+  zoneEditMode,
+  onEnterZoneEditMode,
+  onEnterTraceView,
+  onSaveHtmlMap,
+  savingHtmlMap,
+  onFinalize,
+  onSeedGuardDistanceChange
+}: GeneratedZoneWorkspaceProps) {
+  return (
+    <div className="w-full flex flex-col gap-4">
+      <div className="flex gap-4 w-full flex-wrap 2xl:flex-nowrap">
+        <div className="czgen_map h-[50vh] min-h-80 max-h-140 lg:h-[calc(100vh-13rem)] lg:min-h-136 lg:max-h-192 relative flex-1 min-w-0 w-full lg:min-w-176">
+          {cbgGeoJSON ? (
+            <CBGMap
+              cbgData={cbgGeoJSON}
+              center={null}
+              onCBGClick={onCBGClick}
+              onMapBackgroundClick={onMapBackgroundClick}
+              onTraceCbgInspect={
+                manualEditPanelsActive ? null : onTraceCbgInspect
+              }
+              selectedCBGs={selectedCBGs}
+              seedCbgId={seedCBG}
+              seedCbgIds={mapSeedCbgIds}
+              seedGuardRadiusKm={seedGuardDistanceKm}
+              showSeedGuardCircle={
+                clusterAlgorithm === 'greedy_weight_seed_guard'
+              }
+              traceLayer={activeMapTraceLayer}
+              selectionStyleByCbg={guidedSelectionStyleByCbg}
+              editingEnabled={
+                !guidedSelectionMode &&
+                (manualEditPanelsActive || !activeMapTraceLayer)
+              }
+              focusedCbgId={focusedTraceCbg}
+              focusNonce={focusedTraceNonce}
+            />
+          ) : (
+            <div className="h-full w-full flex items-center justify-center bg-gray-100 text-gray-500">
+              <div className="text-center">
+                <p>CBG map not available</p>
+                <p className="text-sm">
+                  GeoJSON endpoint needed on Algorithms server
+                </p>
+              </div>
+            </div>
+          )}
+        </div>
+
+        {guidedSelectionMode && (
+          <ConnectedCitiesPanel
+            seedLabel={guidedSeedLabel}
+            destinations={guidedDestinations}
+            selectedDestinationIds={selectedGuidedDestinationIds}
+            selectedDestinations={guidedSelectedDestinations}
+            selectedCbgCount={selectedCBGs.length}
+            metadata={guidedMetadata}
+            selectionSummary={guidedSelectionSummary}
+            styleByUnitId={guidedStyleByUnitId}
+            loading={guidedDestinationLoading}
+            error={guidedDestinationError}
+            isFinalizing={isFinalizing}
+            showSummary={showGuidedSummaryPanel}
+            onShowSummary={onShowGuidedSummary}
+            onHideSummary={onHideGuidedSummary}
+            onShowTermsHelp={onShowGuidedTermsHelp}
+            onUseRecommended={onUseRecommendedGuidedDestinations}
+            onSeedOnly={onSeedOnlyGuidedDestinations}
+            onToggleDestination={onToggleGuidedDestination}
+          />
+        )}
+
+        {showCandidatePanels && (
+          <FrontierCandidatesPanel
+            candidates={displayCandidates}
+            hasTraceLayer={Boolean(traceLayer)}
+            loading={manualFrontierLoading}
+            error={manualFrontierError}
+            selectedCbg={selectedTraceCandidateCbg}
+            onSelectCbg={onTraceCandidateSelect}
+          />
+        )}
+
+        {showCandidatePanels && (
+          <CandidateAnalysisPanel
+            selectedCbg={selectedTraceCandidateCbg}
+            population={selectedTracePopulation}
+            status={selectedAnalysisStatus}
+            candidate={selectedAnalysisCandidate}
+            pois={candidatePois}
+            poisLoading={candidatePoiLoading}
+            poisError={candidatePoiError}
+          />
+        )}
+      </div>
+
+      <GeneratedActionBar
+        guidedSelectionMode={guidedSelectionMode}
+        selectedGuidedDestinationCount={selectedGuidedDestinationIds.length}
+        selectedCbgCount={selectedCBGs.length}
+        guidedSelectedDestinationSummary={guidedSelectedDestinationSummary}
+        guidedSelectionSummary={guidedSelectionSummary}
+        mobilityPruneMetadata={mobilityPruneMetadata}
+        totalPopulation={totalPopulation}
+        showTraceControls={showTraceControls}
+        growthTrace={growthTrace}
+        traceStepCount={traceStepCount}
+        traceEnabled={traceEnabled}
+        traceStepIndex={traceStepIndex}
+        maxTraceStep={maxTraceStep}
+        onTraceEnabledChange={onTraceEnabledChange}
+        onJumpTraceStep={onJumpTraceStep}
+        zoneMetricsLoading={zoneMetricsLoading}
+        zoneMetricsError={zoneMetricsError}
+        zoneMetrics={zoneMetrics}
+        clusterAlgorithm={clusterAlgorithm}
+        manualEditPanelsActive={manualEditPanelsActive}
+        seedGuardDistanceKm={seedGuardDistanceKm}
+        onSeedGuardDistanceChange={onSeedGuardDistanceChange}
+        loading={loading}
+        isFinalizing={isFinalizing}
+        algorithmMetadata={algorithmMetadata}
+        zoneEditMode={zoneEditMode}
+        onEnterZoneEditMode={onEnterZoneEditMode}
+        onEnterTraceView={onEnterTraceView}
+        onSaveHtmlMap={onSaveHtmlMap}
+        savingHtmlMap={savingHtmlMap}
+        onFinalize={onFinalize}
+      />
+    </div>
+  );
+}

--- a/src/features/cz-generation/components/generation-page-chrome.tsx
+++ b/src/features/cz-generation/components/generation-page-chrome.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+export function GenerationLoadingState() {
+  return (
+    <div className="czgen_page">
+      <p
+        className="czgen_lede"
+        style={{ textAlign: 'center', paddingTop: '60px' }}
+      >
+        Loading...
+      </p>
+    </div>
+  );
+}
+
+export function GenerationIntroHeader() {
+  return (
+    <div className="czgen_header" data-aos="fade-up" data-aos-once="true">
+      <h1 className="czgen_title">Generate a Convenience Zone</h1>
+      <p className="czgen_lede">
+        Define your simulation&apos;s geographic area by selecting a location
+        and clustering nearby Census Block Groups.
+      </p>
+    </div>
+  );
+}

--- a/src/features/cz-generation/components/guided-terms-help-modal.tsx
+++ b/src/features/cz-generation/components/guided-terms-help-modal.tsx
@@ -1,0 +1,179 @@
+'use client';
+
+type GuidedTermsHelpModalProps = {
+  open: boolean;
+  onClose: () => void;
+};
+
+export function GuidedTermsHelpModal({
+  open,
+  onClose
+}: GuidedTermsHelpModalProps) {
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <div
+      className="czgen_modal_overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="guided-terms-title"
+      tabIndex={-1}
+      onClick={(event) => {
+        if (event.target === event.currentTarget) {
+          onClose();
+        }
+      }}
+      onKeyDown={(event) => {
+        if (event.key === 'Escape') {
+          onClose();
+        }
+      }}
+    >
+      <div className="czgen_modal czgen_modal--wide">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <p id="guided-terms-title" className="czgen_modal_title">
+              How Guided Ranking Works
+            </p>
+            <p className="czgen_modal_subtitle">
+              The city cards use plain-language labels. This panel maps those
+              labels back to the ranking terms and explains which values drive
+              ordering versus selection context.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="czgen_btn czgen_btn--sm"
+            style={{ flexShrink: 0 }}
+          >
+            Close
+          </button>
+        </div>
+
+        <div className="mt-4 flex flex-col gap-3 text-sm text-gray-700">
+          <div className="rounded-lg bg-[#f8fafc] px-3 py-3 text-xs text-gray-700">
+            <div className="font-semibold text-[#1f2937]">
+              Connection (<code>coupling</code>)
+            </div>
+            <div className="mt-1">
+              Distance-adjusted two-way connection between the seed and a city.
+              This is the main ranking score, so the list is ordered by this
+              value.
+            </div>
+            <pre className="mt-2 overflow-x-auto whitespace-pre-wrap font-mono text-[11px] leading-5 text-[#1f2937]">
+              {`bidirectional_flow = outbound_flow + inbound_flow
+
+coupling =
+  bidirectional_flow / (1 + distance_km / distance_scale_km)`}
+            </pre>
+            <div className="mt-2">
+              <span className="font-semibold">Terms:</span>{' '}
+              <code>outbound_flow</code> is travel from the seed to the city,
+              aggregated across the full city approximation.{' '}
+              <code>inbound_flow</code> is travel from the city back to the
+              seed, also aggregated across the full city approximation.{' '}
+              <code>distance_km</code> is the distance from the seed to the
+              selected linked CBG layer for that city.{' '}
+              <code>distance_scale_km</code> is the distance penalty scale.
+            </div>
+          </div>
+          <div className="rounded-lg bg-[#f8fafc] px-3 py-3 text-xs text-gray-700">
+            <div className="font-semibold text-[#1f2937]">
+              Trips Leaving Seed (
+              <code>share_of_seed_external_outbound</code>)
+            </div>
+            <div className="mt-1">
+              On each city card, this is the portion of trips leaving the seed
+              that go to that full connected city. It remains a city-level
+              ranking/context metric.
+            </div>
+            <pre className="mt-2 overflow-x-auto whitespace-pre-wrap font-mono text-[11px] leading-5 text-[#1f2937]">
+              {`share_of_seed_external_outbound =
+  outbound_flow / total_seed_external_outbound_flow`}
+            </pre>
+            <div className="mt-2">
+              <span className="font-semibold">Terms:</span>{' '}
+              <code>total_seed_external_outbound_flow</code> only counts trips
+              that leave the seed for outside destinations. The numerator is
+              the full city approximation&apos;s outbound flow, not only the
+              linked CBG subset.
+            </div>
+          </div>
+          <div className="rounded-lg bg-[#f8fafc] px-3 py-3 text-xs text-gray-700">
+            <div className="font-semibold text-[#1f2937]">
+              Trips Leaving Seed In Summary
+            </div>
+            <div className="mt-1">
+              In the footer and selection summary, this is computed only from
+              the selected linked CBG subset, summed across the chosen cities.
+            </div>
+            <pre className="mt-2 overflow-x-auto whitespace-pre-wrap font-mono text-[11px] leading-5 text-[#1f2937]">
+              {`linked_subset_trips_leaving_seed =
+  selected_linked_outbound_flow / total_seed_external_outbound_flow`}
+            </pre>
+            <div className="mt-2">
+              <span className="font-semibold">Terms:</span>{' '}
+              <code>selected_linked_outbound_flow</code> is the sum of
+              <code>seed_outbound_flow</code> across the linked CBGs kept
+              explicit in the zone.
+            </div>
+          </div>
+          <div className="rounded-lg bg-[#f8fafc] px-3 py-3 text-xs text-gray-700">
+            <div className="font-semibold text-[#1f2937]">
+              Linked CBGs (<code>cbg_count</code>)
+            </div>
+            <div className="mt-1">
+              Number of linked CBGs that would be kept explicit for this city.
+              This is selection context, not part of the ranking formula.
+            </div>
+          </div>
+          <div className="rounded-lg bg-[#f8fafc] px-3 py-3 text-xs text-gray-700">
+            <div className="font-semibold text-[#1f2937]">
+              Added Population (<code>population</code>)
+            </div>
+            <div className="mt-1">
+              Estimated explicit population contributed by that city&apos;s
+              linked CBG layer. This helps judge zone size, but it also is not
+              part of the ranking formula.
+            </div>
+          </div>
+          <div className="rounded-lg bg-[#f8fafc] px-3 py-3 text-xs text-gray-700">
+            <div className="font-semibold text-[#1f2937]">
+              Linked Coverage (
+              <code>captured_bidirectional_flow_share</code>)
+            </div>
+            <div className="mt-1">
+              Portion of the city&apos;s two-way seed connection that is
+              covered by the selected linked CBGs. This is the note shown at the
+              bottom of each card.
+            </div>
+            <pre className="mt-2 overflow-x-auto whitespace-pre-wrap font-mono text-[11px] leading-5 text-[#1f2937]">
+              {`captured_bidirectional_flow_share =
+  captured_gateway_bidirectional_flow / bidirectional_flow`}
+            </pre>
+            <div className="mt-2">
+              <span className="font-semibold">Terms:</span>{' '}
+              <code>captured_gateway_bidirectional_flow</code> is the two-way
+              travel covered by the chosen linked CBG subset for that city.{' '}
+              <code>bidirectional_flow</code> is the full city-level two-way
+              travel between the seed and that city.
+            </div>
+          </div>
+          <div className="czgen_info text-xs">
+            The list is ranked by <code>coupling</code>, shown as{' '}
+            <span className="font-semibold">Connection</span>. The other values
+            help decide whether that city is worth keeping in the explicit zone
+            once you see its linked CBG count and population impact. If you want
+            linked-CBG-only metrics, use the summary UI&apos;s{' '}
+            <span className="font-semibold">Trips Leaving Seed</span> for
+            outbound capture and the city card&apos;s{' '}
+            <code>captured_bidirectional_flow_share</code> for two-way coverage.
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/cz-generation/components/setup-seed-panel.tsx
+++ b/src/features/cz-generation/components/setup-seed-panel.tsx
@@ -1,0 +1,690 @@
+'use client';
+
+import { Info } from 'lucide-react';
+import type { ChangeEvent, ChangeEventHandler } from 'react';
+import {
+  CLUSTER_ALGORITHM_OPTIONS,
+  type ClusterAlgorithm
+} from '@/features/cz-generation/constants';
+import {
+  endDateFromMonth,
+  formatMonthLabel,
+  monthFromDate,
+  monthFromEndDate,
+  startDateFromMonth
+} from '@/features/cz-generation/helpers';
+import type { SeedEditAction } from '@/features/cz-generation/types';
+
+type FormFieldProps = {
+  label: string;
+  name: string;
+  type: 'text' | 'number' | 'date' | 'textarea' | 'select';
+  placeholder?: string;
+  disabled?: boolean;
+  value?: string | number;
+  onChange?: (
+    event: ChangeEvent<
+      HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement
+    >
+  ) => void;
+  min?: number | string;
+  max?: number | string;
+  options?: Array<{ value: string; label: string }>;
+  required?: boolean;
+};
+
+type SeedAdjustmentSummary = {
+  addedCount: number;
+  removedCount: number;
+  hasChanges: boolean;
+};
+
+type SetupSeedPanelProps = {
+  location: string;
+  onLocationChange: (value: string) => void;
+  loading: boolean;
+  resolvingSeed: boolean;
+  seedEditLoading: boolean;
+  onResolveSeedPreview: () => void;
+  isTestLocationInput: boolean;
+  clusterAlgorithm: ClusterAlgorithm;
+  onClusterAlgorithmChange: (algorithm: ClusterAlgorithm) => void;
+  onShowAlgorithmGuide: () => void;
+  mobilityPruneMinSeedCapturePct: number;
+  onMobilityPruneMinSeedCapturePctChange: (value: number) => void;
+  isGuidedSecondOrderAlgorithm: boolean;
+  minPop: number;
+  onMinPopChange: (value: number) => void;
+  monthOptions: string[];
+  availableMonthsLoading: boolean;
+  detectedStateAbbr: string | null;
+  startDate: string;
+  endDate: string;
+  onStartDateChange: (value: string) => void;
+  onEndDateChange: (value: string) => void;
+  description: string;
+  onDescriptionChange: (value: string) => void;
+  setupSeedCbg: string;
+  setupSeedLabel: string;
+  setupSeedCount: number;
+  setupResolvedCityName: string;
+  seedGuardDistanceKm: number;
+  seedAdjustmentSummary: SeedAdjustmentSummary;
+  seedEditMode: boolean;
+  seedEditAction: SeedEditAction;
+  onSeedEditActionChange: (action: SeedEditAction) => void;
+  onFinishSeedEdit: () => void;
+  onCancelSeedEdit: () => void;
+  onShowMoreSeedEditNeighbors: () => void;
+  onBeginSeedEdit: () => void;
+  onResetAdjustedSeed: () => void;
+  seedEditError: string;
+  seedResolveError: string;
+  showAdvancedClustering: boolean;
+  onToggleAdvancedClustering: () => void;
+  onSeedGuardDistanceChange: (value: number) => void;
+  seedGuardNeedsResolvedSeed: boolean;
+};
+
+export function SetupSeedPanel({
+  location,
+  onLocationChange,
+  loading,
+  resolvingSeed,
+  seedEditLoading,
+  onResolveSeedPreview,
+  isTestLocationInput,
+  clusterAlgorithm,
+  onClusterAlgorithmChange,
+  onShowAlgorithmGuide,
+  mobilityPruneMinSeedCapturePct,
+  onMobilityPruneMinSeedCapturePctChange,
+  isGuidedSecondOrderAlgorithm,
+  minPop,
+  onMinPopChange,
+  monthOptions,
+  availableMonthsLoading,
+  detectedStateAbbr,
+  startDate,
+  endDate,
+  onStartDateChange,
+  onEndDateChange,
+  description,
+  onDescriptionChange,
+  setupSeedCbg,
+  setupSeedLabel,
+  setupSeedCount,
+  setupResolvedCityName,
+  seedGuardDistanceKm,
+  seedAdjustmentSummary,
+  seedEditMode,
+  seedEditAction,
+  onSeedEditActionChange,
+  onFinishSeedEdit,
+  onCancelSeedEdit,
+  onShowMoreSeedEditNeighbors,
+  onBeginSeedEdit,
+  onResetAdjustedSeed,
+  seedEditError,
+  seedResolveError,
+  showAdvancedClustering,
+  onToggleAdvancedClustering,
+  onSeedGuardDistanceChange,
+  seedGuardNeedsResolvedSeed
+}: SetupSeedPanelProps) {
+  const monthsReady = monthOptions.length > 0;
+  const placeholderLabel = availableMonthsLoading
+    ? 'Loading available months...'
+    : detectedStateAbbr
+      ? 'No months available for this state'
+      : 'Resolve seed to see available months';
+  const placeholderOption = [{ value: '', label: placeholderLabel }];
+  const startValue = monthsReady ? monthFromDate(startDate) : '';
+  const endValue = monthsReady ? monthFromEndDate(endDate) : '';
+  const startOptions = monthsReady
+    ? monthOptions.map((month) => ({
+        value: month,
+        label: formatMonthLabel(month)
+      }))
+    : placeholderOption;
+  const endOptions = monthsReady
+    ? monthOptions
+        .filter((month) => month >= monthFromDate(startDate))
+        .map((month) => ({
+          value: month,
+          label: formatMonthLabel(month)
+        }))
+    : placeholderOption;
+
+  return (
+    <div className="czgen_panel lg:w-[30rem] xl:w-[32rem] lg:flex-none lg:h-[calc(100vh-6rem)] lg:overflow-y-auto">
+      <div className="flex flex-col gap-4">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-end lg:flex-col xl:flex-row xl:items-end">
+          <div className="flex-1 min-w-0">
+            <FormField
+              label="City, Address, or Location"
+              name="location"
+              type="text"
+              placeholder="e.g. 55902 or TEST"
+              value={location}
+              onChange={(event) => onLocationChange(event.target.value)}
+              disabled={loading || resolvingSeed}
+            />
+          </div>
+          <div className="w-full sm:w-[12rem] lg:w-full xl:w-[12rem]">
+            <button
+              type="button"
+              onClick={onResolveSeedPreview}
+              disabled={
+                loading ||
+                resolvingSeed ||
+                !location.trim() ||
+                isTestLocationInput
+              }
+              className="czgen_btn czgen_btn--full"
+            >
+              {resolvingSeed ? 'Resolving Seed...' : 'Resolve Seed'}
+            </button>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          <div className="w-full sm:col-span-2 flex flex-col gap-0.5">
+            <div className="flex items-center justify-between">
+              <label htmlFor="algorithm">Clustering Algorithm</label>
+              <button
+                type="button"
+                onClick={onShowAlgorithmGuide}
+                className="czgen_btn czgen_btn--sm"
+              >
+                <Info size={12} />
+                <span style={{ marginLeft: '5px' }}>Algorithm Guide</span>
+              </button>
+            </div>
+            <select
+              className="formfield w-full"
+              name="algorithm"
+              id="algorithm"
+              disabled={loading}
+              value={clusterAlgorithm}
+              onChange={(event) =>
+                onClusterAlgorithmChange(event.target.value as ClusterAlgorithm)
+              }
+              required={true}
+            >
+              {CLUSTER_ALGORITHM_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </div>
+          {clusterAlgorithm === 'mobility_prune' ? (
+            <div className="w-full sm:col-span-2">
+              <FormField
+                label="Minimum Seed Movement Captured (%)"
+                name="mobility_prune_min_seed_capture"
+                type="number"
+                value={mobilityPruneMinSeedCapturePct}
+                min={0}
+                max={100}
+                onChange={(event) =>
+                  onMobilityPruneMinSeedCapturePctChange(
+                    Number(event.target.value)
+                  )
+                }
+                disabled={loading}
+              />
+              <div className="mt-1 text-xs text-gray-600">
+                Pruning stops before a removal would drop captured seed movement
+                below this threshold.
+              </div>
+            </div>
+          ) : !isGuidedSecondOrderAlgorithm ? (
+            <div className="w-full sm:col-span-2">
+              <FormField
+                label="Minimum Population"
+                name="min_pop"
+                type="number"
+                value={minPop}
+                min={100}
+                max={100_000}
+                onChange={(event) => onMinPopChange(Number(event.target.value))}
+                disabled={loading}
+              />
+            </div>
+          ) : null}
+          <div className="czgen_warning text-xs sm:col-span-2">
+            Keep zones under 50,000 people for faster generation and review.
+          </div>
+          <div className="w-full">
+            <FormField
+              label="Start Month"
+              name="start_month"
+              type="select"
+              value={startValue}
+              options={startOptions}
+              onChange={(event) => {
+                const nextMonth = event.target.value;
+                if (!nextMonth) {
+                  return;
+                }
+                const nextStart = startDateFromMonth(nextMonth);
+                onStartDateChange(nextStart);
+                if (monthFromEndDate(endDate) < nextMonth) {
+                  onEndDateChange(endDateFromMonth(nextMonth));
+                }
+              }}
+              disabled={loading || !monthsReady}
+            />
+          </div>
+          <div className="w-full">
+            <FormField
+              label="End Month"
+              name="end_month"
+              type="select"
+              value={endValue}
+              options={endOptions}
+              onChange={(event) => {
+                const nextMonth = event.target.value;
+                if (!nextMonth) {
+                  return;
+                }
+                onEndDateChange(endDateFromMonth(nextMonth));
+              }}
+              disabled={loading || !monthsReady}
+            />
+          </div>
+          <div className="w-full sm:col-span-2">
+            <FormField
+              label="Description"
+              name="description"
+              type="textarea"
+              placeholder="a short description for this convenience zone..."
+              value={description}
+              onChange={(event) => onDescriptionChange(event.target.value)}
+              disabled={loading}
+              required={false}
+            />
+          </div>
+        </div>
+
+        {(setupSeedCbg || seedResolveError || isTestLocationInput) && (
+          <SeedPreviewStatus
+            setupSeedCbg={setupSeedCbg}
+            setupSeedLabel={setupSeedLabel}
+            setupSeedCount={setupSeedCount}
+            setupResolvedCityName={setupResolvedCityName}
+            clusterAlgorithm={clusterAlgorithm}
+            seedGuardDistanceKm={seedGuardDistanceKm}
+            seedAdjustmentSummary={seedAdjustmentSummary}
+            seedEditMode={seedEditMode}
+            seedEditAction={seedEditAction}
+            onSeedEditActionChange={onSeedEditActionChange}
+            loading={loading}
+            seedEditLoading={seedEditLoading}
+            onFinishSeedEdit={onFinishSeedEdit}
+            onCancelSeedEdit={onCancelSeedEdit}
+            onShowMoreSeedEditNeighbors={onShowMoreSeedEditNeighbors}
+            onBeginSeedEdit={onBeginSeedEdit}
+            onResetAdjustedSeed={onResetAdjustedSeed}
+            seedEditError={seedEditError}
+            isTestLocationInput={isTestLocationInput}
+            seedResolveError={seedResolveError}
+          />
+        )}
+
+        {clusterAlgorithm === 'greedy_weight_seed_guard' && (
+          <div className="text-xs text-gray-600">
+            Resolve the seed, adjust the blue radius, then preview the cluster.
+          </div>
+        )}
+
+        {isGuidedSecondOrderAlgorithm && (
+          <div className="czgen_info text-xs">
+            This mode starts with the full seed region, ranks nearby connected
+            cities by how much travel they share with it, and asks you which
+            connected cities should contribute linked CBGs to the explicit
+            simulation.
+          </div>
+        )}
+
+        {clusterAlgorithm === 'mobility_prune' && (
+          <div className="czgen_info text-xs">
+            This mode grows a large mobility envelope, then prunes low
+            seed-capture CBGs while preserving the seed CBGs' movement field.
+          </div>
+        )}
+
+        {clusterAlgorithm === 'greedy_weight_seed_guard' && (
+          <div className="czgen_panel w-full" style={{ padding: '12px 14px' }}>
+            <button
+              type="button"
+              className="text-sm font-semibold text-left w-full"
+              onClick={onToggleAdvancedClustering}
+              disabled={loading}
+            >
+              Advanced Clustering {showAdvancedClustering ? 'v' : '>'}
+            </button>
+            {showAdvancedClustering && (
+              <div className="mt-3 flex flex-col gap-3">
+                <FormField
+                  label="Seed Guard Distance (km)"
+                  name="seed_guard_distance_km"
+                  type="number"
+                  value={seedGuardDistanceKm}
+                  min={0}
+                  max={500}
+                  onChange={(event) =>
+                    onSeedGuardDistanceChange(Number(event.target.value))
+                  }
+                  disabled={loading}
+                />
+                <div className="text-xs text-gray-600">
+                  Distant CBGs can still be added, but they will stop
+                  influencing later picks.
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+
+        <div className="pt-1">
+          <button
+            type="submit"
+            disabled={
+              loading ||
+              resolvingSeed ||
+              seedEditLoading ||
+              (seedGuardNeedsResolvedSeed && !setupSeedCbg)
+            }
+            className="czgen_btn czgen_btn--primary czgen_btn--full"
+          >
+            {loading
+              ? isGuidedSecondOrderAlgorithm
+                ? 'Loading Cities...'
+                : 'Clustering...'
+              : isGuidedSecondOrderAlgorithm
+                ? 'Choose Connected Cities'
+                : 'Preview CBGs'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function FormField({
+  label,
+  name,
+  type,
+  placeholder,
+  disabled,
+  value,
+  onChange,
+  min,
+  max,
+  options,
+  required = true
+}: FormFieldProps) {
+  return (
+    <div className="flex flex-col gap-1">
+      <label className="czgen_field_label" htmlFor={name}>
+        {label}
+      </label>
+      {type === 'textarea' ? (
+        <textarea
+          className="formfield"
+          name={name}
+          id={name}
+          placeholder={placeholder}
+          disabled={disabled}
+          value={value as string}
+          onChange={
+            onChange as
+              | ChangeEventHandler<HTMLTextAreaElement>
+              | undefined
+          }
+          required={required}
+        />
+      ) : type === 'select' ? (
+        <select
+          className="formfield"
+          name={name}
+          id={name}
+          disabled={disabled}
+          value={value as string}
+          onChange={
+            onChange as ChangeEventHandler<HTMLSelectElement> | undefined
+          }
+          required={required}
+        >
+          {options?.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+      ) : (
+        <input
+          className="formfield"
+          type={type}
+          name={name}
+          id={name}
+          placeholder={placeholder}
+          disabled={disabled}
+          value={value}
+          onChange={
+            onChange as ChangeEventHandler<HTMLInputElement> | undefined
+          }
+          min={min}
+          max={max}
+          required={required}
+        />
+      )}
+    </div>
+  );
+}
+
+type SeedPreviewStatusProps = {
+  setupSeedCbg: string;
+  setupSeedLabel: string;
+  setupSeedCount: number;
+  setupResolvedCityName: string;
+  clusterAlgorithm: ClusterAlgorithm;
+  seedGuardDistanceKm: number;
+  seedAdjustmentSummary: SeedAdjustmentSummary;
+  seedEditMode: boolean;
+  seedEditAction: SeedEditAction;
+  onSeedEditActionChange: (action: SeedEditAction) => void;
+  loading: boolean;
+  seedEditLoading: boolean;
+  onFinishSeedEdit: () => void;
+  onCancelSeedEdit: () => void;
+  onShowMoreSeedEditNeighbors: () => void;
+  onBeginSeedEdit: () => void;
+  onResetAdjustedSeed: () => void;
+  seedEditError: string;
+  isTestLocationInput: boolean;
+  seedResolveError: string;
+};
+
+function SeedPreviewStatus({
+  setupSeedCbg,
+  setupSeedLabel,
+  setupSeedCount,
+  setupResolvedCityName,
+  clusterAlgorithm,
+  seedGuardDistanceKm,
+  seedAdjustmentSummary,
+  seedEditMode,
+  seedEditAction,
+  onSeedEditActionChange,
+  loading,
+  seedEditLoading,
+  onFinishSeedEdit,
+  onCancelSeedEdit,
+  onShowMoreSeedEditNeighbors,
+  onBeginSeedEdit,
+  onResetAdjustedSeed,
+  seedEditError,
+  isTestLocationInput,
+  seedResolveError
+}: SeedPreviewStatusProps) {
+  return (
+    <div className="flex flex-col gap-2 text-sm">
+      {setupSeedCbg && (
+        <div className="czgen_info text-sm">
+          <div>
+            <span className="font-semibold">Resolved Seed:</span>{' '}
+            {setupSeedLabel || setupSeedCbg}
+            {setupSeedCount > 0 ? ` (${setupSeedCount} CBGs)` : ''}
+            {setupResolvedCityName ? ` for ${setupResolvedCityName}` : ''}
+            {clusterAlgorithm === 'greedy_weight_seed_guard'
+              ? ` | Blue ring radius: ${seedGuardDistanceKm} km`
+              : ''}
+          </div>
+          {seedAdjustmentSummary.hasChanges && (
+            <div className="mt-1 text-xs">
+              {seedAdjustmentSummary.addedCount > 0
+                ? `+${seedAdjustmentSummary.addedCount} added`
+                : ''}
+              {seedAdjustmentSummary.addedCount > 0 &&
+              seedAdjustmentSummary.removedCount > 0
+                ? ' | '
+                : ''}
+              {seedAdjustmentSummary.removedCount > 0
+                ? `-${seedAdjustmentSummary.removedCount} removed`
+                : ''}
+            </div>
+          )}
+          <div className="mt-2 flex flex-wrap gap-2">
+            {seedEditMode ? (
+              <>
+                <div
+                  className="flex overflow-hidden rounded-lg"
+                  style={{ border: '1px solid rgba(61,136,173,0.3)' }}
+                >
+                  <button
+                    type="button"
+                    onClick={() => onSeedEditActionChange('add')}
+                    disabled={loading || seedEditLoading}
+                    className={`px-3 py-1.5 text-xs font-semibold font-[inherit] cursor-pointer disabled:opacity-40 ${
+                      seedEditAction === 'add'
+                        ? 'bg-[#dcfce7] text-[#166534]'
+                        : ''
+                    }`}
+                    style={
+                      seedEditAction !== 'add'
+                        ? {
+                            color: 'var(--color-text-main)',
+                            background: 'var(--color-bg-surface)'
+                          }
+                        : undefined
+                    }
+                  >
+                    Add
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => onSeedEditActionChange('remove')}
+                    disabled={loading || seedEditLoading}
+                    className={`px-3 py-1.5 text-xs font-semibold font-[inherit] cursor-pointer disabled:opacity-40 ${
+                      seedEditAction === 'remove'
+                        ? 'bg-[#fee2e2] text-[#991b1b]'
+                        : ''
+                    }`}
+                    style={{
+                      borderLeft: '1px solid rgba(61,136,173,0.3)',
+                      ...(seedEditAction !== 'remove'
+                        ? {
+                            color: 'var(--color-text-main)',
+                            background: 'var(--color-bg-surface)'
+                          }
+                        : {})
+                    }}
+                  >
+                    Remove
+                  </button>
+                </div>
+                <button
+                  type="button"
+                  onClick={onFinishSeedEdit}
+                  disabled={loading || seedEditLoading}
+                  className="czgen_btn czgen_btn--sm"
+                >
+                  Done
+                </button>
+                <button
+                  type="button"
+                  onClick={onCancelSeedEdit}
+                  disabled={loading || seedEditLoading}
+                  className="czgen_btn czgen_btn--sm"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  onClick={onShowMoreSeedEditNeighbors}
+                  disabled={loading || seedEditLoading}
+                  className="czgen_btn czgen_btn--sm"
+                >
+                  Show More Nearby
+                </button>
+              </>
+            ) : (
+              <button
+                type="button"
+                onClick={onBeginSeedEdit}
+                disabled={loading || seedEditLoading}
+                className="czgen_btn czgen_btn--sm"
+              >
+                {seedEditLoading ? 'Loading Area...' : 'Adjust Seed Area'}
+              </button>
+            )}
+            <button
+              type="button"
+              onClick={onResetAdjustedSeed}
+              disabled={
+                loading || seedEditLoading || !seedAdjustmentSummary.hasChanges
+              }
+              className="czgen_btn czgen_btn--sm"
+            >
+              Reset
+            </button>
+          </div>
+          {seedEditMode && (
+            <div
+              className="mt-2 text-xs czgen_info"
+              style={{ padding: '4px 8px' }}
+            >
+              {seedEditAction === 'add' ? 'Add mode active' : 'Remove mode active'}
+              {seedEditLoading ? ' | Updating map...' : ''}
+            </div>
+          )}
+          {seedEditError && (
+            <div
+              className="mt-2 czgen_error text-xs"
+              style={{ textAlign: 'left', maxWidth: '100%', padding: '6px 10px' }}
+            >
+              {seedEditError}
+            </div>
+          )}
+        </div>
+      )}
+      {!setupSeedCbg && isTestLocationInput && (
+        <div className="czgen_warning text-sm">
+          Seed preview is unavailable in TEST mode.
+        </div>
+      )}
+      {seedResolveError && (
+        <div
+          className="czgen_error text-sm"
+          style={{ textAlign: 'left', maxWidth: '100%' }}
+        >
+          {seedResolveError}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/features/cz-generation/hooks/use-candidate-pois.ts
+++ b/src/features/cz-generation/hooks/use-candidate-pois.ts
@@ -1,0 +1,90 @@
+import { useEffect, useState } from 'react';
+import { fetchCandidatePois } from '@/features/cz-generation/api';
+import type { PoiAnalysis } from '@/features/cz-generation/types';
+
+type UseCandidatePoisOptions = {
+  enabled: boolean;
+  seedCbg: string;
+  candidateCbg: string;
+  clusterCbgs: string[];
+  startDate: string;
+  useTestData: boolean;
+  limit?: number;
+};
+
+export function useCandidatePois({
+  enabled,
+  seedCbg,
+  candidateCbg,
+  clusterCbgs,
+  startDate,
+  useTestData,
+  limit = 8
+}: UseCandidatePoisOptions) {
+  const [pois, setPois] = useState<PoiAnalysis[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (!enabled || !candidateCbg) {
+      setPois([]);
+      setError('');
+      setLoading(false);
+      return undefined;
+    }
+
+    if (clusterCbgs.length === 0) {
+      setPois([]);
+      setError('');
+      setLoading(false);
+      return undefined;
+    }
+
+    let cancelled = false;
+    setLoading(true);
+    setError('');
+
+    fetchCandidatePois({
+      seed_cbg: seedCbg,
+      candidate_cbg: candidateCbg,
+      cluster_cbgs: clusterCbgs,
+      start_date: startDate,
+      use_test_data: useTestData,
+      limit
+    })
+      .then((data) => {
+        if (cancelled) {
+          return;
+        }
+        setPois(Array.isArray(data?.pois) ? data.pois : []);
+      })
+      .catch((err) => {
+        if (cancelled) {
+          return;
+        }
+        setPois([]);
+        setError(
+          err instanceof Error ? err.message : 'Failed to load POI analysis.'
+        );
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    candidateCbg,
+    clusterCbgs,
+    enabled,
+    limit,
+    seedCbg,
+    startDate,
+    useTestData
+  ]);
+
+  return { pois, loading, error };
+}

--- a/src/features/cz-generation/hooks/use-cz-metrics.ts
+++ b/src/features/cz-generation/hooks/use-cz-metrics.ts
@@ -1,0 +1,97 @@
+import { useEffect, useState } from 'react';
+import { fetchCzMetrics } from '@/features/cz-generation/api';
+import type { ZoneMetrics } from '@/features/cz-generation/types';
+
+type UseCzMetricsOptions = {
+  enabled: boolean;
+  seedCbg: string;
+  cbgs: string[];
+  startDate: string;
+  useTestData: boolean;
+  debounceMs?: number;
+  errorMessage?: string;
+  warnMessage?: string;
+};
+
+export function useCzMetrics({
+  enabled,
+  seedCbg,
+  cbgs,
+  startDate,
+  useTestData,
+  debounceMs = 0,
+  errorMessage,
+  warnMessage
+}: UseCzMetricsOptions) {
+  const [metrics, setMetrics] = useState<ZoneMetrics | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (!enabled || !seedCbg || cbgs.length === 0) {
+      setMetrics(null);
+      setError('');
+      setLoading(false);
+      return undefined;
+    }
+
+    let cancelled = false;
+
+    const loadMetrics = async () => {
+      setLoading(true);
+      setError('');
+
+      try {
+        const data = await fetchCzMetrics({
+          seed_cbg: seedCbg,
+          cbg_list: cbgs,
+          start_date: startDate,
+          use_test_data: useTestData
+        });
+        if (!cancelled) {
+          setMetrics(data || null);
+        }
+      } catch (err) {
+        if (cancelled) {
+          return;
+        }
+
+        setMetrics(null);
+        if (warnMessage) {
+          console.warn(warnMessage, err);
+        }
+        if (errorMessage) {
+          setError(err instanceof Error ? err.message : errorMessage);
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    };
+
+    const timer =
+      debounceMs > 0 ? setTimeout(loadMetrics, debounceMs) : null;
+    if (!timer) {
+      void loadMetrics();
+    }
+
+    return () => {
+      cancelled = true;
+      if (timer) {
+        clearTimeout(timer);
+      }
+    };
+  }, [
+    cbgs,
+    debounceMs,
+    enabled,
+    errorMessage,
+    seedCbg,
+    startDate,
+    useTestData,
+    warnMessage
+  ]);
+
+  return { metrics, loading, error };
+}

--- a/src/features/cz-generation/hooks/use-generation-preview-submit.ts
+++ b/src/features/cz-generation/hooks/use-generation-preview-submit.ts
@@ -1,0 +1,579 @@
+import { useCallback, type FormEvent } from 'react';
+import {
+  fetchSecondOrderDestinations,
+  getClusteringProgressUrl,
+  lookupLocation,
+  startClusteringPreview
+} from '@/features/cz-generation/api';
+import type { ClusterAlgorithm } from '@/features/cz-generation/constants';
+import {
+  dedupeCbgList,
+  getPayloadErrorMessage,
+  isClusterAlgorithm,
+  isRecord
+} from '@/features/cz-generation/helpers';
+import type {
+  ClusterAlgorithmMetadata,
+  ClusteringPreviewResponse,
+  GuidedDestinationCandidate,
+  GuidedSecondOrderMetadata,
+  ResolvedSeedLookup,
+  TracePayload
+} from '@/features/cz-generation/types';
+import {
+  type GeoJSONData,
+  getBoundsForGeoJson,
+  mergeGeoJsonFeatures
+} from '@/lib/cz-geo';
+
+type Phase = 'input' | 'edit' | 'finalizing';
+
+type UseGenerationPreviewSubmitParams = {
+  loading: boolean;
+  location: string;
+  setUseTestData: (value: boolean) => void;
+  setSeedEditMode: (value: boolean) => void;
+  resolvedSeedLookup: ResolvedSeedLookup | null;
+  setupSeedCbg: string;
+  setupSeedCbgs: string[];
+  setupResolvedCityName: string;
+  seedGuardNeedsResolvedSeed: boolean;
+  setResolvedSeedLookup: (value: ResolvedSeedLookup | null) => void;
+  setError: (value: string) => void;
+  setLoading: (value: boolean) => void;
+  setAlgorithmMetadata: (value: ClusterAlgorithmMetadata | null) => void;
+  setGuidedMetadata: (value: GuidedSecondOrderMetadata | null) => void;
+  setGuidedDestinations: (value: GuidedDestinationCandidate[]) => void;
+  setGuidedSeedCbgs: (value: string[]) => void;
+  setSelectedGuidedDestinationIds: (value: string[]) => void;
+  setGuidedDestinationError: (value: string) => void;
+  isGuidedSecondOrderAlgorithm: boolean;
+  setGuidedDestinationLoading: (value: boolean) => void;
+  startDate: string;
+  setupSeedGeoJSON: GeoJSONData | null;
+  loadSeedGeoJson: (
+    seedCbgs: string[],
+    includeNeighbors: boolean
+  ) => Promise<GeoJSONData>;
+  setSetupSeedGeoJSON: (value: GeoJSONData | null) => void;
+  setSelectedCBGs: (value: string[]) => void;
+  setSeedCBG: (value: string) => void;
+  setTotalPopulation: (value: number) => void;
+  setCityName: (value: string) => void;
+  setGrowthTrace: (value: TracePayload | null) => void;
+  setTraceStepIndex: (value: number) => void;
+  setTraceEnabled: (value: boolean) => void;
+  setZoneEditMode: (value: boolean) => void;
+  setSelectedTraceCandidateCbg: (value: string) => void;
+  setFocusedTraceCbg: (value: string) => void;
+  setCbgGeoJSON: (value: GeoJSONData | null) => void;
+  setMapCenter: (value: [number, number] | null) => void;
+  setPhase: (value: Phase) => void;
+  minPop: number;
+  clusterAlgorithm: ClusterAlgorithm;
+  seedGuardDistanceKm: number;
+  mobilityPruneMinSeedCapturePct: number;
+  setClusterAlgorithm: (value: ClusterAlgorithm) => void;
+  setSeedGuardDistanceKm: (value: number) => void;
+  setMobilityPruneMinSeedCapturePct: (value: number) => void;
+};
+
+export function useGenerationPreviewSubmit({
+  loading,
+  location,
+  setUseTestData,
+  setSeedEditMode,
+  resolvedSeedLookup,
+  setupSeedCbg,
+  setupSeedCbgs,
+  setupResolvedCityName,
+  seedGuardNeedsResolvedSeed,
+  setResolvedSeedLookup,
+  setError,
+  setLoading,
+  setAlgorithmMetadata,
+  setGuidedMetadata,
+  setGuidedDestinations,
+  setGuidedSeedCbgs,
+  setSelectedGuidedDestinationIds,
+  setGuidedDestinationError,
+  isGuidedSecondOrderAlgorithm,
+  setGuidedDestinationLoading,
+  startDate,
+  setupSeedGeoJSON,
+  loadSeedGeoJson,
+  setSetupSeedGeoJSON,
+  setSelectedCBGs,
+  setSeedCBG,
+  setTotalPopulation,
+  setCityName,
+  setGrowthTrace,
+  setTraceStepIndex,
+  setTraceEnabled,
+  setZoneEditMode,
+  setSelectedTraceCandidateCbg,
+  setFocusedTraceCbg,
+  setCbgGeoJSON,
+  setMapCenter,
+  setPhase,
+  minPop,
+  clusterAlgorithm,
+  seedGuardDistanceKm,
+  mobilityPruneMinSeedCapturePct,
+  setClusterAlgorithm,
+  setSeedGuardDistanceKm,
+  setMobilityPruneMinSeedCapturePct
+}: UseGenerationPreviewSubmitParams) {
+  const waitForClusteringResult = useCallback(
+    (clusteringId: number): Promise<ClusteringPreviewResponse> =>
+      new Promise((resolve, reject) => {
+        let settled = false;
+        const eventSource = new EventSource(
+          getClusteringProgressUrl(clusteringId)
+        );
+        const timeout = window.setTimeout(
+          () => {
+            if (settled) {
+              return;
+            }
+            settled = true;
+            eventSource.close();
+            reject(
+              new Error(
+                'Timed out waiting for the clustering preview to finish.'
+              )
+            );
+          },
+          5 * 60 * 1000
+        );
+
+        const finish = (callback: () => void) => {
+          if (settled) {
+            return;
+          }
+          settled = true;
+          window.clearTimeout(timeout);
+          eventSource.close();
+          callback();
+        };
+
+        eventSource.onmessage = (event) => {
+          let payload: Record<string, unknown> | null = null;
+          try {
+            const parsed = JSON.parse(event.data);
+            payload = isRecord(parsed) ? parsed : null;
+          } catch {
+            finish(() =>
+              reject(
+                new Error(
+                  'Received an invalid clustering progress payload from the Algorithms service.'
+                )
+              )
+            );
+            return;
+          }
+
+          if (payload?.error) {
+            finish(() =>
+              reject(
+                new Error(
+                  getPayloadErrorMessage(
+                    payload,
+                    'Failed to cluster CBGs. Please try again.'
+                  )
+                )
+              )
+            );
+            return;
+          }
+
+          if (!payload?.done) {
+            return;
+          }
+
+          const result = isRecord(payload.result) ? payload.result : null;
+          if (!result) {
+            finish(() =>
+              reject(
+                new Error(
+                  'Clustering finished without returning the preview result payload.'
+                )
+              )
+            );
+            return;
+          }
+
+          finish(() => resolve(result as ClusteringPreviewResponse));
+        };
+
+        eventSource.onerror = () => {
+          finish(() =>
+            reject(
+              new Error(
+                'Lost connection to the Algorithms service while previewing CBGs.'
+              )
+            )
+          );
+        };
+      }),
+    []
+  );
+
+  return useCallback(
+    async (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      if (loading) {
+        return;
+      }
+
+      const rawLocationInput = String(location ?? '').trim();
+      const isTestMode = rawLocationInput.toUpperCase() === 'TEST';
+      setUseTestData(isTestMode);
+      setSeedEditMode(false);
+
+      const cachedSeedLookup =
+        resolvedSeedLookup?.query === rawLocationInput
+          ? resolvedSeedLookup
+          : null;
+      let coreCbg = setupSeedCbg || cachedSeedLookup?.cbg || null;
+      let resolvedSeedCbgs =
+        setupSeedCbgs.length > 0
+          ? setupSeedCbgs
+          : cachedSeedLookup?.seedCbgs ||
+            (setupSeedCbg ? [setupSeedCbg] : ([] as string[]));
+      let resolvedCityName =
+        setupResolvedCityName ||
+        cachedSeedLookup?.cityName ||
+        (isTestMode ? 'TEST' : rawLocationInput);
+
+      if (seedGuardNeedsResolvedSeed && !coreCbg) {
+        setError(
+          'Resolve the seed first so you can verify the seed guard radius before previewing.'
+        );
+        return;
+      }
+
+      if (!isTestMode && !coreCbg) {
+        try {
+          const resolved = await lookupLocation(rawLocationInput);
+          coreCbg = resolved?.cbg || null;
+          resolvedSeedCbgs = Array.isArray(resolved?.seed_cbgs)
+            ? resolved.seed_cbgs.filter(
+                (cbg): cbg is string => typeof cbg === 'string'
+              )
+            : coreCbg
+              ? [coreCbg]
+              : [];
+          resolvedCityName =
+            resolved?.city && resolved?.state
+              ? `${resolved.city}, ${resolved.state}`
+              : resolved?.city || resolved?.state || rawLocationInput;
+          if (coreCbg) {
+            setResolvedSeedLookup({
+              query: rawLocationInput,
+              cbg: coreCbg,
+              cityName: resolvedCityName,
+              seedName: resolved?.seed_name || coreCbg,
+              seedCbgs: resolvedSeedCbgs,
+              seedZip: resolved?.zip
+            });
+          }
+        } catch (err) {
+          setError(
+            err instanceof Error ? err.message : 'Failed to resolve location.'
+          );
+          return;
+        }
+      }
+
+      if (!isTestMode && !coreCbg) {
+        setError(
+          'Could not find location. Please try entering a 5-digit ZIP code (e.g. 21201 for Baltimore).'
+        );
+        return;
+      }
+
+      setError('');
+      setLoading(true);
+      setAlgorithmMetadata(null);
+      setGuidedMetadata(null);
+      setGuidedDestinations([]);
+      setGuidedSeedCbgs([]);
+      setSelectedGuidedDestinationIds([]);
+      setGuidedDestinationError('');
+
+      try {
+        if (isGuidedSecondOrderAlgorithm) {
+          setGuidedDestinationLoading(true);
+          const data = await fetchSecondOrderDestinations({
+            cbg: coreCbg,
+            seed_cbgs: resolvedSeedCbgs,
+            start_date: startDate,
+            use_test_data: isTestMode,
+            limit: 12
+          });
+
+          let seedGeoJson = setupSeedGeoJSON;
+          if (!seedGeoJson?.features?.length) {
+            seedGeoJson = await loadSeedGeoJson(resolvedSeedCbgs, false);
+            setSetupSeedGeoJSON(seedGeoJson);
+          }
+
+          const destinations = Array.isArray(data.destinations)
+            ? (data.destinations as GuidedDestinationCandidate[]).filter(
+                (destination) =>
+                  Boolean(destination?.unit_id) &&
+                  Array.isArray(destination?.cbgs)
+              )
+            : [];
+          const recommendedIds = Array.isArray(data.recommended_unit_ids)
+            ? (data.recommended_unit_ids as unknown[])
+                .filter(
+                  (unitId): unitId is string => typeof unitId === 'string'
+                )
+                .filter((unitId) =>
+                  destinations.some(
+                    (destination) => destination.unit_id === unitId
+                  )
+                )
+            : destinations
+                .filter((destination) => destination.recommended)
+                .map((destination) => destination.unit_id);
+
+          const nextGuidedMetadata = {
+            ...(data as GuidedSecondOrderMetadata),
+            seed_cbg: String(data.seed_cbg || coreCbg || ''),
+            seed_cbgs: Array.isArray(data.seed_cbgs)
+              ? (data.seed_cbgs as unknown[]).filter(
+                  (cbg): cbg is string => typeof cbg === 'string'
+                )
+              : resolvedSeedCbgs,
+            destinations,
+            recommended_unit_ids: recommendedIds
+          };
+          const initialSelectedCBGs = dedupeCbgList([
+            ...nextGuidedMetadata.seed_cbgs,
+            ...destinations
+              .filter((destination) =>
+                recommendedIds.includes(destination.unit_id)
+              )
+              .flatMap((destination) => destination.cbgs)
+          ]);
+
+          setGuidedMetadata(nextGuidedMetadata);
+          setGuidedDestinations(destinations);
+          setGuidedSeedCbgs(nextGuidedMetadata.seed_cbgs);
+          setSelectedGuidedDestinationIds(recommendedIds);
+          setSelectedCBGs(initialSelectedCBGs);
+          setSeedCBG(nextGuidedMetadata.seed_cbg);
+          setTotalPopulation(
+            Number(nextGuidedMetadata.seed_population ?? 0) +
+              destinations
+                .filter((destination) =>
+                  recommendedIds.includes(destination.unit_id)
+                )
+                .reduce(
+                  (sum, destination) =>
+                    sum + Number(destination.population ?? 0),
+                  0
+                )
+          );
+          setCityName(resolvedCityName);
+          setUseTestData(Boolean(data.use_test_data ?? isTestMode));
+          setGrowthTrace(null);
+          setTraceStepIndex(0);
+          setTraceEnabled(false);
+          setZoneEditMode(false);
+          setSelectedTraceCandidateCbg('');
+          setFocusedTraceCbg('');
+          setCbgGeoJSON(seedGeoJson);
+          const seedBounds = getBoundsForGeoJson(seedGeoJson);
+          if (seedBounds) {
+            setMapCenter([
+              (seedBounds[0][1] + seedBounds[1][1]) / 2,
+              (seedBounds[0][0] + seedBounds[1][0]) / 2
+            ]);
+          }
+          setPhase('edit');
+          return;
+        }
+
+        const clusterReq: Record<string, unknown> = {
+          min_pop: Number(minPop),
+          algorithm: clusterAlgorithm,
+          start_date: startDate,
+          use_test_data: isTestMode,
+          include_trace: true
+        };
+
+        if (clusterAlgorithm === 'greedy_weight_seed_guard') {
+          if (Number.isFinite(Number(seedGuardDistanceKm))) {
+            clusterReq.seed_guard_distance_km = Number(seedGuardDistanceKm);
+          }
+        }
+        if (clusterAlgorithm === 'mobility_prune') {
+          const minSeedCapture = Number(mobilityPruneMinSeedCapturePct) / 100;
+          if (Number.isFinite(minSeedCapture)) {
+            clusterReq.mobility_prune_min_seed_capture = Math.min(
+              1,
+              Math.max(0, minSeedCapture)
+            );
+          }
+        }
+
+        if (coreCbg) {
+          clusterReq.cbg = coreCbg;
+        }
+        if (resolvedSeedCbgs.length > 0) {
+          clusterReq.seed_cbgs = resolvedSeedCbgs;
+        }
+
+        const kickoffData = await startClusteringPreview(clusterReq);
+
+        let data = kickoffData;
+        if (!Array.isArray(data?.cluster)) {
+          const clusteringId = Number(data?.clustering_id);
+          if (Number.isInteger(clusteringId) && clusteringId > 0) {
+            data = await waitForClusteringResult(clusteringId);
+          }
+        }
+
+        if (!Array.isArray(data?.cluster)) {
+          throw new Error(
+            getPayloadErrorMessage(
+              kickoffData,
+              'The Algorithms service returned an unexpected clustering response.'
+            )
+          );
+        }
+
+        const cluster = data.cluster.filter(
+          (cbg: unknown): cbg is string => typeof cbg === 'string'
+        );
+        setSelectedCBGs(cluster);
+        setSeedCBG(data.seed_cbg || coreCbg || '');
+        setMapCenter(data.center || null);
+        setTotalPopulation(Number(data.size || 0));
+        setCityName(resolvedCityName);
+        setUseTestData(Boolean(data.use_test_data ?? isTestMode));
+        setAlgorithmMetadata(
+          data.algorithm_metadata || data.trace?.algorithm_metadata || null
+        );
+        const responseAlgorithm = isClusterAlgorithm(data.algorithm)
+          ? data.algorithm
+          : clusterAlgorithm;
+        if (isClusterAlgorithm(data.algorithm)) {
+          setClusterAlgorithm(responseAlgorithm);
+        }
+
+        if (
+          data.clustering_params &&
+          data.algorithm === 'greedy_weight_seed_guard'
+        ) {
+          const rawThreshold = Number(
+            data.clustering_params.seed_guard_distance_km
+          );
+          if (Number.isFinite(rawThreshold)) {
+            setSeedGuardDistanceKm(rawThreshold);
+          }
+        }
+        if (data.clustering_params && data.algorithm === 'mobility_prune') {
+          const rawMinSeedCapture = Number(
+            data.clustering_params.min_seed_capture
+          );
+          if (Number.isFinite(rawMinSeedCapture)) {
+            setMobilityPruneMinSeedCapturePct(
+              Math.round(Math.min(1, Math.max(0, rawMinSeedCapture)) * 100)
+            );
+          }
+        }
+
+        setGrowthTrace(data.trace || null);
+        setTraceStepIndex(0);
+        setTraceEnabled(
+          Boolean(data.trace?.steps?.length) &&
+            responseAlgorithm !== 'mobility_prune'
+        );
+        setZoneEditMode(false);
+
+        if (data.geojson || data.trace_geojson) {
+          setCbgGeoJSON(
+            mergeGeoJsonFeatures(
+              data.geojson || null,
+              data.trace_geojson || null
+            )
+          );
+        }
+
+        setPhase('edit');
+      } catch (err) {
+        console.error(err);
+        setAlgorithmMetadata(null);
+        setGuidedMetadata(null);
+        setGuidedDestinations([]);
+        setGuidedSeedCbgs([]);
+        setSelectedGuidedDestinationIds([]);
+        setGuidedDestinationError(
+          err instanceof Error
+            ? err.message
+            : 'Failed to load connected city destinations.'
+        );
+        setError(
+          err instanceof Error
+            ? err.message
+            : 'Failed to cluster CBGs. Please try again.'
+        );
+      } finally {
+        setGuidedDestinationLoading(false);
+        setLoading(false);
+      }
+    },
+    [
+      clusterAlgorithm,
+      isGuidedSecondOrderAlgorithm,
+      loadSeedGeoJson,
+      loading,
+      location,
+      minPop,
+      mobilityPruneMinSeedCapturePct,
+      resolvedSeedLookup,
+      seedGuardDistanceKm,
+      seedGuardNeedsResolvedSeed,
+      setAlgorithmMetadata,
+      setCbgGeoJSON,
+      setCityName,
+      setClusterAlgorithm,
+      setError,
+      setFocusedTraceCbg,
+      setGrowthTrace,
+      setGuidedDestinationError,
+      setGuidedDestinationLoading,
+      setGuidedDestinations,
+      setGuidedMetadata,
+      setGuidedSeedCbgs,
+      setLoading,
+      setMapCenter,
+      setMobilityPruneMinSeedCapturePct,
+      setPhase,
+      setResolvedSeedLookup,
+      setSeedCBG,
+      setSeedEditMode,
+      setSeedGuardDistanceKm,
+      setSelectedCBGs,
+      setSelectedGuidedDestinationIds,
+      setSelectedTraceCandidateCbg,
+      setSetupSeedGeoJSON,
+      setTotalPopulation,
+      setTraceEnabled,
+      setTraceStepIndex,
+      setUseTestData,
+      setZoneEditMode,
+      setupResolvedCityName,
+      setupSeedCbg,
+      setupSeedCbgs,
+      setupSeedGeoJSON,
+      startDate,
+      waitForClusteringResult
+    ]
+  );
+}

--- a/src/features/cz-generation/hooks/use-guided-selection-state.ts
+++ b/src/features/cz-generation/hooks/use-guided-selection-state.ts
@@ -1,0 +1,189 @@
+import { useEffect, useMemo, type Dispatch, type SetStateAction } from 'react';
+import {
+  GUIDED_REGION_PALETTE,
+  GUIDED_SEED_STYLE
+} from '@/features/cz-generation/constants';
+import { dedupeCbgList, sameStringArray } from '@/features/cz-generation/helpers';
+import type {
+  GuidedDestinationCandidate,
+  GuidedSecondOrderMetadata,
+  GuidedSelectionStyle
+} from '@/features/cz-generation/types';
+import { normalizeCbgId } from '@/lib/cz-geo';
+
+type UseGuidedSelectionStateParams = {
+  guidedSelectionMode: boolean;
+  guidedDestinations: GuidedDestinationCandidate[];
+  selectedGuidedDestinationIds: string[];
+  guidedMetadata: GuidedSecondOrderMetadata | null;
+  guidedSeedCbgs: string[];
+  setSelectedCBGs: Dispatch<SetStateAction<string[]>>;
+  setTotalPopulation: (value: number) => void;
+};
+
+export function useGuidedSelectionState({
+  guidedSelectionMode,
+  guidedDestinations,
+  selectedGuidedDestinationIds,
+  guidedMetadata,
+  guidedSeedCbgs,
+  setSelectedCBGs,
+  setTotalPopulation
+}: UseGuidedSelectionStateParams) {
+  const guidedSelectedDestinations = useMemo(
+    () =>
+      guidedDestinations.filter((destination) =>
+        selectedGuidedDestinationIds.includes(destination.unit_id)
+      ),
+    [guidedDestinations, selectedGuidedDestinationIds]
+  );
+
+  const guidedSelectionSummary = useMemo(() => {
+    const selectedLinkedOutboundFlow = guidedSelectedDestinations.reduce(
+      (sum, destination) =>
+        sum +
+        (destination.gateway_cbgs ?? []).reduce(
+          (inner, detail) => inner + Number(detail.seed_outbound_flow ?? 0),
+          0
+        ),
+      0
+    );
+    const selectedLinkedOutboundShare = Math.min(
+      1,
+      Number(guidedMetadata?.total_seed_external_outbound_flow ?? 0) > 0
+        ? selectedLinkedOutboundFlow /
+            Number(guidedMetadata?.total_seed_external_outbound_flow ?? 0)
+        : 0
+    );
+    const selectedExternalBidirectionalShare = Math.min(
+      1,
+      guidedSelectedDestinations.reduce(
+        (sum, destination) =>
+          sum + Number(destination.share_of_seed_external_bidirectional ?? 0),
+        0
+      )
+    );
+    const selectedSeedMovementShare = Math.min(
+      1,
+      guidedSelectedDestinations.reduce(
+        (sum, destination) =>
+          sum + Number(destination.share_of_seed_total_movement ?? 0),
+        0
+      )
+    );
+    const selectedPopulation =
+      Number(guidedMetadata?.seed_population ?? 0) +
+      guidedSelectedDestinations.reduce(
+        (sum, destination) => sum + Number(destination.population ?? 0),
+        0
+      );
+
+    return {
+      selectedLinkedOutboundFlow,
+      selectedLinkedOutboundShare,
+      selectedExternalBidirectionalShare,
+      selectedSeedMovementShare,
+      externalRemainderShare: Math.max(
+        0,
+        1 - selectedExternalBidirectionalShare
+      ),
+      selectedPopulation
+    };
+  }, [guidedMetadata, guidedSelectedDestinations]);
+
+  const guidedSeedLabel = useMemo(() => {
+    if (guidedMetadata?.seed_city_labels?.length) {
+      return guidedMetadata.seed_city_labels.join(', ');
+    }
+    if (guidedMetadata?.seed_zip_codes?.length) {
+      return guidedMetadata.seed_zip_codes.join(', ');
+    }
+    return `${guidedSeedCbgs.length} seed CBGs`;
+  }, [guidedMetadata, guidedSeedCbgs]);
+
+  const guidedSelectedDestinationSummary = useMemo(() => {
+    const labels = guidedSelectedDestinations
+      .map((destination) => destination.label)
+      .filter(Boolean);
+    if (labels.length === 0) {
+      return 'Seed only';
+    }
+    if (labels.length <= 3) {
+      return labels.join(', ');
+    }
+    return `${labels.slice(0, 3).join(', ')} +${labels.length - 3} more`;
+  }, [guidedSelectedDestinations]);
+
+  const guidedStyleByUnitId = useMemo(() => {
+    const styleMap = new Map<string, GuidedSelectionStyle>();
+    guidedSelectedDestinations.forEach((destination, index) => {
+      styleMap.set(
+        destination.unit_id,
+        GUIDED_REGION_PALETTE[index % GUIDED_REGION_PALETTE.length]
+      );
+    });
+    return styleMap;
+  }, [guidedSelectedDestinations]);
+
+  const guidedSelectionStyleByCbg = useMemo(() => {
+    if (!guidedSelectionMode) {
+      return null;
+    }
+
+    const styleMap = new Map<string, GuidedSelectionStyle>();
+    guidedSeedCbgs.forEach((cbg) => {
+      const normalized = normalizeCbgId(cbg);
+      if (normalized) {
+        styleMap.set(normalized, GUIDED_SEED_STYLE);
+      }
+    });
+    guidedSelectedDestinations.forEach((destination) => {
+      const style =
+        guidedStyleByUnitId.get(destination.unit_id) || GUIDED_SEED_STYLE;
+      destination.cbgs.forEach((cbg) => {
+        const normalized = normalizeCbgId(cbg);
+        if (normalized) {
+          styleMap.set(normalized, style);
+        }
+      });
+    });
+    return styleMap;
+  }, [
+    guidedSeedCbgs,
+    guidedSelectedDestinations,
+    guidedSelectionMode,
+    guidedStyleByUnitId
+  ]);
+
+  useEffect(() => {
+    if (!guidedSelectionMode) {
+      return;
+    }
+
+    const nextSelectedCBGs = dedupeCbgList([
+      ...guidedSeedCbgs,
+      ...guidedSelectedDestinations.flatMap((destination) => destination.cbgs)
+    ]);
+
+    setSelectedCBGs((prev) =>
+      sameStringArray(prev, nextSelectedCBGs) ? prev : nextSelectedCBGs
+    );
+    setTotalPopulation(guidedSelectionSummary.selectedPopulation);
+  }, [
+    guidedSeedCbgs,
+    guidedSelectedDestinations,
+    guidedSelectionMode,
+    guidedSelectionSummary.selectedPopulation,
+    setSelectedCBGs,
+    setTotalPopulation
+  ]);
+
+  return {
+    guidedSelectedDestinations,
+    guidedSelectionSummary,
+    guidedSeedLabel,
+    guidedSelectedDestinationSummary,
+    guidedStyleByUnitId,
+    guidedSelectionStyleByCbg
+  };
+}

--- a/src/features/cz-generation/hooks/use-manual-frontier-candidates.ts
+++ b/src/features/cz-generation/hooks/use-manual-frontier-candidates.ts
@@ -1,0 +1,137 @@
+import { useEffect, useState } from 'react';
+import {
+  fetchFrontierCandidates,
+  type FrontierCandidatesResponse
+} from '@/features/cz-generation/api';
+import type { ClusterAlgorithm } from '@/features/cz-generation/constants';
+import type { TraceCandidate } from '@/features/cz-generation/types';
+import { normalizeCbgId } from '@/lib/cz-geo';
+
+type UseManualFrontierCandidatesOptions = {
+  enabled: boolean;
+  seedCbg: string;
+  cbgs: string[];
+  clusterAlgorithm: ClusterAlgorithm;
+  minPop: number;
+  startDate: string;
+  useTestData: boolean;
+  seedGuardDistanceKm: number;
+  mobilityPruneMinSeedCapturePct: number;
+  selectedCbg: string;
+  onFallbackCbg: (cbg: string) => void;
+};
+
+export function useManualFrontierCandidates({
+  enabled,
+  seedCbg,
+  cbgs,
+  clusterAlgorithm,
+  minPop,
+  startDate,
+  useTestData,
+  seedGuardDistanceKm,
+  mobilityPruneMinSeedCapturePct,
+  selectedCbg,
+  onFallbackCbg
+}: UseManualFrontierCandidatesOptions) {
+  const [candidates, setCandidates] = useState<TraceCandidate[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (!enabled || !seedCbg || !cbgs.length) {
+      setCandidates([]);
+      setError('');
+      setLoading(false);
+      return undefined;
+    }
+
+    let cancelled = false;
+    setLoading(true);
+    setError('');
+
+    const req: Record<string, unknown> = {
+      seed_cbg: seedCbg,
+      cbg_list: cbgs,
+      algorithm: clusterAlgorithm,
+      min_pop: Number(minPop),
+      start_date: startDate,
+      use_test_data: useTestData,
+      limit: 2000
+    };
+
+    if (clusterAlgorithm === 'greedy_weight_seed_guard') {
+      if (Number.isFinite(Number(seedGuardDistanceKm))) {
+        req.seed_guard_distance_km = Number(seedGuardDistanceKm);
+      }
+    }
+    if (clusterAlgorithm === 'mobility_prune') {
+      const minSeedCapture = Number(mobilityPruneMinSeedCapturePct) / 100;
+      if (Number.isFinite(minSeedCapture)) {
+        req.mobility_prune_min_seed_capture = Math.min(
+          1,
+          Math.max(0, minSeedCapture)
+        );
+      }
+    }
+
+    fetchFrontierCandidates(req)
+      .then((data: FrontierCandidatesResponse) => {
+        if (cancelled) {
+          return;
+        }
+
+        const nextCandidates = Array.isArray(data?.candidates)
+          ? data.candidates
+          : [];
+        setCandidates(nextCandidates);
+
+        const selectedNow = normalizeCbgId(selectedCbg);
+        const selectedStillValid =
+          (selectedNow && cbgs.includes(selectedNow)) ||
+          nextCandidates.some(
+            (candidate) => normalizeCbgId(candidate?.cbg) === selectedNow
+          );
+
+        if (!selectedStillValid) {
+          onFallbackCbg(
+            normalizeCbgId(nextCandidates[0]?.cbg || cbgs[0] || '')
+          );
+        }
+      })
+      .catch((err) => {
+        if (cancelled) {
+          return;
+        }
+        setCandidates([]);
+        setError(
+          err instanceof Error
+            ? err.message
+            : 'Failed to load frontier candidates.'
+        );
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    cbgs,
+    clusterAlgorithm,
+    enabled,
+    minPop,
+    mobilityPruneMinSeedCapturePct,
+    onFallbackCbg,
+    seedCbg,
+    seedGuardDistanceKm,
+    selectedCbg,
+    startDate,
+    useTestData
+  ]);
+
+  return { candidates, loading, error };
+}

--- a/src/features/cz-generation/hooks/use-pattern-availability.ts
+++ b/src/features/cz-generation/hooks/use-pattern-availability.ts
@@ -1,0 +1,69 @@
+import { useEffect, useMemo, useState } from 'react';
+import { fetchPatternAvailability } from '@/features/cz-generation/api';
+
+export function usePatternAvailability(detectedStateAbbr: string | null) {
+  const [availableMonths, setAvailableMonths] = useState<string[]>([]);
+  const [availableMonthsLoading, setAvailableMonthsLoading] = useState(false);
+
+  useEffect(() => {
+    if (!detectedStateAbbr) {
+      setAvailableMonths([]);
+      setAvailableMonthsLoading(false);
+      return undefined;
+    }
+
+    const controller = new AbortController();
+    let cancelled = false;
+    setAvailableMonthsLoading(true);
+
+    fetchPatternAvailability(
+      {
+        state: detectedStateAbbr,
+        startDate: '2018-01-01',
+        endDate: '2025-12-31'
+      },
+      controller.signal
+    )
+      .then((resp) => {
+        if (cancelled) {
+          return;
+        }
+        const months = Array.isArray(resp?.data?.available_months)
+          ? resp.data.available_months.filter(
+              (month): month is string => typeof month === 'string'
+            )
+          : [];
+        setAvailableMonths(months);
+      })
+      .catch((err) => {
+        if ((err as Error).name === 'AbortError') {
+          return;
+        }
+        console.warn('Failed to load available months:', err);
+        if (!cancelled) {
+          setAvailableMonths([]);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setAvailableMonthsLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [detectedStateAbbr]);
+
+  const monthOptions = useMemo(
+    () => [...availableMonths].sort(),
+    [availableMonths]
+  );
+
+  return {
+    availableMonths,
+    availableMonthsLoading,
+    monthOptions
+  };
+}

--- a/src/features/cz-generation/hooks/use-seed-editing.ts
+++ b/src/features/cz-generation/hooks/use-seed-editing.ts
@@ -1,0 +1,474 @@
+import { useCallback, useMemo, useState } from 'react';
+import { fetchCbgGeoJson } from '@/features/cz-generation/api';
+import {
+  CBG_GEOJSON_REQUEST_CHUNK_SIZE,
+  INITIAL_SEED_EDIT_NEIGHBOR_RINGS
+} from '@/features/cz-generation/constants';
+import {
+  dedupeCbgList,
+  filterGeoJsonByCbgs,
+  getCbgIdsFromGeoJson,
+  sameStringArray
+} from '@/features/cz-generation/helpers';
+import type {
+  ResolvedSeedLookup,
+  SeedEditAction
+} from '@/features/cz-generation/types';
+import {
+  type GeoJSONData,
+  mergeGeoJsonFeatures,
+  normalizeCbgId
+} from '@/lib/cz-geo';
+
+type ApplyResolvedSeedPreviewArgs = {
+  query: string;
+  coreCbg: string;
+  seedName: string;
+  seedCbgs: string[];
+  seedGeoJson: GeoJSONData;
+  cityName: string;
+  seedZip?: string;
+};
+
+export function useSeedEditing() {
+  const [setupSeedCbg, setSetupSeedCbg] = useState('');
+  const [setupSeedLabel, setSetupSeedLabel] = useState('');
+  const [setupSeedCount, setSetupSeedCount] = useState(0);
+  const [setupSeedCbgs, setSetupSeedCbgs] = useState<string[]>([]);
+  const [resolvedSetupSeedCbgs, setResolvedSetupSeedCbgs] = useState<string[]>(
+    []
+  );
+  const [setupSeedGeoJSON, setSetupSeedGeoJSON] =
+    useState<GeoJSONData | null>(null);
+  const [seedEditGeoJSON, setSeedEditGeoJSON] =
+    useState<GeoJSONData | null>(null);
+  const [seedEditMode, setSeedEditMode] = useState(false);
+  const [seedEditAction, setSeedEditAction] = useState<SeedEditAction>('add');
+  const [seedEditLoading, setSeedEditLoading] = useState(false);
+  const [seedEditError, setSeedEditError] = useState('');
+  const [seedEditStartCbgs, setSeedEditStartCbgs] = useState<string[]>([]);
+  const [seedEditNeighborRings, setSeedEditNeighborRings] = useState(0);
+  const [setupResolvedCityName, setSetupResolvedCityName] = useState('');
+  const [resolvedSeedLookup, setResolvedSeedLookup] =
+    useState<ResolvedSeedLookup | null>(null);
+  const [seedResolveError, setSeedResolveError] = useState('');
+
+  const seedAdjustmentSummary = useMemo(() => {
+    const resolvedSet = new Set(resolvedSetupSeedCbgs);
+    const currentSet = new Set(setupSeedCbgs);
+    const addedCount = setupSeedCbgs.filter(
+      (cbg) => !resolvedSet.has(cbg)
+    ).length;
+    const removedCount = resolvedSetupSeedCbgs.filter(
+      (cbg) => !currentSet.has(cbg)
+    ).length;
+
+    return {
+      addedCount,
+      removedCount,
+      hasChanges: addedCount > 0 || removedCount > 0
+    };
+  }, [resolvedSetupSeedCbgs, setupSeedCbgs]);
+
+  const activeSetupSeedGeoJSON = seedEditMode
+    ? seedEditGeoJSON || setupSeedGeoJSON
+    : setupSeedGeoJSON;
+
+  const resetSeedPreview = useCallback(() => {
+    setSetupSeedCbg('');
+    setSetupSeedLabel('');
+    setSetupSeedCount(0);
+    setSetupSeedCbgs([]);
+    setResolvedSetupSeedCbgs([]);
+    setSetupSeedGeoJSON(null);
+    setSeedEditGeoJSON(null);
+    setSeedEditMode(false);
+    setSeedEditAction('add');
+    setSeedEditLoading(false);
+    setSeedEditError('');
+    setSeedEditStartCbgs([]);
+    setSeedEditNeighborRings(0);
+    setSetupResolvedCityName('');
+    setResolvedSeedLookup(null);
+    setSeedResolveError('');
+  }, []);
+
+  const loadSeedGeoJson = useCallback(
+    async (seedCbgs: string[], includeNeighbors: boolean) => {
+      const normalizedSeedCbgs = dedupeCbgList(seedCbgs);
+      if (!normalizedSeedCbgs.length) {
+        throw new Error('Select at least one seed CBG.');
+      }
+
+      let mergedGeoJson: GeoJSONData | null = null;
+      for (
+        let index = 0;
+        index < normalizedSeedCbgs.length;
+        index += CBG_GEOJSON_REQUEST_CHUNK_SIZE
+      ) {
+        const chunk = normalizedSeedCbgs.slice(
+          index,
+          index + CBG_GEOJSON_REQUEST_CHUNK_SIZE
+        );
+        const seedGeoJson = await fetchCbgGeoJson(chunk, includeNeighbors);
+        if (!seedGeoJson?.features?.length) {
+          throw new Error(
+            seedGeoJson?.message ||
+              'Resolved the seed CBGs, but could not load their map boundary.'
+          );
+        }
+
+        mergedGeoJson = mergeGeoJsonFeatures(
+          mergedGeoJson,
+          seedGeoJson as GeoJSONData
+        );
+      }
+
+      if (!mergedGeoJson?.features?.length) {
+        throw new Error(
+          'Resolved the seed CBGs, but could not load their map boundary.'
+        );
+      }
+
+      return mergedGeoJson;
+    },
+    []
+  );
+
+  const loadSeedEditGeoJson = useCallback(
+    async (seedCbgs: string[], neighborRings: number) => {
+      const rings = Math.max(1, Math.floor(neighborRings));
+      let queryCbgs = dedupeCbgList(seedCbgs);
+      let mergedGeoJson: GeoJSONData | null = null;
+
+      for (let ringIndex = 0; ringIndex < rings; ringIndex += 1) {
+        const ringGeoJson = await loadSeedGeoJson(queryCbgs, true);
+        const nextMergedGeoJson = mergeGeoJsonFeatures(
+          mergedGeoJson,
+          ringGeoJson
+        );
+        const nextQueryCbgs = getCbgIdsFromGeoJson(nextMergedGeoJson);
+
+        mergedGeoJson = nextMergedGeoJson;
+        if (sameStringArray(nextQueryCbgs, queryCbgs)) {
+          break;
+        }
+        queryCbgs = nextQueryCbgs;
+      }
+
+      return mergeGeoJsonFeatures(setupSeedGeoJSON, mergedGeoJson);
+    },
+    [loadSeedGeoJson, setupSeedGeoJSON]
+  );
+
+  const refreshSeedEditGeoJson = useCallback(
+    async (seedCbgs: string[], neighborRings: number) => {
+      const editGeoJson = await loadSeedEditGeoJson(seedCbgs, neighborRings);
+      setSeedEditGeoJSON(editGeoJson);
+      setSeedEditNeighborRings(
+        Math.max(
+          1,
+          Math.floor(neighborRings || INITIAL_SEED_EDIT_NEIGHBOR_RINGS)
+        )
+      );
+    },
+    [loadSeedEditGeoJson]
+  );
+
+  const commitSetupSeedCbgs = useCallback(
+    (nextSeedCbgs: string[]) => {
+      const normalizedSeedCbgs = dedupeCbgList(nextSeedCbgs);
+      if (!normalizedSeedCbgs.length) {
+        setSeedEditError('Keep at least one CBG in the seed area.');
+        return null;
+      }
+
+      const currentAnchor = normalizeCbgId(setupSeedCbg);
+      const nextAnchor = normalizedSeedCbgs.includes(currentAnchor)
+        ? currentAnchor
+        : normalizedSeedCbgs[0];
+      const sourceGeoJson = seedEditGeoJSON || setupSeedGeoJSON;
+      const selectedGeoJson = filterGeoJsonByCbgs(
+        sourceGeoJson,
+        normalizedSeedCbgs
+      );
+
+      setSetupSeedCbgs(normalizedSeedCbgs);
+      setSetupSeedCount(normalizedSeedCbgs.length);
+      setSetupSeedCbg(nextAnchor);
+      setSeedEditError('');
+      if (selectedGeoJson) {
+        setSetupSeedGeoJSON(selectedGeoJson);
+      }
+      setResolvedSeedLookup((prev) =>
+        prev
+          ? {
+              ...prev,
+              cbg: nextAnchor,
+              seedCbgs: normalizedSeedCbgs
+            }
+          : prev
+      );
+
+      return normalizedSeedCbgs;
+    },
+    [seedEditGeoJSON, setupSeedCbg, setupSeedGeoJSON]
+  );
+
+  const beginSeedEdit = useCallback(async () => {
+    if (!setupSeedCbgs.length) {
+      return;
+    }
+
+    setSeedEditMode(true);
+    setSeedEditAction('add');
+    setSeedEditStartCbgs(setupSeedCbgs);
+    setSeedEditError('');
+    setSeedEditLoading(true);
+    try {
+      await refreshSeedEditGeoJson(
+        setupSeedCbgs,
+        INITIAL_SEED_EDIT_NEIGHBOR_RINGS
+      );
+    } catch (err) {
+      setSeedEditError(
+        err instanceof Error
+          ? err.message
+          : 'Could not load nearby CBGs for seed adjustment.'
+      );
+    } finally {
+      setSeedEditLoading(false);
+    }
+  }, [refreshSeedEditGeoJson, setupSeedCbgs]);
+
+  const updateEditableSeedSelection = useCallback(
+    async (cbgIds: string[]) => {
+      const normalizedClickedCbgs = dedupeCbgList(cbgIds);
+      if (!normalizedClickedCbgs.length) {
+        return;
+      }
+
+      const clickedSet = new Set(normalizedClickedCbgs);
+      const currentSet = new Set(setupSeedCbgs);
+      const nextSeedCbgs =
+        seedEditAction === 'add'
+          ? dedupeCbgList([...setupSeedCbgs, ...normalizedClickedCbgs])
+          : setupSeedCbgs.filter((cbg) => !clickedSet.has(cbg));
+
+      if (seedEditAction === 'add' && nextSeedCbgs.length === currentSet.size) {
+        return;
+      }
+
+      if (seedEditAction === 'remove' && nextSeedCbgs.length === 0) {
+        setSeedEditError('Keep at least one CBG in the seed area.');
+        return;
+      }
+
+      const committedSeedCbgs = commitSetupSeedCbgs(nextSeedCbgs);
+      if (
+        !committedSeedCbgs ||
+        sameStringArray(committedSeedCbgs, setupSeedCbgs)
+      ) {
+        return;
+      }
+
+      setSeedEditLoading(true);
+      try {
+        await refreshSeedEditGeoJson(
+          committedSeedCbgs,
+          seedEditNeighborRings || INITIAL_SEED_EDIT_NEIGHBOR_RINGS
+        );
+      } catch (err) {
+        setSeedEditError(
+          err instanceof Error
+            ? err.message
+            : 'Could not refresh nearby CBGs after updating the seed area.'
+        );
+      } finally {
+        setSeedEditLoading(false);
+      }
+    },
+    [
+      commitSetupSeedCbgs,
+      refreshSeedEditGeoJson,
+      seedEditAction,
+      seedEditNeighborRings,
+      setupSeedCbgs
+    ]
+  );
+
+  const finishSeedEdit = useCallback(() => {
+    setSeedEditMode(false);
+    setSeedEditGeoJSON(null);
+    setSeedEditStartCbgs([]);
+    setSeedEditError('');
+  }, []);
+
+  const cancelSeedEdit = useCallback(() => {
+    const committedSeedCbgs = commitSetupSeedCbgs(seedEditStartCbgs);
+    if (committedSeedCbgs) {
+      setSeedEditMode(false);
+      setSeedEditGeoJSON(null);
+      setSeedEditStartCbgs([]);
+      setSeedEditError('');
+    }
+  }, [commitSetupSeedCbgs, seedEditStartCbgs]);
+
+  const resetAdjustedSeed = useCallback(async () => {
+    const committedSeedCbgs = commitSetupSeedCbgs(resolvedSetupSeedCbgs);
+    if (!committedSeedCbgs) {
+      return;
+    }
+
+    setSeedEditLoading(true);
+    try {
+      if (seedEditMode) {
+        await refreshSeedEditGeoJson(
+          committedSeedCbgs,
+          seedEditNeighborRings || INITIAL_SEED_EDIT_NEIGHBOR_RINGS
+        );
+      } else {
+        const seedGeoJson = await loadSeedGeoJson(committedSeedCbgs, false);
+        setSetupSeedGeoJSON(seedGeoJson);
+      }
+      setSeedEditError('');
+    } catch (err) {
+      setSeedEditError(
+        err instanceof Error
+          ? err.message
+          : 'Could not reset the seed area boundary.'
+      );
+    } finally {
+      setSeedEditLoading(false);
+    }
+  }, [
+    commitSetupSeedCbgs,
+    loadSeedGeoJson,
+    refreshSeedEditGeoJson,
+    resolvedSetupSeedCbgs,
+    seedEditNeighborRings,
+    seedEditMode
+  ]);
+
+  const showMoreSeedEditNeighbors = useCallback(async () => {
+    if (!seedEditMode || !setupSeedCbgs.length) {
+      return;
+    }
+
+    const nextNeighborRings = Math.max(
+      seedEditNeighborRings + 1,
+      INITIAL_SEED_EDIT_NEIGHBOR_RINGS + 1
+    );
+
+    setSeedEditLoading(true);
+    setSeedEditError('');
+    try {
+      await refreshSeedEditGeoJson(setupSeedCbgs, nextNeighborRings);
+    } catch (err) {
+      setSeedEditError(
+        err instanceof Error
+          ? err.message
+          : 'Could not load a wider nearby area.'
+      );
+    } finally {
+      setSeedEditLoading(false);
+    }
+  }, [
+    refreshSeedEditGeoJson,
+    seedEditMode,
+    seedEditNeighborRings,
+    setupSeedCbgs
+  ]);
+
+  const applyResolvedSeedPreview = useCallback(
+    ({
+      query,
+      coreCbg,
+      seedName,
+      seedCbgs,
+      seedGeoJson,
+      cityName,
+      seedZip
+    }: ApplyResolvedSeedPreviewArgs) => {
+      setSetupSeedCbg(coreCbg);
+      setSetupSeedLabel(seedName);
+      setSetupSeedCount(seedCbgs.length);
+      setSetupSeedCbgs(seedCbgs);
+      setResolvedSetupSeedCbgs(seedCbgs);
+      setSetupSeedGeoJSON(seedGeoJson);
+      setSeedEditGeoJSON(null);
+      setSeedEditMode(false);
+      setSeedEditAction('add');
+      setSeedEditError('');
+      setSeedEditStartCbgs([]);
+      setSeedEditNeighborRings(0);
+      setSetupResolvedCityName(cityName);
+      setResolvedSeedLookup({
+        query,
+        cbg: coreCbg,
+        cityName,
+        seedName,
+        seedCbgs,
+        seedZip
+      });
+    },
+    []
+  );
+
+  const clearSeedPreviewWithError = useCallback((message: string) => {
+    setSetupSeedCbg('');
+    setSetupSeedLabel('');
+    setSetupSeedCount(0);
+    setSetupSeedCbgs([]);
+    setResolvedSetupSeedCbgs([]);
+    setSetupSeedGeoJSON(null);
+    setSeedEditGeoJSON(null);
+    setSeedEditMode(false);
+    setSeedEditAction('add');
+    setSeedEditError('');
+    setSeedEditStartCbgs([]);
+    setSeedEditNeighborRings(0);
+    setSetupResolvedCityName('');
+    setResolvedSeedLookup(null);
+    setSeedResolveError(message);
+  }, []);
+
+  const seedStateCbg =
+    setupSeedCbg || setupSeedCbgs[0] || resolvedSeedLookup?.cbg || '';
+
+  return {
+    setupSeedCbg,
+    setupSeedLabel,
+    setupSeedCount,
+    setupSeedCbgs,
+    resolvedSetupSeedCbgs,
+    setupSeedGeoJSON,
+    seedEditGeoJSON,
+    seedEditMode,
+    seedEditAction,
+    seedEditLoading,
+    seedEditError,
+    seedEditNeighborRings,
+    setupResolvedCityName,
+    resolvedSeedLookup,
+    seedResolveError,
+    seedAdjustmentSummary,
+    activeSetupSeedGeoJSON,
+    seedStateCbg,
+    setSetupSeedGeoJSON,
+    setSeedEditMode,
+    setSeedEditAction,
+    setResolvedSeedLookup,
+    setSeedResolveError,
+    resetSeedPreview,
+    loadSeedGeoJson,
+    beginSeedEdit,
+    updateEditableSeedSelection,
+    finishSeedEdit,
+    cancelSeedEdit,
+    resetAdjustedSeed,
+    showMoreSeedEditNeighbors,
+    applyResolvedSeedPreview,
+    clearSeedPreviewWithError
+  };
+}

--- a/src/features/cz-generation/hooks/use-zone-finalization.ts
+++ b/src/features/cz-generation/hooks/use-zone-finalization.ts
@@ -1,0 +1,396 @@
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+import {
+  exportCzMapHtml,
+  finalizeConvenienceZone
+} from '@/features/cz-generation/api';
+import {
+  CLUSTER_ALGORITHM_OPTIONS,
+  GUIDED_HARD_EXPLICIT_POPULATION,
+  type ClusterAlgorithm
+} from '@/features/cz-generation/constants';
+import { getLengthHours } from '@/features/cz-generation/helpers';
+import type {
+  GuidedDestinationCandidate,
+  GuidedSecondOrderMetadata,
+  GuidedSelectionSummary
+} from '@/features/cz-generation/types';
+import { useSession } from '@/lib/auth-client';
+import {
+  createGuestZoneClaimToken,
+  rememberGuestZoneClaim
+} from '@/lib/guest-zone-claims';
+import useSimSettings, { type ConvenienceZone } from '@/stores/simsettings';
+
+type Phase = 'input' | 'edit' | 'finalizing';
+
+type UseZoneFinalizationParams = {
+  selectedCBGs: string[];
+  startDate: string;
+  endDate: string;
+  guidedSelectionMode: boolean;
+  guidedSelectionSummary: GuidedSelectionSummary;
+  description: string;
+  setDescription: (value: string) => void;
+  cityName: string;
+  location: string;
+  seedCBG: string;
+  clusterAlgorithm: ClusterAlgorithm;
+  mobilityPruneMinSeedCapturePct: number;
+  isGuidedSecondOrderAlgorithm: boolean;
+  minPop: number;
+  useTestData: boolean;
+  guidedMetadata: GuidedSecondOrderMetadata | null;
+  guidedSelectedDestinations: GuidedDestinationCandidate[];
+  seedGuardDistanceKm: number;
+  mapCenter: [number, number] | null;
+  setError: (value: string) => void;
+  setPhase: (value: Phase) => void;
+};
+
+async function fetchZoneById(
+  zoneId: number,
+  guestClaimToken?: string | null
+): Promise<ConvenienceZone | null> {
+  try {
+    const response = await fetch(`/api/convenience-zones/${zoneId}`, {
+      headers: guestClaimToken
+        ? { 'X-Delineo-Guest-Zone-Claims': guestClaimToken }
+        : {}
+    });
+    if (!response.ok) {
+      return null;
+    }
+    const json = await response.json().catch(() => ({}));
+    const zone = json?.data as ConvenienceZone | undefined;
+    return zone?.ready ? zone : null;
+  } catch {
+    return null;
+  }
+}
+
+function waitForZoneReady(
+  zoneId: number,
+  onProgress: (percent: number) => void,
+  guestClaimToken?: string | null
+): Promise<ConvenienceZone | null> {
+  return new Promise((resolve) => {
+    let done = false;
+    let currentProgress = 15;
+    let eventSource: EventSource | null = null;
+
+    const finish = (zone: ConvenienceZone | null) => {
+      if (done) {
+        return;
+      }
+      done = true;
+      if (progressTimer) {
+        clearInterval(progressTimer);
+      }
+      if (pollTimer) {
+        clearInterval(pollTimer);
+      }
+      if (eventSource) {
+        eventSource.close();
+      }
+      resolve(zone);
+    };
+
+    const progressTimer = window.setInterval(() => {
+      if (done) {
+        return;
+      }
+      currentProgress = Math.min(
+        92,
+        currentProgress + (92 - currentProgress) * 0.05
+      );
+      onProgress(Math.round(currentProgress));
+    }, 1000);
+
+    const checkReady = async () => {
+      const zone = await fetchZoneById(zoneId, guestClaimToken);
+      if (zone) {
+        finish(zone);
+      }
+    };
+
+    const pollTimer = window.setInterval(checkReady, 5000);
+
+    try {
+      eventSource = new EventSource('/api/convenience-zones/events');
+      eventSource.onmessage = (event) => {
+        try {
+          const payload = JSON.parse(event.data);
+          if (
+            payload?.type === 'zone-ready' &&
+            Number(payload.zone_id) === zoneId
+          ) {
+            checkReady();
+          }
+        } catch {
+          // Ignore non-JSON heartbeats.
+        }
+      };
+      eventSource.onerror = () => {
+        // Polling remains as fallback.
+      };
+    } catch {
+      // EventSource may be unavailable; polling will still run.
+    }
+
+    checkReady();
+  });
+}
+
+export function useZoneFinalization({
+  selectedCBGs,
+  startDate,
+  endDate,
+  guidedSelectionMode,
+  guidedSelectionSummary,
+  description,
+  setDescription,
+  cityName,
+  location,
+  seedCBG,
+  clusterAlgorithm,
+  mobilityPruneMinSeedCapturePct,
+  isGuidedSecondOrderAlgorithm,
+  minPop,
+  useTestData,
+  guidedMetadata,
+  guidedSelectedDestinations,
+  seedGuardDistanceKm,
+  mapCenter,
+  setError,
+  setPhase
+}: UseZoneFinalizationParams) {
+  const router = useRouter();
+  const { data: session, isPending } = useSession();
+  const user = session?.user;
+  const setSettings = useSimSettings((state) => state.setSettings);
+  const [savingHtmlMap, setSavingHtmlMap] = useState(false);
+  const [finalizeProgress, setFinalizeProgress] = useState(0);
+  const [finalizeStatusMessage, setFinalizeStatusMessage] = useState('');
+
+  const finalizeCZ = async () => {
+    if (selectedCBGs.length === 0) {
+      setError('Please select at least one CBG');
+      return;
+    }
+
+    if (isPending) {
+      setError(
+        'Please wait while we check whether this zone should be saved to your account.'
+      );
+      return;
+    }
+
+    const lengthHours = getLengthHours(startDate, endDate);
+    if (!lengthHours || lengthHours <= 0) {
+      setError('End date must be after start date.');
+      return;
+    }
+
+    if (
+      guidedSelectionMode &&
+      guidedSelectionSummary.selectedPopulation >
+        GUIDED_HARD_EXPLICIT_POPULATION
+    ) {
+      setError(
+        `Guided explicit population is ${Number(
+          guidedSelectionSummary.selectedPopulation
+        ).toLocaleString()}, which is above the supported cap of ${GUIDED_HARD_EXPLICIT_POPULATION.toLocaleString()}. Remove some connected cities before finalizing.`
+      );
+      return;
+    }
+
+    setPhase('finalizing');
+    setError('');
+    setFinalizeProgress(5);
+    setFinalizeStatusMessage('Creating convenience zone...');
+
+    try {
+      const trimmedDescription = String(description ?? '').trim();
+      const now = new Date();
+      const algorithmLabel =
+        CLUSTER_ALGORITHM_OPTIONS.find(
+          (option) => option.value === clusterAlgorithm
+        )?.label || clusterAlgorithm;
+
+      const generatedDescription = [
+        `Auto-generated on ${now.toLocaleString()}`,
+        `Location: ${cityName || location || 'N/A'}`,
+        `Seed CBG: ${seedCBG || 'N/A'}`,
+        `Algorithm: ${algorithmLabel}`,
+        clusterAlgorithm === 'mobility_prune'
+          ? `Minimum seed movement captured: ${Number(
+              mobilityPruneMinSeedCapturePct || 0
+            ).toFixed(0)}%`
+          : isGuidedSecondOrderAlgorithm
+            ? 'Minimum population filter: not used in guided connected cities mode'
+            : `Minimum population: ${Number(minPop || 0).toLocaleString()}`,
+        `Date range: ${startDate} to ${endDate}`,
+        `CBGs in zone: ${selectedCBGs.length}`,
+        `Test data mode: ${useTestData ? 'Yes' : 'No'}`
+      ];
+
+      if (isGuidedSecondOrderAlgorithm && guidedMetadata) {
+        const selectedLabels = guidedSelectedDestinations.map(
+          (destination) => destination.label
+        );
+        generatedDescription.push(
+          `Seed region: ${
+            guidedMetadata.seed_city_labels?.join(', ') ||
+            guidedMetadata.seed_zip_codes?.join(', ') ||
+            `${guidedMetadata.seed_cbgs.length} seed CBGs`
+          }`
+        );
+        generatedDescription.push(
+          `Selected connected cities: ${
+            selectedLabels.length ? selectedLabels.join(', ') : 'Seed only'
+          }`
+        );
+        generatedDescription.push(
+          `Explicit linked CBGs: ${selectedCBGs.length}`
+        );
+        generatedDescription.push(
+          `Explicit population: ${Number(
+            guidedSelectionSummary.selectedPopulation || 0
+          ).toLocaleString()}`
+        );
+        generatedDescription.push(
+          `Captured external outbound flow (linked CBGs): ${(
+            guidedSelectionSummary.selectedLinkedOutboundShare * 100
+          ).toFixed(1)}%`
+        );
+        generatedDescription.push(
+          `Captured total seed movement: ${(
+            guidedSelectionSummary.selectedSeedMovementShare * 100
+          ).toFixed(1)}%`
+        );
+        generatedDescription.push(
+          `Unmodeled external pressure: ${(
+            guidedSelectionSummary.externalRemainderShare * 100
+          ).toFixed(1)}%`
+        );
+      }
+
+      if (clusterAlgorithm === 'greedy_weight_seed_guard') {
+        generatedDescription.push(
+          `Seed guard distance (km): ${seedGuardDistanceKm}`
+        );
+      }
+      const descriptionToSave =
+        trimmedDescription || generatedDescription.join('\n');
+      if (!trimmedDescription) {
+        setDescription(descriptionToSave);
+      }
+
+      const guestClaimToken = user?.id ? null : createGuestZoneClaimToken();
+
+      const finalizePayload = {
+        name: cityName,
+        description: descriptionToSave,
+        cbg_list: selectedCBGs,
+        start_date: new Date(`${startDate}T00:00:00`).toISOString(),
+        length: lengthHours,
+        latitude: mapCenter?.[0] || 0,
+        longitude: mapCenter?.[1] || 0,
+        use_test_data: useTestData,
+        ...(user?.id ? { user_id: user.id } : {}),
+        ...(guestClaimToken ? { guest_claim_token: guestClaimToken } : {})
+      };
+
+      const data = await finalizeConvenienceZone(finalizePayload);
+      if (!data?.id) {
+        throw new Error(
+          data?.message ||
+            'Failed to create convenience zone. Please try again.'
+        );
+      }
+
+      const zoneId: number = data.id;
+      if (guestClaimToken) {
+        rememberGuestZoneClaim(zoneId, guestClaimToken);
+      }
+      setFinalizeProgress(15);
+      setFinalizeStatusMessage(
+        user?.id
+          ? 'Zone saved. Generating movement patterns...'
+          : 'Zone generated. Generating movement patterns...'
+      );
+
+      const readyZone = await waitForZoneReady(
+        zoneId,
+        (percent) => {
+          setFinalizeProgress(percent);
+        },
+        guestClaimToken
+      );
+
+      if (readyZone) {
+        setSettings({
+          zone: readyZone,
+          hours: readyZone.length,
+          sim_id: null
+        });
+      }
+
+      setFinalizeProgress(100);
+      setFinalizeStatusMessage('Generation complete. Opening simulator...');
+
+      router.push('/simulator');
+    } catch (err) {
+      console.error('Error finalizing CZ:', err);
+      setError(
+        err instanceof Error
+          ? err.message
+          : 'Failed to create convenience zone. Please try again.'
+      );
+      setPhase('edit');
+    }
+  };
+
+  const saveCZHtmlMap = async () => {
+    if (!selectedCBGs.length) {
+      setError('Please select at least one CBG');
+      return;
+    }
+
+    setSavingHtmlMap(true);
+    try {
+      const suggestedName =
+        String(cityName || location || 'cz-map').trim() || 'cz-map';
+      const exportedMap = await exportCzMapHtml({
+        cbg_list: selectedCBGs,
+        name: suggestedName
+      });
+
+      const url = URL.createObjectURL(exportedMap.blob);
+      const anchor = document.createElement('a');
+      anchor.href = url;
+      anchor.download = exportedMap.filename;
+      document.body.appendChild(anchor);
+      anchor.click();
+      anchor.remove();
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      console.error('Failed to save CZ HTML map:', err);
+      setError(
+        err instanceof Error ? err.message : 'Failed to export the CZ HTML map.'
+      );
+    } finally {
+      setSavingHtmlMap(false);
+    }
+  };
+
+  return {
+    isPending,
+    savingHtmlMap,
+    finalizeProgress,
+    finalizeStatusMessage,
+    finalizeCZ,
+    saveCZHtmlMap
+  };
+}

--- a/src/features/cz-generation/types.ts
+++ b/src/features/cz-generation/types.ts
@@ -198,6 +198,15 @@ export type GuidedSecondOrderMetadata = {
   recommended_explicit_population_cap?: number;
 };
 
+export type GuidedSelectionSummary = {
+  selectedLinkedOutboundFlow: number;
+  selectedLinkedOutboundShare: number;
+  selectedExternalBidirectionalShare: number;
+  selectedSeedMovementShare: number;
+  externalRemainderShare: number;
+  selectedPopulation: number;
+};
+
 export type GuidedSelectionStyle = {
   fillColor: string;
   lineColor: string;

--- a/src/features/model-map/map-data.ts
+++ b/src/features/model-map/map-data.ts
@@ -1,116 +1,36 @@
-export type Coordinate = [number, number];
+import type {
+  Coordinate,
+  GeoJSONData,
+  GeoJSONFeature,
+  GeoJSONGeometry,
+  HotspotsByLocation,
+  HouseholdCircleDraft,
+  HouseholdCircleLayout,
+  HouseholdLayoutBundle,
+  MapLocation,
+  MapPoi,
+  MapPoiType,
+  PapDataForMap,
+  PeopleDotFeature,
+  PeopleDotFeatureCollection,
+  PoiFeatureCollection,
+  SimTimeDataForMap
+} from './map-types';
 
-export type GeoJSONGeometry = {
-  type?: string;
-  coordinates?: unknown;
-};
-
-export type GeoJSONFeature = {
-  type?: string;
-  properties?: Record<string, unknown>;
-  geometry?: GeoJSONGeometry | null;
-};
-
-export type GeoJSONData = {
-  type?: string;
-  features?: GeoJSONFeature[];
-};
-
-export type HotspotsByLocation = Record<string, number[]>;
-
-export type MapLocation = {
-  id: string | number;
-  cbg?: unknown;
-  latitude?: unknown;
-  longitude?: unknown;
-  label?: string;
-  top_category?: string;
-  footprint?: GeoJSONGeometry | null;
-};
-
-export type PapDataForMap = {
-  homes?: MapLocation[];
-  places?: MapLocation[];
-};
-
-export type SimTimeDataForMap = {
-  h?: number[];
-  p?: number[];
-};
-
-export type MapPoiType = 'homes' | 'places';
-
-export type MapPoi = {
-  type: MapPoiType;
-  id: string | number;
-  latitude: number;
-  longitude: number;
-  label: string;
-  description: string;
-  footprint: GeoJSONGeometry | null;
-  icon: string;
-  population: number;
-  infected: number;
-};
-
-type HouseholdCircleLayout = {
-  anchorLat: number;
-  anchorLng: number;
-  centerLat: number;
-  centerLng: number;
-  radiusLat: number;
-  radiusLng: number;
-};
-
-type HouseholdLayoutBundle = {
-  fallback: HouseholdCircleLayout;
-  byCbg: Record<string, HouseholdCircleLayout>;
-};
-
-type HouseholdCircleDraft = {
-  cbgId: string;
-  anchorLat: number;
-  anchorLng: number;
-  x: number;
-  y: number;
-  radius: number;
-  homeCount: number;
-};
-
-type PeopleDotFeature = {
-  type: 'Feature';
-  properties: {
-    id: string;
-    loc_id: string | number;
-    loc_type: MapPoiType;
-    label: string;
-  };
-  geometry: {
-    type: 'Point';
-    coordinates: Coordinate;
-  };
-};
-
-export type PeopleDotFeatureCollection = {
-  type: 'FeatureCollection';
-  features: PeopleDotFeature[];
-};
-
-type PoiFeature = {
-  type: 'Feature';
-  properties: MapPoi & {
-    infection_ratio: number;
-  };
-  geometry: {
-    type: 'Point';
-    coordinates: Coordinate;
-  };
-};
-
-export type PoiFeatureCollection = {
-  type: 'FeatureCollection';
-  features: PoiFeature[];
-};
+export type {
+  Coordinate,
+  GeoJSONData,
+  GeoJSONFeature,
+  GeoJSONGeometry,
+  HotspotsByLocation,
+  MapLocation,
+  MapPoi,
+  MapPoiType,
+  PapDataForMap,
+  PeopleDotFeatureCollection,
+  PoiFeatureCollection,
+  SimTimeDataForMap
+} from './map-types';
 
 export const iconLookup: Record<string, string> = {
   'Depository Credit Intermediation': '🏦',

--- a/src/features/model-map/map-types.ts
+++ b/src/features/model-map/map-types.ts
@@ -1,0 +1,113 @@
+export type Coordinate = [number, number];
+
+export type GeoJSONGeometry = {
+  type?: string;
+  coordinates?: unknown;
+};
+
+export type GeoJSONFeature = {
+  type?: string;
+  properties?: Record<string, unknown>;
+  geometry?: GeoJSONGeometry | null;
+};
+
+export type GeoJSONData = {
+  type?: string;
+  features?: GeoJSONFeature[];
+};
+
+export type HotspotsByLocation = Record<string, number[]>;
+
+export type MapLocation = {
+  id: string | number;
+  cbg?: unknown;
+  latitude?: unknown;
+  longitude?: unknown;
+  label?: string;
+  top_category?: string;
+  footprint?: GeoJSONGeometry | null;
+};
+
+export type PapDataForMap = {
+  homes?: MapLocation[];
+  places?: MapLocation[];
+};
+
+export type SimTimeDataForMap = {
+  h?: number[];
+  p?: number[];
+};
+
+export type MapPoiType = 'homes' | 'places';
+
+export type MapPoi = {
+  type: MapPoiType;
+  id: string | number;
+  latitude: number;
+  longitude: number;
+  label: string;
+  description: string;
+  footprint: GeoJSONGeometry | null;
+  icon: string;
+  population: number;
+  infected: number;
+};
+
+export type HouseholdCircleLayout = {
+  anchorLat: number;
+  anchorLng: number;
+  centerLat: number;
+  centerLng: number;
+  radiusLat: number;
+  radiusLng: number;
+};
+
+export type HouseholdLayoutBundle = {
+  fallback: HouseholdCircleLayout;
+  byCbg: Record<string, HouseholdCircleLayout>;
+};
+
+export type HouseholdCircleDraft = {
+  cbgId: string;
+  anchorLat: number;
+  anchorLng: number;
+  x: number;
+  y: number;
+  radius: number;
+  homeCount: number;
+};
+
+export type PeopleDotFeature = {
+  type: 'Feature';
+  properties: {
+    id: string;
+    loc_id: string | number;
+    loc_type: MapPoiType;
+    label: string;
+  };
+  geometry: {
+    type: 'Point';
+    coordinates: Coordinate;
+  };
+};
+
+export type PeopleDotFeatureCollection = {
+  type: 'FeatureCollection';
+  features: PeopleDotFeature[];
+};
+
+export type PoiFeature = {
+  type: 'Feature';
+  properties: MapPoi & {
+    infection_ratio: number;
+  };
+  geometry: {
+    type: 'Point';
+    coordinates: Coordinate;
+  };
+};
+
+export type PoiFeatureCollection = {
+  type: 'FeatureCollection';
+  features: PoiFeature[];
+};

--- a/src/styles/dmp-selector.css
+++ b/src/styles/dmp-selector.css
@@ -122,7 +122,10 @@
   font-size: 11px;
   font-weight: 500;
   letter-spacing: 0.02em;
-  transition: background 120ms, border-color 120ms, color 120ms;
+  transition:
+    background 120ms,
+    border-color 120ms,
+    color 120ms;
 }
 
 .dmps_upload_btn:hover {
@@ -235,6 +238,16 @@
   transition: background 120ms;
 }
 
+.dmps_matrix_select {
+  flex: 1;
+  min-width: 0;
+  border: none;
+  background: transparent;
+  padding: 0;
+  text-align: left;
+  cursor: pointer;
+}
+
 .dmps_matrix_row:hover {
   background: rgba(61, 136, 173, 0.07);
 }
@@ -345,7 +358,10 @@
   cursor: pointer;
   font-size: 13px;
   line-height: 1;
-  transition: background 120ms, border-color 120ms, color 120ms;
+  transition:
+    background 120ms,
+    border-color 120ms,
+    color 120ms;
   padding: 0;
 }
 
@@ -379,7 +395,16 @@
   padding: 16px;
 }
 
+.dmps_overlay_backdrop {
+  position: absolute;
+  inset: 0;
+  border: none;
+  background: transparent;
+  cursor: default;
+}
+
 .dmps_dialog {
+  position: relative;
   background: var(--color-bg-dark);
   border: 1px solid var(--color-border-light);
   border-radius: 10px;
@@ -450,7 +475,10 @@
   font-size: 12px;
   font-weight: 500;
   cursor: pointer;
-  transition: background 120ms, color 120ms, transform 100ms;
+  transition:
+    background 120ms,
+    color 120ms,
+    transform 100ms;
 }
 
 .dmps_file_btn:hover {
@@ -492,7 +520,9 @@
   font-size: 13px;
   font-weight: 500;
   cursor: pointer;
-  transition: background 120ms, color 120ms;
+  transition:
+    background 120ms,
+    color 120ms;
 }
 
 .dmps_dialog_cancel:hover {
@@ -514,7 +544,10 @@
   font-size: 13px;
   font-weight: 500;
   cursor: pointer;
-  transition: background 120ms, color 120ms, transform 100ms;
+  transition:
+    background 120ms,
+    color 120ms,
+    transform 100ms;
 }
 
 .dmps_dialog_submit:hover {


### PR DESCRIPTION
## Summary
- split the CZ generation page into focused components and hooks
- extract CZ finalization, generated workspace, guided selection state, seed editing, preview submit, metrics, candidate POI, and modal logic
- move model-map types into a dedicated module so source files stay below 1,000 lines

## Validation
- pnpm lint
- pnpm typecheck
- pnpm test
- git diff --check

## File size check
- max source file is now src/app/cz-generation/page.tsx at 998 lines
- src/features/model-map/map-data.ts is now 967 lines