### PR TITLE
Refresh simulation results page

### DIFF
--- a/src/app/simulator/[run_id]/page.tsx
+++ b/src/app/simulator/[run_id]/page.tsx
@@ -1,11 +1,11 @@
 'use client';
 
 import dynamic from 'next/dynamic';
+import { ArrowLeft } from 'lucide-react';
 import { useParams, useRouter, useSearchParams } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import ComparisonSummary from '@/components/comparison-summary';
 import EditDeleteActions from '@/components/edit-delete-actions';
-import InstructionBanner from '@/components/instruction-banner';
 import LoginModal from '@/components/login-modal';
 import OutputGraphs from '@/components/outputgraphs';
 import PersonPathPanel from '@/components/person-path-panel';
@@ -41,6 +41,19 @@ interface SimRunData {
 }
 
 type RunView = 'intervention' | 'baseline' | 'disabled';
+
+const RUN_VIEW_LABELS: Record<RunView, string> = {
+  intervention: 'With interventions',
+  baseline: 'Baseline',
+  disabled: 'Disabled POIs'
+};
+
+function formatRunDate(value?: string | null) {
+  if (!value) {
+    return 'Unknown date';
+  }
+  return new Date(value).toLocaleDateString();
+}
 
 function getDisabledPoiIdsFromMetadata(metadata: unknown) {
   if (!metadata || typeof metadata !== 'object') {
@@ -202,6 +215,8 @@ export default function SimulatorRun() {
       : activeView === 'baseline' && baselineId != null
         ? baselineId
         : interventionSimId;
+  const hasComparisonRuns = baselineId != null || disabledSimId != null;
+  const activeViewLabel = RUN_VIEW_LABELS[activeView];
 
   // Swap which run drives the map. setSimData merges by default, so clear it
   // first to guarantee a clean replace rather than a union of both timelines.
@@ -589,18 +604,18 @@ export default function SimulatorRun() {
 
   if (loading) {
     return (
-      <div className="sim_container">
-        <div className="flex flex-col items-center gap-4 my-auto">
-          <div className="text-lg">Loading simulation data...</div>
-          <div className="w-72 rounded-full h-2 bg-(--color-bg-dark)">
+      <div className="sim_container sim_run_container">
+        <div className="sim_run_status">
+          <p className="sim_run_status_label">Loading simulation data</p>
+          <div className="sim_run_status_track">
             <div
-              className="bg-(--color-primary-blue) h-2 rounded-full transition-all duration-100"
+              className="sim_run_status_fill"
               style={{ width: `${Math.max(progress, 2)}%` }}
             />
-            <p className="text-sm text-center mt-2">
-              {progress > 0 ? `${progress}%` : 'Starting...'}
-            </p>
           </div>
+          <p className="sim_run_status_detail">
+            {progress > 0 ? `${progress}%` : 'Starting...'}
+          </p>
         </div>
       </div>
     );
@@ -608,43 +623,52 @@ export default function SimulatorRun() {
 
   if (error) {
     return (
-      <div className="sim_container">
-        <div className="flex flex-col items-center justify-center gap-4 mt-20">
-          <div className="text-red-500 text-lg">{error}</div>
-          <button
+      <div className="sim_container sim_run_container">
+        <div className="sim_run_status">
+          <p className="sim_run_status_label is-error">{error}</p>
+          <Button
             type="button"
+            variant="secondary"
             onClick={() => router.push('/simulator')}
-            className="bg-(--color-bg-dark) text-(--color-text-light) w-32 h-12 p-3 rounded-md transition-[200ms] ease-in-out hover:scale-105 cursor-pointer active:brightness-75"
+            className="sim_return_button"
           >
-            Return
-          </button>
+            <ArrowLeft size={16} aria-hidden="true" />
+            <span>New setup</span>
+          </Button>
         </div>
       </div>
     );
   }
 
   if (!selectedZone) {
-    return <div className="sim_container">Loading...</div>;
+    return (
+      <div className="sim_container sim_run_container">
+        <div className="sim_run_status">
+          <p className="sim_run_status_label">Loading...</p>
+        </div>
+      </div>
+    );
   }
 
   return (
-    <div className="sim_container">
-      <div className="sim_output px-4">
-        <InstructionBanner text="Tip: Click on a marker in the map below to view its population and infection stats in the charts on the bottom." />
-        <div className="flex flex-col gap-4">
-          <div className="flex justify-between">
-            <span className="flex flex-col gap-1">
-              <h2 className="text-xl font-semibold">{selectedZone.name}</h2>
-              <p className="text-sm italic text-gray-600">
-                Created on:{' '}
-                {new Date(selectedZone.created_at).toLocaleDateString()}
-              </p>
-            </span>
+    <div className="sim_container sim_run_container">
+      <div className="sim_output sim_run_shell">
+        <header className="sim_run_header">
+          <div className="sim_run_title_group">
+            <span className="sim_run_kicker">Simulation Result</span>
+            <h1 className="sim_run_title">{selectedZone.name}</h1>
+            <div className="sim_run_meta">
+              <span>{runName || 'Untitled Run'}</span>
+              <span>Created {formatRunDate(selectedZone.created_at)}</span>
+              <span>Viewing {activeViewLabel}</span>
+            </div>
+          </div>
 
-            <span className="flex flex-col gap-1 items-end">
-              <h3 className="text-md font-semibold text-(--color-text-dark)">
+          <div className="sim_run_header_actions">
+            <div className="sim_run_edit_actions">
+              <span className="sim_run_edit_label">
                 {runName || 'Untitled Run'}
-              </h3>
+              </span>
               {user ? (
                 <EditDeleteActions
                   align="right"
@@ -686,15 +710,26 @@ export default function SimulatorRun() {
               ) : (
                 <button
                   type="button"
-                  className="text-xs text-(--color-text-muted) hover:underline cursor-pointer"
+                  className="sim_login_edit_button"
                   onClick={() => setLoginOpen(true)}
                 >
                   Login to edit or delete this run
                 </button>
               )}
-            </span>
+            </div>
+            <Button
+              variant="secondary"
+              className="sim_return_button"
+              onClick={() => router.push('/simulator')}
+            >
+              <ArrowLeft size={16} aria-hidden="true" />
+              <span>New setup</span>
+            </Button>
           </div>
-          {(baselineId != null || disabledSimId != null) && (
+        </header>
+
+        {hasComparisonRuns && (
+          <section className="sim_run_panel sim_run_comparison_panel">
             <ComparisonSummary
               referenceSimId={interventionSimId}
               referenceLabel="Interventions"
@@ -707,19 +742,24 @@ export default function SimulatorRun() {
                   : [])
               ]}
             />
-          )}
-          {(baselineId != null || disabledSimId != null) && (
-            <div className="flex items-center gap-3 flex-wrap">
-              <span className="text-sm text-(--color-text-muted)">
-                Map view:
-              </span>
-              <div className="inline-flex rounded-md border border-(--color-border-light) overflow-hidden">
+          </section>
+        )}
+
+        <section className="sim_run_panel sim_run_map_panel">
+          <div className="sim_run_section_header">
+            <div>
+              <span className="sim_run_section_kicker">Map</span>
+              <h2 className="sim_run_section_title">
+                Movement and exposure over time
+              </h2>
+            </div>
+            {hasComparisonRuns && (
+              <fieldset className="sim_view_switcher">
+                <legend className="sr-only">Map view</legend>
                 <button
                   type="button"
-                  className={`px-3 py-1.5 text-sm transition-colors ${
-                    activeView === 'intervention'
-                      ? 'bg-(--color-primary-blue) text-(--color-text-light)'
-                      : 'bg-(--color-bg-ivory) hover:brightness-95'
+                  className={`sim_view_switcher_button ${
+                    activeView === 'intervention' ? 'is-active' : ''
                   }`}
                   onClick={() => showRun('intervention')}
                 >
@@ -729,10 +769,8 @@ export default function SimulatorRun() {
                   <button
                     type="button"
                     disabled={!baselinePayload}
-                    className={`px-3 py-1.5 text-sm transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
-                      activeView === 'baseline'
-                        ? 'bg-(--color-primary-blue) text-(--color-text-light)'
-                        : 'bg-(--color-bg-ivory) hover:brightness-95'
+                    className={`sim_view_switcher_button ${
+                      activeView === 'baseline' ? 'is-active' : ''
                     }`}
                     onClick={() => showRun('baseline')}
                   >
@@ -743,10 +781,8 @@ export default function SimulatorRun() {
                   <button
                     type="button"
                     disabled={!disabledPayload}
-                    className={`px-3 py-1.5 text-sm transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
-                      activeView === 'disabled'
-                        ? 'bg-(--color-primary-blue) text-(--color-text-light)'
-                        : 'bg-(--color-bg-ivory) hover:brightness-95'
+                    className={`sim_view_switcher_button ${
+                      activeView === 'disabled' ? 'is-active' : ''
                     }`}
                     onClick={() => showRun('disabled')}
                   >
@@ -755,9 +791,9 @@ export default function SimulatorRun() {
                       : 'Disabled POIs (loading...)'}
                   </button>
                 )}
-              </div>
-            </div>
-          )}
+              </fieldset>
+            )}
+          </div>
           <ModelMap
             key={activeSimId}
             selectedZone={selectedZone}
@@ -765,10 +801,7 @@ export default function SimulatorRun() {
             disabledPoiIds={effectiveDisabledPoiIds}
             onMarkerClick={handleMarkerClick}
           />
-          <PersonPathPanel simId={activeSimId} />
-        </div>
-
-        <InstructionBanner text="Use the time slider or play button to navigate through the simulation timeline." />
+        </section>
 
         <OutputGraphs
           simId={interventionSimId}
@@ -777,6 +810,8 @@ export default function SimulatorRun() {
           selected_loc={selectedLoc}
           onReset={onReset}
         />
+
+        <PersonPathPanel simId={activeSimId} />
 
         <PoiRankings
           onSelectPoi={handleMarkerClick}
@@ -791,10 +826,18 @@ export default function SimulatorRun() {
           disabledComparisonMessage={disabledRunMessage}
           disabledComparisonError={disabledRunError}
         />
+
+        <div className="sim_run_bottom_actions">
+          <Button
+            variant="secondary"
+            className="sim_return_button"
+            onClick={() => router.push('/simulator')}
+          >
+            <ArrowLeft size={16} aria-hidden="true" />
+            <span>Return to simulator setup</span>
+          </Button>
+        </div>
       </div>
-      <Button className="w-32" onClick={() => router.push('/simulator')}>
-        Return
-      </Button>
       <LoginModal
         isOpen={loginOpen}
         onRequestClose={() => setLoginOpen(false)}

--- a/src/components/comparison-summary.tsx
+++ b/src/components/comparison-summary.tsx
@@ -70,23 +70,17 @@ type Row = { label: string; value: string; delta: Delta | null };
 
 function MetricCard({ title, rows }: { title: string; rows: Row[] }) {
   return (
-    <div className="rounded-lg border border-(--color-border-light) bg-(--color-bg-ivory) p-4 flex flex-col gap-3">
-      <span className={`text-xs uppercase tracking-wide ${MUTED_TONE}`}>
-        {title}
-      </span>
-      <div className="flex flex-col gap-2 text-sm">
+    <div className="comparison_metric_card">
+      <span className="comparison_metric_title">{title}</span>
+      <div className="comparison_metric_rows">
         {rows.map((row, i) => (
-          <div key={row.label} className="flex flex-col">
-            <div className="flex items-baseline justify-between gap-3">
-              <span className={i === 0 ? 'font-medium' : MUTED_TONE}>
-                {row.label}
-              </span>
-              <span className="font-semibold tabular-nums whitespace-nowrap">
-                {row.value}
-              </span>
+          <div key={row.label} className="comparison_metric_row">
+            <div>
+              <span className={i === 0 ? 'is-reference' : ''}>{row.label}</span>
+              <span className="comparison_metric_value">{row.value}</span>
             </div>
             <span
-              className={`text-xs font-medium text-right whitespace-nowrap ${
+              className={`comparison_metric_delta ${
                 row.delta ? row.delta.tone : MUTED_TONE
               }`}
             >
@@ -104,7 +98,7 @@ export default function ComparisonSummary({
   referenceLabel = 'Interventions',
   scenarios,
   title = 'Scenario comparison',
-  note = 'Tip: for a clean comparison, disable “Random Seed” before running so every scenario shares the same seed — otherwise some of the difference is stochastic noise rather than the change you made.'
+  note = null
 }: ComparisonSummaryProps) {
   const [data, setData] = useState<Loaded | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -218,32 +212,38 @@ export default function ComparisonSummary({
     : [];
 
   return (
-    <div className="flex flex-col gap-3">
-      <div className="flex items-baseline justify-between gap-3">
-        <h3 className="text-md font-semibold">{title}</h3>
+    <div className="comparison_summary">
+      <div className="comparison_summary_header">
+        <div>
+          <span className="sim_run_section_kicker">Comparison</span>
+          <h2 className="sim_run_section_title">{title}</h2>
+        </div>
         {!data && !error && (
-          <span className={`text-xs ${MUTED_TONE}`}>Loading comparison…</span>
+          <span className={`comparison_loading ${MUTED_TONE}`}>
+            Loading comparison…
+          </span>
         )}
       </div>
 
       {error ? (
-        <p className={`text-sm ${MUTED_TONE}`}>{error}</p>
+        <p className={`comparison_error ${MUTED_TONE}`}>{error}</p>
       ) : data ? (
         <>
-          <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+          <div className="comparison_metric_grid">
             {cards.map((card) => (
-              <MetricCard key={card.title} title={card.title} rows={card.rows} />
+              <MetricCard
+                key={card.title}
+                title={card.title}
+                rows={card.rows}
+              />
             ))}
           </div>
-          {note && <p className={`text-xs italic ${MUTED_TONE}`}>{note}</p>}
+          {note && <p className={`comparison_note ${MUTED_TONE}`}>{note}</p>}
         </>
       ) : (
-        <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+        <div className="comparison_metric_grid">
           {[0, 1, 2].map((i) => (
-            <div
-              key={i}
-              className="rounded-lg border border-(--color-border-light) bg-(--color-bg-ivory) h-28 animate-pulse"
-            />
+            <div key={i} className="comparison_metric_skeleton" />
           ))}
         </div>
       )}

--- a/src/components/modelmap.tsx
+++ b/src/components/modelmap.tsx
@@ -370,7 +370,7 @@ export default function ModelMap({
   }, [maxHours, sim_data]);
 
   return (
-    <div>
+    <div className="modelmap_panel">
       <div className="heatmap-toggle">
         <MapLegend icon_lookup={iconLookup} />
         <div className="heatmap-toggle-group">
@@ -426,7 +426,7 @@ export default function ModelMap({
         peopleDotColor={peopleDotColor}
         personStatusDotGeoJSON={personStatusDotGeoJSON}
       />
-      <div className="mt-3 text-center w-full">
+      <div className="modelmap_current_time">
         {new Date(
           new Date(selectedZone.start_date).getTime() +
             currentTime * 60 * 60 * 1000
@@ -440,11 +440,12 @@ export default function ModelMap({
           timeZone: 'UTC'
         })}
       </div>
-      <div className="flex items-center justify-center gap-3 mt-3">
+      <div className="modelmap_timeline_controls">
         <Button
           variant="primary"
-          className="py-1!"
+          className="modelmap_play_button py-1!"
           onClick={() => setIsPlaying(!isPlaying)}
+          aria-label={isPlaying ? 'Pause timeline' : 'Play timeline'}
         >
           {isPlaying ? (
             <Pause size={14} fill="currentColor" />
@@ -453,16 +454,14 @@ export default function ModelMap({
           )}
         </Button>
         <Slider
-          className="w-full max-w-[90vw]"
+          className="modelmap_slider"
           min={1}
           max={maxHours}
           value={currentTime}
           onChange={(e) => setCurrentTime(parseInt(e.target.value, 10))}
         />
-      </div>
-      <div className="flex justify-center mt-3">
         <input
-          className="w-[10%] px-1 bg-(--color-bg-ivory) outline-solid outline-2 outline-(--color-primary-blue)"
+          className="modelmap_time_input"
           type="number"
           min={1}
           max={maxHours}

--- a/src/components/outputgraphs.tsx
+++ b/src/components/outputgraphs.tsx
@@ -213,6 +213,17 @@ function getSeriesKeys(series: DataPoint[]) {
   return [...keys];
 }
 
+function hasSeriesData(data: DataPoint[], key: string) {
+  return data.some((point) => {
+    const value = point[key];
+    return typeof value === 'number' && Number.isFinite(value);
+  });
+}
+
+function getPlottedSeriesDefs(data: DataPoint[], seriesDefs: SeriesDef[]) {
+  return seriesDefs.filter((series) => hasSeriesData(data, series.key));
+}
+
 function lineSampleStyle(color: string): CSSProperties {
   return { '--series-color': color } as CSSProperties;
 }
@@ -246,6 +257,10 @@ function SeriesLegend({
   hiddenLines: Set<string>;
   onToggle: (key: string) => void;
 }) {
+  if (seriesDefs.length === 0) {
+    return null;
+  }
+
   return (
     <fieldset className="outputgraph_legend">
       <legend className="sr-only">Chart series</legend>
@@ -516,11 +531,22 @@ export default function OutputGraphs({
     hasDisabledPoi
   ]);
 
+  const legendSeriesDefs = useMemo(() => {
+    if (splitCharts.length > 0) {
+      return seriesDefs.filter((series) =>
+        splitCharts.some((chart) => hasSeriesData(chart.data, series.key))
+      );
+    }
+
+    return getPlottedSeriesDefs(mergedData, seriesDefs);
+  }, [mergedData, seriesDefs, splitCharts]);
+
   return (
     <div className="outputgraphs_container">
-      <div className="relative outputgraph_chart">
+      <section className="outputgraph_chart">
         <div className="outputgraph_header">
           <div className="min-w-0">
+            <span className="sim_run_section_kicker">Outcomes</span>
             <h6 className="outputgraph_title">
               {activeChart?.heading ?? 'Infection chart'}
               {selected_loc && <span> for {selected_loc.label}</span>}
@@ -569,7 +595,7 @@ export default function OutputGraphs({
             <p className="text-lg text-red-500">{chartError}</p>
           </div>
         ) : !chartData ? (
-          <div className="absolute inset-0 z-10 flex flex-col items-center justify-center p-4 text-center gap-2">
+          <div className="outputgraph_loading">
             <p className="text-md">
               {processing ? 'Processing simulation chart data' : 'Loading...'}
             </p>
@@ -583,41 +609,53 @@ export default function OutputGraphs({
           <>
             {splitCharts.length > 0 ? (
               <div className="outputgraph_split_grid">
-                {splitCharts.map((chart) => (
-                  <section className="outputgraph_split_panel" key={chart.key}>
-                    <h3 className="outputgraph_split_title">{chart.title}</h3>
-                    <div className="outputgraph_split_plot">
-                      <ChartLines
-                        data={chart.data}
-                        seriesDefs={seriesDefs}
-                        hiddenLines={hiddenLines}
-                      />
-                    </div>
-                  </section>
-                ))}
+                {splitCharts.map((chart) => {
+                  const chartSeriesDefs = getPlottedSeriesDefs(
+                    chart.data,
+                    seriesDefs
+                  );
+
+                  return (
+                    <section
+                      className="outputgraph_split_panel"
+                      key={chart.key}
+                    >
+                      <h3 className="outputgraph_split_title">
+                        {chart.title}
+                      </h3>
+                      <div className="outputgraph_split_plot">
+                        <ChartLines
+                          data={chart.data}
+                          seriesDefs={chartSeriesDefs}
+                          hiddenLines={hiddenLines}
+                        />
+                      </div>
+                    </section>
+                  );
+                })}
               </div>
             ) : (
               <div className="outputgraph_plot">
                 <ChartLines
                   data={mergedData}
-                  seriesDefs={seriesDefs}
+                  seriesDefs={legendSeriesDefs}
                   hiddenLines={hiddenLines}
                 />
               </div>
             )}
             <SeriesLegend
-              seriesDefs={seriesDefs}
+              seriesDefs={legendSeriesDefs}
               hiddenLines={hiddenLines}
               onToggle={handleLegendToggle}
             />
           </>
         )}
-      </div>
+      </section>
       {selected_loc && (
-        <div style={{ textAlign: 'center', marginBottom: '10px' }}>
+        <div className="outputgraph_reset">
           <Button
             variant="destructive"
-            className="px-4! py-2! mt-4"
+            className="px-4! py-2!"
             onClick={onReset}
           >
             Reset Selection

--- a/src/components/person-path-panel.tsx
+++ b/src/components/person-path-panel.tsx
@@ -134,9 +134,7 @@ export default function PersonPathPanel({ simId }: PersonPathPanelProps) {
     } catch (e) {
       console.error(e);
       setPathData(null);
-      setError(
-        e instanceof Error ? e.message : 'Failed to load person path.'
-      );
+      setError(e instanceof Error ? e.message : 'Failed to load person path.');
     } finally {
       setIsLoading(false);
     }
@@ -147,17 +145,17 @@ export default function PersonPathPanel({ simId }: PersonPathPanelProps) {
   };
 
   return (
-    <div className="w-full rounded-md border-2 border-(--color-primary-blue) bg-(--color-bg-ivory) px-3 py-3">
-      <div className="flex flex-wrap items-center justify-between gap-2">
-        <h3 className="text-sm font-semibold">Person Movement Explorer</h3>
-        <span className="text-xs text-gray-600">
-          Load a person timeline by simulation person ID.
-        </span>
+    <section className="person_path_panel">
+      <div className="person_path_header">
+        <div>
+          <span className="sim_run_section_kicker">Movement</span>
+          <h2 className="sim_run_section_title">Person path explorer</h2>
+        </div>
       </div>
 
-      <div className="mt-2 flex flex-wrap items-center gap-2">
+      <div className="person_path_controls">
         <input
-          className="w-44 rounded px-2 py-1 text-sm bg-white outline-solid outline-2 outline-(--color-primary-blue)"
+          className="person_path_input"
           type="number"
           min={0}
           step={1}
@@ -172,6 +170,7 @@ export default function PersonPathPanel({ simId }: PersonPathPanelProps) {
         />
         <Button
           variant="primary"
+          className="person_path_button"
           onClick={() => void handleLoad()}
           disabled={isLoading || !simId}
         >
@@ -181,7 +180,7 @@ export default function PersonPathPanel({ simId }: PersonPathPanelProps) {
           <select
             value={selectedDay}
             onChange={(e) => setSelectedDay(e.target.value)}
-            className="rounded px-2 py-1 text-xs bg-white outline-solid outline-2 outline-(--color-primary-blue)"
+            className="person_path_select"
           >
             <option value="all">All Days</option>
             {pathData.days.map((day) => (
@@ -193,29 +192,28 @@ export default function PersonPathPanel({ simId }: PersonPathPanelProps) {
         ) : null}
       </div>
 
-      {error ? <div className="mt-2 text-xs text-red-600">{error}</div> : null}
+      {error ? <div className="person_path_error">{error}</div> : null}
 
       {pathData ? (
-        <div className="mt-3 max-h-96 space-y-3 overflow-y-scroll rounded-md border-2 border-(--color-primary-blue) p-3 pr-4 [&::-webkit-scrollbar]:w-2 [&::-webkit-scrollbar]:mr-1 [&::-webkit-scrollbar-track]:rounded-full [&::-webkit-scrollbar-track]:bg-gray-100 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-gray-300">
-          <div className="text-xs text-gray-700">
-            <span className="font-semibold">Person #{pathData.person_id}</span>
+        <div className="person_path_results">
+          <div className="person_path_summary">
+            <span>Person #{pathData.person_id}</span>
             {pathData.person ? (
               <>
                 {' '}
-                | Age {pathData.person.age ?? '-'} | {pathData.person.sex} | Home #
-                {pathData.person.home ?? '-'}
+                | Age {pathData.person.age ?? '-'} | {pathData.person.sex} |
+                Home #{pathData.person.home ?? '-'}
               </>
-            ) : null}
-            {' '}
+            ) : null}{' '}
             | {pathData.total_hours}h tracked | {pathData.days.length} day(s)
           </div>
 
           {filteredDays.length === 0 ? (
-            <div className="text-xs text-gray-600">
+            <div className="person_path_empty">
               No movement segments found for this person.
             </div>
           ) : (
-            <div className="space-y-3">
+            <div className="person_path_days">
               {filteredDays.map((day) => {
                 const isExpanded = Boolean(expandedDays[day.day_index]);
                 const visibleStops = isExpanded
@@ -223,27 +221,24 @@ export default function PersonPathPanel({ simId }: PersonPathPanelProps) {
                   : day.stops.slice(0, MAX_VISIBLE_STOPS);
 
                 return (
-                  <div
-                    key={day.day_index}
-                    className="rounded border border-[#d7e8f1] bg-white p-2"
-                  >
-                    <div className="flex flex-wrap items-center justify-between gap-1 text-xs">
-                      <div className="font-semibold">
+                  <div key={day.day_index} className="person_path_day">
+                    <div className="person_path_day_header">
+                      <div>
                         Day {day.day_index} - {formatDayLabel(day.day_date_iso)}
                       </div>
-                      <div className="text-gray-600">{day.total_hours}h tracked</div>
+                      <div>{day.total_hours}h tracked</div>
                     </div>
 
-                    <div className="mt-2 space-y-1 text-xs">
+                    <div className="person_path_stop_list">
                       {visibleStops.map((stop) => (
                         <div
                           key={`${day.day_index}-${stop.location_type}-${stop.location_id}-${stop.start_minute}-${stop.end_time_iso}`}
-                          className="grid grid-cols-[1fr_1fr_2fr_auto] gap-2 rounded px-2 py-1 odd:bg-[#f7fbfe]"
+                          className="person_path_stop"
                         >
                           <span>{formatDateTime(stop.start_time_iso)}</span>
                           <span>{formatDateTime(stop.end_time_iso)}</span>
                           <span>{stop.location_label}</span>
-                          <span className="font-semibold">
+                          <span className="person_path_stop_duration">
                             {formatDuration(stop.duration_minutes)}
                           </span>
                         </div>
@@ -253,7 +248,7 @@ export default function PersonPathPanel({ simId }: PersonPathPanelProps) {
                     {day.stops.length > MAX_VISIBLE_STOPS ? (
                       <button
                         type="button"
-                        className="mt-2 text-xs text-[#2a6f92] underline"
+                        className="person_path_show_more"
                         onClick={() => toggleDayExpansion(day.day_index)}
                       >
                         {isExpanded
@@ -263,20 +258,21 @@ export default function PersonPathPanel({ simId }: PersonPathPanelProps) {
                     ) : null}
 
                     {day.totals?.length ? (
-                      <div className="mt-2 border-t border-[#e6eef3] pt-2">
-                        <div className="mb-1 text-xs font-semibold">
+                      <div className="person_path_totals">
+                        <div className="person_path_totals_title">
                           Top locations by time
                         </div>
-                        <div className="grid gap-1 text-xs">
+                        <div className="person_path_totals_list">
                           {day.totals.slice(0, 5).map((total) => (
                             <div
                               key={`${day.day_index}-${total.location_type}-${total.location_id}`}
-                              className="flex justify-between gap-2"
+                              className="person_path_total_row"
                             >
                               <span>{total.location_label}</span>
                               <span>
                                 {formatDuration(total.duration_minutes)} (
-                                {total.visits} visit{total.visits === 1 ? '' : 's'})
+                                {total.visits} visit
+                                {total.visits === 1 ? '' : 's'})
                               </span>
                             </div>
                           ))}
@@ -290,6 +286,6 @@ export default function PersonPathPanel({ simId }: PersonPathPanelProps) {
           )}
         </div>
       ) : null}
-    </div>
+    </section>
   );
 }

--- a/src/components/poi-rankings.tsx
+++ b/src/components/poi-rankings.tsx
@@ -68,18 +68,10 @@ function HotspotSwitch({
       aria-checked={checked}
       aria-label={checked ? `Enable ${label}` : `Disable ${label}`}
       disabled={!onToggle}
-      className={`relative h-5 w-9 shrink-0 overflow-hidden rounded-full border transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${
-        checked
-          ? 'border-gray-950 bg-gray-950'
-          : 'border-(--color-border-light) bg-white'
-      }`}
+      className={`hotspot_switch ${checked ? 'is-checked' : ''}`}
       onClick={onToggle}
     >
-      <span
-        className={`absolute left-0.5 top-0.5 h-4 w-4 rounded-full bg-white shadow-sm transition-transform ${
-          checked ? 'translate-x-4' : 'translate-x-0'
-        }`}
-      />
+      <span />
     </button>
   );
 }
@@ -104,7 +96,7 @@ function RankingViewToggle({
     <div
       role="tablist"
       aria-label="Hotspot ranking type"
-      className="inline-flex overflow-hidden rounded-md border border-(--color-border-light) bg-white text-xs font-semibold"
+      className="hotspot_view_toggle"
     >
       {options.map((option) => {
         const selected = activeView === option.id;
@@ -116,17 +108,13 @@ function RankingViewToggle({
             role="tab"
             aria-selected={selected}
             aria-label={`${option.label} (${option.count})`}
-            className={`px-3 py-1.5 transition-colors ${
-              selected
-                ? 'bg-(--color-primary-blue) text-(--color-text-light)'
-                : 'text-(--color-text-main) hover:bg-gray-50'
+            className={`hotspot_view_toggle_button ${
+              selected ? 'is-active' : ''
             }`}
             onClick={() => onChange(option.id)}
           >
             {option.label}
-            <span className="ml-1 tabular-nums opacity-75">
-              {option.count}
-            </span>
+            <span>{option.count}</span>
           </button>
         );
       })}
@@ -150,19 +138,17 @@ function RankingTable({
   const maxValue = Math.max(0, ...rows.map((row) => row.value));
 
   return (
-    <div className="overflow-hidden rounded-md border border-(--color-border-light) bg-white">
-      <div className="grid grid-cols-[2rem_2.25rem_minmax(0,1fr)_4.75rem] items-center gap-2 bg-white/80 px-3 py-2 text-[10px] font-bold uppercase text-(--color-text-muted) sm:grid-cols-[2.5rem_2.75rem_minmax(0,1fr)_5.5rem]">
-        <span className="text-center">#</span>
+    <div className="hotspot_table">
+      <div className="hotspot_table_header">
+        <span>#</span>
         <span className="sr-only">Disable</span>
         <span>Hotspot</span>
-        <span className="text-right">Peak</span>
+        <span className="hotspot_table_header_peak">Peak</span>
       </div>
       {rows.length === 0 ? (
-        <div className="flex h-40 items-center justify-center border-t border-(--color-border-light) text-sm text-(--color-text-muted)">
-          No infections recorded.
-        </div>
+        <div className="hotspot_empty">No infections recorded.</div>
       ) : (
-        <div className="divide-y divide-(--color-border-light)">
+        <div className="hotspot_table_body">
           {rows.map((row, index) => {
             const disabled = isDisabled(row);
             const width =
@@ -191,20 +177,10 @@ function RankingTable({
             return (
               <div
                 key={row.id}
-                className={`grid grid-cols-[2rem_2.25rem_minmax(0,1fr)_4.75rem] items-center gap-2 px-3 py-2.5 transition-colors sm:grid-cols-[2.5rem_2.75rem_minmax(0,1fr)_5.5rem] ${
-                  disabled ? 'bg-white' : 'bg-white/70 hover:bg-white'
-                }`}
+                className={`hotspot_row ${disabled ? 'is-disabled' : ''}`}
               >
-                <span
-                  className={`text-center text-xs font-semibold tabular-nums ${
-                    disabled
-                      ? 'text-gray-950'
-                      : 'text-(--color-text-muted)'
-                  }`}
-                >
-                  {index + 1}
-                </span>
-                <div className="flex justify-center">
+                <span className="hotspot_rank">{index + 1}</span>
+                <div className="hotspot_switch_cell">
                   <HotspotSwitch
                     checked={disabled}
                     label={row.fullLabel}
@@ -214,22 +190,18 @@ function RankingTable({
                 {onSelectRow ? (
                   <button
                     type="button"
-                    className="min-w-0 cursor-pointer text-left hover:underline"
+                    className="hotspot_name_button"
                     title={row.fullLabel}
                     onClick={() => onSelectRow(row)}
                   >
                     {content}
                   </button>
                 ) : (
-                  <div className="min-w-0" title={row.fullLabel}>
+                  <div className="hotspot_name" title={row.fullLabel}>
                     {content}
                   </div>
                 )}
-                <div className="text-right">
-                  <span className="block text-sm font-bold tabular-nums leading-none">
-                    {row.value.toLocaleString()}
-                  </span>
-                </div>
+                <div className="hotspot_peak">{row.value.toLocaleString()}</div>
               </div>
             );
           })}
@@ -344,7 +316,9 @@ export default function PoiRankings({
 
   const activeRows = activeView === 'pois' ? poiRows : typeRows;
   const activeTitle =
-    activeView === 'pois' ? 'Most infectious POIs' : 'Most infectious POI types';
+    activeView === 'pois'
+      ? 'Most infectious POIs'
+      : 'Most infectious POI types';
   const activeIsDisabled =
     activeView === 'pois'
       ? (row: RankRow) => disabledPoiIds.has(row.id)
@@ -368,29 +342,26 @@ export default function PoiRankings({
       : undefined;
   const activeDetail =
     activeView === 'pois'
-      ? (row: RankRow) =>
-          `${row.population.toLocaleString()} present at peak`
+      ? (row: RankRow) => `${row.population.toLocaleString()} present at peak`
       : (row: RankRow) =>
           `${formatPoiCount(row.poiCount ?? 0)}, ${row.population.toLocaleString()} present at peaks`;
 
   return (
-    <div className="flex w-[760px] max-w-full flex-col gap-3">
-      <div className="text-center">
-        <h5 className="font-bold">Infection Hotspots</h5>
-        <p className="-mt-1 text-xs text-(--color-text-muted)">
-          Ranked over the whole run by peak simultaneous infections.
-        </p>
-      </div>
-      <div className="rounded-md border-2 border-(--color-primary-blue) bg-(--color-bg-ivory) p-3">
-        <div className="mb-3 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-          <h6 className="text-sm font-bold">{activeTitle}</h6>
-          <RankingViewToggle
-            activeView={activeView}
-            poiCount={poiRows.length}
-            typeCount={typeRows.length}
-            onChange={setActiveView}
-          />
+    <section className="poi_rankings_panel">
+      <div className="poi_rankings_header">
+        <div>
+          <span className="sim_run_section_kicker">Hotspots</span>
+          <h2 className="sim_run_section_title">Infection hotspots</h2>
         </div>
+        <RankingViewToggle
+          activeView={activeView}
+          poiCount={poiRows.length}
+          typeCount={typeRows.length}
+          onChange={setActiveView}
+        />
+      </div>
+      <div className="poi_rankings_body">
+        <h3 className="poi_rankings_subtitle">{activeTitle}</h3>
         <RankingTable
           rows={activeRows}
           isDisabled={activeIsDisabled}
@@ -400,11 +371,11 @@ export default function PoiRankings({
         />
       </div>
       {onRunDisabledComparison && (
-        <div className="flex flex-col gap-2 rounded-md border border-(--color-border-light) bg-white/60 p-3">
-          <div className="flex items-center justify-between gap-3">
-            <span className="text-xs text-(--color-text-muted)">
+        <div className="poi_comparison_action">
+          <div className="poi_comparison_action_top">
+            <span>
               {effectiveDisabledPoiCount === 0
-                ? 'Toggle POIs or types above to disable them, then re-run.'
+                ? 'No POIs disabled for a comparison run.'
                 : `${effectiveDisabledPoiCount.toLocaleString()} POI${
                     effectiveDisabledPoiCount === 1 ? '' : 's'
                   } disabled — rerouted to their homes.`}
@@ -415,7 +386,7 @@ export default function PoiRankings({
               disabled={
                 effectiveDisabledPoiCount === 0 || disabledComparisonRunning
               }
-              className="shrink-0 rounded-md bg-(--color-primary-blue) px-3 py-1.5 text-sm font-semibold text-(--color-text-light) transition-colors hover:brightness-95 disabled:cursor-not-allowed disabled:opacity-50"
+              className="poi_comparison_button"
             >
               {disabledComparisonRunning
                 ? 'Running…'
@@ -423,10 +394,10 @@ export default function PoiRankings({
             </button>
           </div>
           {disabledComparisonRunning && (
-            <div className="flex flex-col gap-1">
-              <div className="h-1.5 overflow-hidden rounded-full bg-gray-200">
+            <div className="poi_comparison_progress">
+              <div className="poi_comparison_progress_track">
                 <div
-                  className="h-full rounded-full bg-(--color-primary-blue) transition-[width]"
+                  className="poi_comparison_progress_fill"
                   style={{
                     width: `${Math.min(
                       100,
@@ -436,19 +407,17 @@ export default function PoiRankings({
                 />
               </div>
               {disabledComparisonMessage && (
-                <span className="text-[11px] text-(--color-text-muted)">
-                  {disabledComparisonMessage}
-                </span>
+                <span>{disabledComparisonMessage}</span>
               )}
             </div>
           )}
           {disabledComparisonError && (
-            <span className="text-[11px] text-red-600">
+            <span className="poi_comparison_error">
               {disabledComparisonError}
             </span>
           )}
         </div>
       )}
-    </div>
+    </section>
   );
 }

--- a/src/styles/maplegend.css
+++ b/src/styles/maplegend.css
@@ -10,9 +10,9 @@
   font-family: "Poppins", sans-serif;
   font-size: 0.8rem;
   color: #444;
-  background: var(--color-bg-ivory);
-  border: 2px solid var(--color-primary-blue);
-  border-radius: 0.375rem;
+  background: rgba(255, 255, 255, 0.74);
+  border: 1px solid rgba(61, 136, 173, 0.24);
+  border-radius: 8px;
   cursor: pointer;
   transition: all 0.2s ease;
 }
@@ -32,9 +32,10 @@
   max-height: 0;
   opacity: 0;
   background: var(--color-bg-ivory);
-  border: 2px solid var(--color-primary-blue);
-  border-radius: 0.375rem;
+  border: 1px solid rgba(31, 41, 55, 0.12);
+  border-radius: 8px;
   z-index: 20;
+  box-shadow: 0 16px 42px rgba(15, 23, 42, 0.16);
   transition:
     max-height 300ms ease,
     opacity 200ms ease;
@@ -68,7 +69,7 @@
   width: 22px;
   text-align: center;
   font-size: 14px;
-  font-family: 'Noto Color Emoji', sans-serif;
+  font-family: "Noto Color Emoji", sans-serif;
 }
 
 .maplegend-label {

--- a/src/styles/modelmap.css
+++ b/src/styles/modelmap.css
@@ -1,13 +1,21 @@
+.modelmap_panel {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
 div.mapcontainer {
   position: relative;
-  width: 56rem;
-  height: 32rem;
-  max-width: 90vw;
+  width: 100%;
+  height: min(62vh, 560px);
+  min-height: 430px;
+  max-width: none;
   z-index: 0;
 
   overflow: hidden;
-  border: 2px solid var(--color-primary-blue);
-  border-radius: 0.375rem;
+  border: 1px solid rgba(31, 41, 55, 0.11);
+  border-radius: 8px;
+  background: #fff;
 }
 
 .pulse-icon {
@@ -90,7 +98,7 @@ div.mapcontainer {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 0.5rem;
+  gap: 12px;
 }
 
 .heatmap-toggle-group {
@@ -108,9 +116,9 @@ div.mapcontainer {
 
 .heatmap-toggle-btn {
   padding: 0.375rem 0.75rem;
-  border: 2px solid var(--color-primary-blue);
-  border-radius: 0.375rem;
-  background: var(--color-bg-ivory);
+  border: 1px solid rgba(61, 136, 173, 0.24);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.74);
   font-family: "Poppins", sans-serif;
   font-size: 0.8rem;
   font-weight: 500;
@@ -138,6 +146,68 @@ div.mapcontainer {
   color: var(--color-text-main);
   font-family: "Poppins", sans-serif;
   font-size: 0.75rem;
+}
+
+.modelmap_current_time {
+  width: 100%;
+  color: var(--color-text-main);
+  font-size: 13px;
+  font-weight: 600;
+  text-align: center;
+}
+
+.modelmap_timeline_controls {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) 84px;
+  align-items: center;
+  gap: 12px;
+}
+
+.modelmap_play_button {
+  min-width: 38px;
+}
+
+.modelmap_slider {
+  width: 100%;
+  max-width: 100%;
+}
+
+.modelmap_time_input {
+  width: 100%;
+  min-height: 34px;
+  padding: 0 8px;
+  border: 1px solid rgba(31, 41, 55, 0.13);
+  border-radius: 8px;
+  background: #fff;
+  color: var(--color-text-main);
+  font: inherit;
+  font-size: 13px;
+  text-align: center;
+}
+
+@media (max-width: 720px) {
+  div.mapcontainer {
+    height: 420px;
+    min-height: 360px;
+  }
+
+  .heatmap-toggle,
+  .people-map-key {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .heatmap-toggle-group {
+    justify-content: flex-start;
+  }
+
+  .modelmap_timeline_controls {
+    grid-template-columns: auto minmax(0, 1fr);
+  }
+
+  .modelmap_time_input {
+    grid-column: 1 / -1;
+  }
 }
 
 .people-map-key-item {

--- a/src/styles/outputgraphs.css
+++ b/src/styles/outputgraphs.css
@@ -1,16 +1,15 @@
 div.outputgraphs_container {
-  width: 980px;
-  max-width: 100%;
-  padding-bottom: 24px;
+  width: 100%;
 }
 
 div.outputgraph_chart {
+  position: relative;
   width: 100%;
-  background-color: var(--color-bg-ivory);
+  background: rgba(255, 255, 255, 0.66);
   padding: 18px;
-  border: 2px solid var(--color-primary-blue);
-  border-radius: 0.375rem;
-  box-shadow: var(--shadow-card);
+  border: 1px solid rgba(31, 41, 55, 0.09);
+  border-radius: 8px;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
 }
 
 .outputgraph_header {
@@ -25,8 +24,8 @@ div.outputgraph_chart {
 .outputgraph_title {
   margin: 0;
   color: var(--color-text-main);
-  font-size: 1rem;
-  font-weight: 700;
+  font-size: 18px;
+  font-weight: 600;
   line-height: 1.25;
 }
 
@@ -44,8 +43,8 @@ div.outputgraph_chart {
   gap: 7px;
   min-height: 26px;
   border: 1px solid var(--color-border-subtle);
-  border-radius: 999px;
-  background: #ffffff;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.74);
   color: var(--color-text-main);
   padding: 4px 9px;
   font-size: 0.72rem;
@@ -57,9 +56,9 @@ div.outputgraph_chart {
   display: inline-flex;
   flex: 0 0 auto;
   overflow: hidden;
-  border: 1px solid rgba(61, 136, 173, 0.35);
-  border-radius: 0.375rem;
-  background: #ffffff;
+  border: 1px solid rgba(61, 136, 173, 0.24);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.74);
 }
 
 .outputgraph_segment {
@@ -96,14 +95,14 @@ div.outputgraph_chart {
 .outputgraph_plot {
   width: 100%;
   height: 390px;
-  margin-top: 10px;
+  margin-top: 14px;
 }
 
 .outputgraph_split_grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 18px;
-  margin-top: 12px;
+  margin-top: 14px;
 }
 
 .outputgraph_split_panel {
@@ -111,7 +110,7 @@ div.outputgraph_chart {
 }
 
 .outputgraph_split_title {
-  margin: 0 0 4px 14px;
+  margin: 0 0 6px 14px;
   color: var(--color-text-main);
   font-size: 0.84rem;
   font-weight: 700;
@@ -141,8 +140,8 @@ div.outputgraph_chart {
   max-width: 220px;
   min-height: 28px;
   border: 1px solid var(--color-border-subtle);
-  border-radius: 0.375rem;
-  background: #ffffff;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.74);
   color: var(--color-text-main);
   cursor: pointer;
   font: inherit;
@@ -183,13 +182,33 @@ div.outputgraph_chart {
   );
 }
 
+.outputgraph_loading {
+  position: absolute;
+  inset: 0;
+  z-index: 10;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 18px;
+  color: var(--color-text-muted);
+  text-align: center;
+}
+
+.outputgraph_reset {
+  display: flex;
+  justify-content: center;
+  margin-top: 12px;
+}
+
 @media (max-width: 768px) {
   div.outputgraphs_container {
-    padding-bottom: 18px;
+    width: 100%;
   }
 
   div.outputgraph_chart {
-    padding: 14px 8px 14px 4px;
+    padding: 14px;
   }
 
   .outputgraph_header {
@@ -222,11 +241,11 @@ div.outputgraph_chart {
 
 @media (max-width: 480px) {
   div.outputgraphs_container {
-    padding-bottom: 14px;
+    width: 100%;
   }
 
   div.outputgraph_chart {
-    padding: 12px 4px 12px 0;
+    padding: 12px;
   }
 
   .outputgraph_plot {

--- a/src/styles/simulator.css
+++ b/src/styles/simulator.css
@@ -72,7 +72,7 @@ h1.sim_title {
   font-size: 13.5px;
   font-weight: 500;
   color: var(--color-primary-blue);
-  background: rgba(112, 180, 212, 0.10);
+  background: rgba(112, 180, 212, 0.1);
   border: 1px solid rgba(61, 136, 173, 0.18);
   border-radius: 999px;
   max-width: 720px;
@@ -87,7 +87,7 @@ h1.sim_title {
   width: 22px;
   height: 22px;
   border-radius: 50%;
-  background: rgba(112, 180, 212, 0.20);
+  background: rgba(112, 180, 212, 0.2);
   color: var(--color-primary-blue);
   font-size: 13px;
   flex-shrink: 0;
@@ -104,8 +104,10 @@ h1.sim_title {
   text-decoration: underline;
   text-underline-offset: 3px;
   text-decoration-thickness: 1.5px;
-  text-decoration-color: rgba(61, 136, 173, 0.40);
-  transition: text-decoration-color 160ms ease, color 160ms ease;
+  text-decoration-color: rgba(61, 136, 173, 0.4);
+  transition:
+    text-decoration-color 160ms ease,
+    color 160ms ease;
 }
 
 .instruction-banner-link:hover {
@@ -341,18 +343,25 @@ div.sim_output {
   color: var(--color-text-muted);
   border-radius: 10px;
   cursor: pointer;
-  transition: background-color 140ms ease, border-color 140ms ease, color 140ms ease;
+  transition:
+    background-color 140ms ease,
+    border-color 140ms ease,
+    color 140ms ease;
   font-family: inherit;
 }
 
 .sim_table_row:hover {
   background: rgba(112, 180, 212, 0.08);
-  border-color: rgba(61, 136, 173, 0.20);
+  border-color: rgba(61, 136, 173, 0.2);
 }
 
 .sim_table_row.is-selected {
-  background: linear-gradient(180deg, rgba(112, 180, 212, 0.18), rgba(61, 136, 173, 0.14));
-  border-color: rgba(61, 136, 173, 0.40);
+  background: linear-gradient(
+    180deg,
+    rgba(112, 180, 212, 0.18),
+    rgba(61, 136, 173, 0.14)
+  );
+  border-color: rgba(61, 136, 173, 0.4);
   color: var(--color-primary-blue);
   font-weight: 500;
 }
@@ -399,7 +408,7 @@ div.sim_output {
   border-radius: 999px;
   background: var(--color-bg-dark);
   color: var(--color-text-light);
-  box-shadow: 0 4px 12px rgba(15, 23, 42, 0.20);
+  box-shadow: 0 4px 12px rgba(15, 23, 42, 0.2);
   z-index: 1;
 }
 
@@ -457,7 +466,10 @@ div.sim_output {
   font-weight: 500;
   cursor: pointer;
   font-family: inherit;
-  transition: background-color 160ms ease, color 160ms ease, border-color 160ms ease;
+  transition:
+    background-color 160ms ease,
+    color 160ms ease,
+    border-color 160ms ease;
   box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
 }
 
@@ -477,7 +489,7 @@ div.sim_output {
 
 .iv_control_btn--danger:hover:not(:disabled) {
   background: rgba(232, 72, 90, 0.08);
-  border-color: rgba(232, 72, 90, 0.30);
+  border-color: rgba(232, 72, 90, 0.3);
 }
 
 .iv_control_btn--add {
@@ -485,8 +497,8 @@ div.sim_output {
 }
 
 .iv_control_btn--add:hover:not(:disabled) {
-  background: rgba(112, 180, 212, 0.10);
-  border-color: rgba(61, 136, 173, 0.30);
+  background: rgba(112, 180, 212, 0.1);
+  border-color: rgba(61, 136, 173, 0.3);
 }
 
 .iv_intervention_label {
@@ -574,14 +586,18 @@ div.sim_output {
 .sim_progress_track {
   width: 100%;
   height: 8px;
-  background: rgba(47, 53, 64, 0.10);
+  background: rgba(47, 53, 64, 0.1);
   border-radius: 999px;
   overflow: hidden;
 }
 
 .sim_progress_fill {
   height: 100%;
-  background: linear-gradient(90deg, var(--color-primary-blue-soft), var(--color-primary-blue));
+  background: linear-gradient(
+    90deg,
+    var(--color-primary-blue-soft),
+    var(--color-primary-blue)
+  );
   border-radius: 999px;
   transition: width 500ms ease;
 }
@@ -599,6 +615,874 @@ div.sim_output {
   text-align: center;
   padding: 10px 16px;
   background: rgba(232, 72, 90, 0.08);
-  border: 1px solid rgba(232, 72, 90, 0.20);
+  border: 1px solid rgba(232, 72, 90, 0.2);
   border-radius: 10px;
+}
+
+/* ---------- Simulation result page ---------- */
+.sim_run_container {
+  align-items: stretch;
+  max-width: 1360px;
+  padding-top: 36px;
+}
+
+.sim_run_shell {
+  align-items: stretch;
+  justify-content: flex-start;
+  flex-wrap: nowrap;
+  gap: 22px;
+  width: 100%;
+  padding: 0;
+}
+
+.sim_run_header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 24px;
+  width: 100%;
+  padding-bottom: 4px;
+}
+
+.sim_run_title_group {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-width: 0;
+}
+
+.sim_run_kicker,
+.sim_run_section_kicker {
+  display: block;
+  color: var(--color-primary-blue);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.sim_run_title {
+  margin: 0;
+  color: var(--color-text-main);
+  font-size: clamp(30px, 4vw, 44px);
+  font-weight: 600;
+  line-height: 1.08;
+}
+
+.sim_run_meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.sim_run_meta span {
+  display: inline-flex;
+  align-items: center;
+  min-height: 28px;
+  padding: 4px 10px;
+  border: 1px solid rgba(31, 41, 55, 0.08);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.54);
+  color: var(--color-text-muted);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.sim_run_header_actions {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  flex-shrink: 0;
+}
+
+.sim_run_edit_actions {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 6px;
+  max-width: 260px;
+}
+
+.sim_run_edit_label {
+  overflow: hidden;
+  max-width: 100%;
+  color: var(--color-text-main);
+  font-size: 14px;
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sim_login_edit_button {
+  border: 0;
+  background: transparent;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  font: inherit;
+  font-size: 12px;
+  text-align: right;
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+.sim_return_button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  white-space: nowrap;
+}
+
+.sim_run_bottom_actions {
+  display: flex;
+  justify-content: center;
+  padding: 4px 0 10px;
+}
+
+.sim_run_panel,
+.person_path_panel,
+.poi_rankings_panel {
+  width: 100%;
+  border: 1px solid rgba(31, 41, 55, 0.09);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.66);
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
+}
+
+.sim_run_panel {
+  padding: 18px;
+}
+
+.sim_run_map_panel {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.sim_run_comparison_panel {
+  padding: 16px;
+}
+
+.sim_run_section_header,
+.comparison_summary_header,
+.poi_rankings_header,
+.person_path_header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.sim_run_section_title {
+  margin: 3px 0 0;
+  color: var(--color-text-main);
+  font-size: 18px;
+  font-weight: 600;
+  line-height: 1.25;
+}
+
+.sim_view_switcher {
+  display: inline-flex;
+  overflow: hidden;
+  border: 1px solid rgba(61, 136, 173, 0.24);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.74);
+  flex-shrink: 0;
+  margin: 0;
+  padding: 0;
+  min-inline-size: 0;
+}
+
+.sim_view_switcher_button {
+  min-height: 34px;
+  padding: 0 12px;
+  border: 0;
+  border-right: 1px solid rgba(31, 41, 55, 0.08);
+  background: transparent;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 600;
+  transition:
+    background-color 160ms ease,
+    color 160ms ease;
+}
+
+.sim_view_switcher_button:last-child {
+  border-right: 0;
+}
+
+.sim_view_switcher_button:hover:not(:disabled) {
+  background: rgba(61, 136, 173, 0.08);
+  color: var(--color-text-main);
+}
+
+.sim_view_switcher_button.is-active {
+  background: var(--color-primary-blue);
+  color: var(--color-text-light);
+}
+
+.sim_view_switcher_button:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
+.sim_run_status {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  min-height: 360px;
+  width: min(420px, 100%);
+  margin: auto;
+  text-align: center;
+}
+
+.sim_run_status_label {
+  margin: 0;
+  color: var(--color-text-main);
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.sim_run_status_label.is-error {
+  color: var(--color-accent-red);
+}
+
+.sim_run_status_track {
+  width: 100%;
+  height: 8px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: rgba(47, 53, 64, 0.1);
+}
+
+.sim_run_status_fill {
+  height: 100%;
+  border-radius: 999px;
+  background: linear-gradient(
+    90deg,
+    var(--color-accent-teal),
+    var(--color-primary-blue)
+  );
+  transition: width 300ms ease;
+}
+
+.sim_run_status_detail {
+  margin: 0;
+  color: var(--color-text-muted);
+  font-size: 13px;
+}
+
+/* ---------- Scenario comparison ---------- */
+.comparison_summary {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.comparison_loading,
+.comparison_error,
+.comparison_note {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.comparison_metric_grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.comparison_metric_card,
+.comparison_metric_skeleton {
+  border: 1px solid rgba(31, 41, 55, 0.08);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.64);
+}
+
+.comparison_metric_card {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 14px;
+}
+
+.comparison_metric_skeleton {
+  height: 112px;
+  animation: sim-run-pulse 1.8s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+}
+
+@keyframes sim-run-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.46;
+  }
+}
+
+.comparison_metric_title {
+  color: var(--color-text-muted);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.comparison_metric_rows {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.comparison_metric_row {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.comparison_metric_row > div {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  color: var(--color-text-muted);
+  font-size: 13px;
+}
+
+.comparison_metric_row .is-reference {
+  color: var(--color-text-main);
+  font-weight: 600;
+}
+
+.comparison_metric_value {
+  color: var(--color-text-main);
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.comparison_metric_delta {
+  font-size: 12px;
+  font-weight: 600;
+  text-align: right;
+  white-space: nowrap;
+}
+
+/* ---------- Person path ---------- */
+.person_path_panel {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 18px;
+}
+
+.person_path_controls {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.person_path_input,
+.person_path_select {
+  min-height: 36px;
+  border: 1px solid rgba(31, 41, 55, 0.13);
+  border-radius: 8px;
+  background: #fff;
+  color: var(--color-text-main);
+  font: inherit;
+  font-size: 13px;
+}
+
+.person_path_input {
+  width: 190px;
+  padding: 0 10px;
+}
+
+.person_path_select {
+  padding: 0 9px;
+}
+
+.person_path_button {
+  min-height: 36px;
+}
+
+.person_path_error {
+  color: var(--color-accent-red);
+  font-size: 12px;
+}
+
+.person_path_results {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  max-height: 360px;
+  overflow-y: auto;
+  padding: 12px;
+  border: 1px solid rgba(31, 41, 55, 0.08);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.56);
+}
+
+.person_path_results::-webkit-scrollbar {
+  width: 10px;
+}
+
+.person_path_results::-webkit-scrollbar-thumb {
+  border: 2px solid rgba(255, 255, 255, 0.72);
+  border-radius: 999px;
+  background: rgba(47, 53, 64, 0.16);
+}
+
+.person_path_summary,
+.person_path_empty {
+  color: var(--color-text-muted);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.person_path_summary span {
+  color: var(--color-text-main);
+  font-weight: 700;
+}
+
+.person_path_days {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.person_path_day {
+  padding: 10px;
+  border: 1px solid rgba(31, 41, 55, 0.08);
+  border-radius: 8px;
+  background: #fff;
+}
+
+.person_path_day_header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  color: var(--color-text-muted);
+  font-size: 12px;
+}
+
+.person_path_day_header div:first-child {
+  color: var(--color-text-main);
+  font-weight: 700;
+}
+
+.person_path_stop_list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  margin-top: 8px;
+  font-size: 12px;
+}
+
+.person_path_stop {
+  display: grid;
+  grid-template-columns: 1fr 1fr minmax(0, 2fr) auto;
+  gap: 10px;
+  padding: 6px 8px;
+  border-radius: 6px;
+}
+
+.person_path_stop:nth-child(odd) {
+  background: rgba(61, 136, 173, 0.05);
+}
+
+.person_path_stop span:nth-child(3) {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.person_path_stop_duration {
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.person_path_show_more {
+  margin-top: 8px;
+  border: 0;
+  background: transparent;
+  color: var(--color-primary-blue);
+  cursor: pointer;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 600;
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+.person_path_totals {
+  margin-top: 10px;
+  padding-top: 10px;
+  border-top: 1px solid rgba(31, 41, 55, 0.08);
+}
+
+.person_path_totals_title {
+  margin-bottom: 5px;
+  color: var(--color-text-main);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.person_path_totals_list {
+  display: grid;
+  gap: 4px;
+  font-size: 12px;
+}
+
+.person_path_total_row {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  color: var(--color-text-muted);
+}
+
+/* ---------- Hotspot rankings ---------- */
+.poi_rankings_panel {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 18px;
+}
+
+.poi_rankings_body {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.poi_rankings_subtitle {
+  margin: 0;
+  color: var(--color-text-main);
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.hotspot_view_toggle {
+  display: inline-flex;
+  overflow: hidden;
+  border: 1px solid rgba(61, 136, 173, 0.24);
+  border-radius: 8px;
+  background: #fff;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.hotspot_view_toggle_button {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  min-height: 32px;
+  padding: 0 11px;
+  border: 0;
+  border-right: 1px solid rgba(31, 41, 55, 0.08);
+  background: transparent;
+  color: var(--color-text-muted);
+  cursor: pointer;
+}
+
+.hotspot_view_toggle_button:last-child {
+  border-right: 0;
+}
+
+.hotspot_view_toggle_button.is-active {
+  background: var(--color-primary-blue);
+  color: var(--color-text-light);
+}
+
+.hotspot_view_toggle_button span {
+  font-variant-numeric: tabular-nums;
+  opacity: 0.72;
+}
+
+.hotspot_table {
+  overflow: hidden;
+  border: 1px solid rgba(31, 41, 55, 0.08);
+  border-radius: 8px;
+  background: #fff;
+}
+
+.hotspot_table_header,
+.hotspot_row {
+  display: grid;
+  grid-template-columns: 2.5rem 2.75rem minmax(0, 1fr) 5.5rem;
+  align-items: center;
+  gap: 8px;
+}
+
+.hotspot_table_header {
+  padding: 9px 12px;
+  background: rgba(47, 53, 64, 0.025);
+  color: var(--color-text-muted);
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.hotspot_table_header span:first-child {
+  text-align: center;
+}
+
+.hotspot_table_header_peak {
+  text-align: right;
+}
+
+.hotspot_empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 160px;
+  border-top: 1px solid rgba(31, 41, 55, 0.08);
+  color: var(--color-text-muted);
+  font-size: 13px;
+}
+
+.hotspot_table_body {
+  display: flex;
+  flex-direction: column;
+}
+
+.hotspot_row {
+  padding: 10px 12px;
+  border-top: 1px solid rgba(31, 41, 55, 0.08);
+  background: rgba(255, 255, 255, 0.72);
+  transition: background-color 140ms ease;
+}
+
+.hotspot_row:hover {
+  background: #fff;
+}
+
+.hotspot_row.is-disabled {
+  background: rgba(47, 53, 64, 0.025);
+}
+
+.hotspot_rank {
+  text-align: center;
+  color: var(--color-text-muted);
+  font-size: 12px;
+  font-weight: 800;
+  font-variant-numeric: tabular-nums;
+}
+
+.hotspot_row.is-disabled .hotspot_rank {
+  color: var(--color-text-main);
+}
+
+.hotspot_switch_cell {
+  display: flex;
+  justify-content: center;
+}
+
+.hotspot_switch {
+  position: relative;
+  width: 36px;
+  height: 20px;
+  flex-shrink: 0;
+  overflow: hidden;
+  border: 1px solid rgba(31, 41, 55, 0.14);
+  border-radius: 999px;
+  background: #fff;
+  cursor: pointer;
+  transition:
+    background-color 160ms ease,
+    border-color 160ms ease;
+}
+
+.hotspot_switch:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.hotspot_switch span {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+  border-radius: 999px;
+  background: #fff;
+  box-shadow: 0 1px 3px rgba(15, 23, 42, 0.18);
+  transition: transform 160ms ease;
+}
+
+.hotspot_switch.is-checked {
+  border-color: var(--color-bg-dark);
+  background: var(--color-bg-dark);
+}
+
+.hotspot_switch.is-checked span {
+  transform: translateX(16px);
+}
+
+.hotspot_name,
+.hotspot_name_button {
+  min-width: 0;
+}
+
+.hotspot_name_button {
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+  text-align: left;
+}
+
+.hotspot_name_button:hover {
+  text-decoration: underline;
+}
+
+.hotspot_peak {
+  color: var(--color-text-main);
+  font-size: 14px;
+  font-weight: 800;
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+  text-align: right;
+}
+
+.poi_comparison_action {
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+  padding: 12px;
+  border: 1px solid rgba(31, 41, 55, 0.08);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.58);
+}
+
+.poi_comparison_action_top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.poi_comparison_action_top span {
+  color: var(--color-text-muted);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.poi_comparison_button {
+  flex-shrink: 0;
+  min-height: 34px;
+  padding: 0 12px;
+  border: 1px solid var(--color-primary-blue);
+  border-radius: 8px;
+  background: var(--color-primary-blue);
+  color: var(--color-text-light);
+  cursor: pointer;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 700;
+  transition: filter 160ms ease;
+}
+
+.poi_comparison_button:hover:not(:disabled) {
+  filter: brightness(1.05);
+}
+
+.poi_comparison_button:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.poi_comparison_progress {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  color: var(--color-text-muted);
+  font-size: 11px;
+}
+
+.poi_comparison_progress_track {
+  height: 6px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: rgba(47, 53, 64, 0.1);
+}
+
+.poi_comparison_progress_fill {
+  height: 100%;
+  border-radius: 999px;
+  background: var(--color-primary-blue);
+  transition: width 160ms ease;
+}
+
+.poi_comparison_error {
+  color: var(--color-accent-red);
+  font-size: 11px;
+}
+
+@media (max-width: 900px) {
+  .sim_run_header,
+  .sim_run_header_actions,
+  .sim_run_section_header,
+  .comparison_summary_header,
+  .poi_rankings_header,
+  .person_path_header {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .sim_run_edit_actions {
+    align-items: flex-start;
+  }
+
+  .comparison_metric_grid {
+    grid-template-columns: 1fr;
+  }
+
+  .person_path_stop {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 640px) {
+  .sim_run_container {
+    padding: 28px 16px 64px;
+  }
+
+  .sim_run_header_actions,
+  .person_path_controls,
+  .poi_comparison_action_top {
+    width: 100%;
+  }
+
+  .sim_return_button,
+  .person_path_input,
+  .person_path_select,
+  .person_path_button,
+  .poi_comparison_button {
+    width: 100%;
+  }
+
+  .sim_view_switcher,
+  .hotspot_view_toggle {
+    width: 100%;
+    overflow-x: auto;
+  }
+
+  .sim_view_switcher_button,
+  .hotspot_view_toggle_button {
+    flex: 1 0 auto;
+  }
+
+  .hotspot_table_header,
+  .hotspot_row {
+    grid-template-columns: 2rem 2.25rem minmax(0, 1fr) 4.75rem;
+  }
 }


### PR DESCRIPTION
## Summary
- Redesign the post-run simulation results page into clearer report-style sections
- Clean up comparison, map, outcome chart, person path, and hotspot panels
- Show chart legends only for plotted series and add a bottom return action

## Checks
- pnpm lint
- pnpm typecheck