### PR TITLE
Write sim map cache atomically (fix "Failed to load run from URL")

### DIFF
--- a/src/lib/sim-processor.ts
+++ b/src/lib/sim-processor.ts
@@ -1,4 +1,4 @@
-import { readFile, writeFile } from 'node:fs/promises';
+import { readFile, rename, writeFile } from 'node:fs/promises';
 import { gunzipSync } from 'node:zlib';
 import { getCachedPapdata } from './papdata-cache';
 import {
@@ -291,10 +291,22 @@ export async function processSimulation(opts: ProcessOpts): Promise<ChartData> {
 
   processingProgress.delete(simDataId);
 
-  // Finalize map cache
+  // Finalize map cache.
+  //
+  // Write atomically (temp file + rename) rather than in place. GET
+  // /api/simdata/[id] returns 200 the moment this file exists, so an in-place
+  // writeFile lets the results page read a half-written file and fail
+  // JSON.parse — surfacing as "Failed to load run from URL". The bug is
+  // timing-dependent: it hits when the write window is wide (slow/contended
+  // disk, large payloads), e.g. long runs on the shared prod host, and is rare
+  // on a fast local SSD. rename() is atomic on the same filesystem, so a
+  // concurrent reader sees either no file (-> 202, keep polling) or the
+  // complete file — never a partial one.
   cacheParts.push(`},"hotspots":${JSON.stringify(hotspots)}`);
   stageStart = nowMs();
-  await writeFile(mapCachePath, cacheParts.join(''));
+  const tmpMapCachePath = `${mapCachePath}.tmp`;
+  await writeFile(tmpMapCachePath, cacheParts.join(''));
+  await rename(tmpMapCachePath, mapCachePath);
   logPerfTiming('processSimulation map cache write', stageStart);
   logPerfTiming('processSimulation total', totalStart);
 


### PR DESCRIPTION
## Symptom

Running a simulation on prod (covidmod.isi.jhu.edu) intermittently fails on the results page with **"Failed to load run from URL"** (sometimes after a long wait). The same run on localhost works fine.

## Root cause — a read-during-write race

`processSimulation` writes the map-cache file **in place**:

```ts
await writeFile(mapCachePath, cacheParts.join(''));   // ~8 MB, non-atomic
```

`GET /api/simdata/[id]` returns **HTTP 200 the instant that file exists** (it just `readFile`s it; otherwise 202 "processing"). So there's a window where the results page (`/simulator/[id]`) fetches and `JSON.parse`s a **half-written file** → throw → `setError('Failed to load run from URL.')`.

The window scales with write duration, so it bites the **shared/contended prod host** on large **720h** runs and is effectively invisible on a fast local SSD.

## Verification

Reproduced the full browser flow (fresh sim → poll `/api/simdata/[id]` → download → `JSON.parse`):

| | body | JSON.parse |
|---|---|---|
| **prod run #1** | 200, **3.1 MB** (of ~7.9) | **FAIL** `Expecting ',' at char 3146428` |
| **prod run #2** | 200, **2.5 MB** | **FAIL** at char 2462396 |
| prod refetch (completed) | 7.9 MB | OK |
| local | 7.9 MB | OK |

Varying truncation offsets + "refetch fixes it" = a partial-file read, not a network drop (which would error, not produce parseable-then-truncated JSON).

Isolated race test of the fix (concurrent reader vs. a slow writer):

```
NON-ATOMIC (current): reads=109 ok=83 ENOENT=18 TRUNCATED=8
ATOMIC (temp+rename): reads=126 ok=87 ENOENT=39 TRUNCATED=0
```

## Fix

Write to `${mapCachePath}.tmp`, then `rename()` into place. `rename` is atomic on the same filesystem, so a concurrent reader sees either no file (→ 202, keep polling) or the complete file — never a partial one. One-file change; `biome lint` clean, no new `tsc` errors.

## Notes
- Independent of the simulator-speed work; this fixes the **error**, not throughput.
- The `.tmp` and final path are both in `DB_FOLDER` (same filesystem), so `rename` won't hit `EXDEV`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)