### PR TITLE
Cases map: numeric SoA movement, binary patterns transport, per-place dot passthrough

### DIFF
--- a/src/app/api/patterns/route.ts
+++ b/src/app/api/patterns/route.ts
@@ -30,7 +30,13 @@ export async function POST(request: NextRequest) {
     const papdata_id = crypto.randomUUID();
     const patterns_id = crypto.randomUUID();
     const papdataPath = `${DB_FOLDER}${papdata_id}.gz`;
-    const patternsPath = `${DB_FOLDER}${patterns_id}.gz`;
+
+    // Sniff the patterns body: the compact binary (DLNOPAT) format is stored raw
+    // under `.bin` (it is already zstd-compressed); legacy JSON is gzipped under
+    // `.gz`. resolveDbDataPath detects which on read.
+    const patternsHead = Buffer.from(await patterns.slice(0, 8).arrayBuffer());
+    const patternsBinary = patternsHead.toString('latin1').startsWith('DLNOPAT');
+    const patternsPath = `${DB_FOLDER}${patterns_id}${patternsBinary ? '.bin' : '.gz'}`;
 
     const existingZone = await prisma.convenienceZone.findUnique({
       where: { id: czone_id },
@@ -46,7 +52,7 @@ export async function POST(request: NextRequest) {
 
     try {
       await Promise.all([
-        saveFileStream(patterns, patternsPath, true),
+        saveFileStream(patterns, patternsPath, !patternsBinary),
         saveFileStream(papdata, papdataPath, true)
       ]);
 

--- a/src/app/api/simdata-json/route.ts
+++ b/src/app/api/simdata-json/route.ts
@@ -5,7 +5,7 @@ import { z } from 'zod';
 import type { Prisma } from '@/generated/prisma/client';
 import { DB_FOLDER } from '@/lib/db-files';
 import { prisma } from '@/lib/prisma';
-import { processingProgress, processSimulation } from '@/lib/sim-processor';
+import { clearProcessingStatus, processSimulation } from '@/lib/sim-processor';
 
 export const maxDuration = 300;
 
@@ -109,7 +109,7 @@ export async function POST(request: Request) {
       )
       .catch((error) => {
         console.error('Simulation processing failed:', error);
-        processingProgress.delete(simData.id);
+        clearProcessingStatus(simData.id);
         prisma.simData
           .update({
             where: { id: simData.id },

--- a/src/app/api/simdata/[id]/map/route.ts
+++ b/src/app/api/simdata/[id]/map/route.ts
@@ -1,0 +1,102 @@
+import type { NextRequest } from 'next/server';
+import { DB_FOLDER } from '@/lib/db-files';
+import { loadMapCacheFrame, loadMapCacheManifest } from '@/lib/map-cache';
+import { prisma } from '@/lib/prisma';
+import { processingProgress } from '@/lib/sim-processor';
+import { jsonMessage } from '@/server/api/responses';
+import { parseNonNegativeRouteNumber } from '@/server/api/route-params';
+
+function getPublicZone<T extends { guest_claim_token_hash?: unknown }>(
+  zone: T
+) {
+  const { guest_claim_token_hash: _claimHash, ...publicZone } = zone;
+  return publicZone;
+}
+
+function getRunMetadata(globalStats: unknown) {
+  if (!globalStats || typeof globalStats !== 'object') {
+    return null;
+  }
+  const metadata = (globalStats as Record<string, unknown>).metadata;
+  return metadata === undefined ? null : metadata;
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id: idRaw } = await params;
+  const id = parseNonNegativeRouteNumber(idRaw, 'id');
+
+  if (!id.ok) {
+    return jsonMessage(id.message, id.status);
+  }
+
+  const simdata = await prisma.simData.findUnique({
+    where: { id: id.value },
+    include: { czone: true }
+  });
+
+  if (!simdata) {
+    return Response.json(
+      { message: `Could not find simdata #${id.value}` },
+      { status: 404 }
+    );
+  }
+
+  const mapCachePath = `${DB_FOLDER}${simdata.file_id}.map.json`;
+
+  try {
+    const requestedTime = request.nextUrl.searchParams.get('time');
+    if (requestedTime !== null) {
+      const time = Number(requestedTime);
+      if (!Number.isFinite(time) || time < 0) {
+        return Response.json({ message: 'Invalid time' }, { status: 400 });
+      }
+
+      const frame = await loadMapCacheFrame(mapCachePath, Math.round(time));
+      return Response.json(
+        {
+          data: {
+            time: frame.time,
+            requested_time: frame.requested_time,
+            simdata: { [frame.time.toString()]: frame.frame }
+          }
+        },
+        { headers: { 'Cache-Control': 'private, max-age=30' } }
+      );
+    }
+
+    const manifest = await loadMapCacheManifest(mapCachePath);
+    return Response.json(
+      {
+        data: {
+          name: simdata.name,
+          length: simdata.length,
+          zone: getPublicZone(simdata.czone),
+          metadata: getRunMetadata(simdata.global_stats),
+          papdata: manifest.papdata,
+          hotspots: manifest.hotspots,
+          timesteps: manifest.timesteps,
+          poiPeaks: manifest.poiPeaks
+        }
+      },
+      { headers: { 'Cache-Control': 'private, max-age=30' } }
+    );
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException)?.code !== 'ENOENT') {
+      console.error('Map cache read error:', error);
+    }
+
+    const progress = processingProgress.get(id.value) ?? 0;
+    return Response.json(
+      {
+        processing: true,
+        progress,
+        message:
+          'Simulation map data is still being processed. Please retry shortly.'
+      },
+      { status: 202 }
+    );
+  }
+}

--- a/src/app/api/simdata/[id]/map/route.ts
+++ b/src/app/api/simdata/[id]/map/route.ts
@@ -2,7 +2,7 @@ import type { NextRequest } from 'next/server';
 import { DB_FOLDER } from '@/lib/db-files';
 import { loadMapCacheFrame, loadMapCacheManifest } from '@/lib/map-cache';
 import { prisma } from '@/lib/prisma';
-import { processingProgress } from '@/lib/sim-processor';
+import { getProcessingStatus, processingStatus } from '@/lib/sim-processor';
 import { jsonMessage } from '@/server/api/responses';
 import { parseNonNegativeRouteNumber } from '@/server/api/route-params';
 
@@ -45,6 +45,17 @@ export async function GET(
   }
 
   const mapCachePath = `${DB_FOLDER}${simdata.file_id}.map.json`;
+  const activeStatus = processingStatus.get(id.value);
+  if (activeStatus) {
+    return Response.json(
+      {
+        processing: true,
+        progress: activeStatus.progress,
+        message: activeStatus.message
+      },
+      { status: 202 }
+    );
+  }
 
   try {
     const requestedTime = request.nextUrl.searchParams.get('time');
@@ -88,13 +99,12 @@ export async function GET(
       console.error('Map cache read error:', error);
     }
 
-    const progress = processingProgress.get(id.value) ?? 0;
+    const status = getProcessingStatus(id.value);
     return Response.json(
       {
         processing: true,
-        progress,
-        message:
-          'Simulation map data is still being processed. Please retry shortly.'
+        progress: status.progress,
+        message: status.message
       },
       { status: 202 }
     );

--- a/src/app/api/simdata/[id]/people-map/route.ts
+++ b/src/app/api/simdata/[id]/people-map/route.ts
@@ -8,6 +8,7 @@ import {
   placesFromNumeric
 } from '@/lib/numeric-movement';
 import { getCachedPapdata } from '@/lib/papdata-cache';
+import { ensureDotsFile, readDotsPayload } from '@/lib/people-map-cache';
 import { prisma } from '@/lib/prisma';
 import type {
   DiseaseStateTimestep,
@@ -451,12 +452,38 @@ export async function GET(
     );
   }
 
+  const fileId = simdata.file_id;
+  const papdataId = simdata.czone.papdata_id;
+  const requested = Math.round(requestedTime);
+
   try {
-    const data = await buildPeopleMapPayload(
-      simdata.file_id,
-      Math.round(requestedTime),
-      simdata.czone.papdata_id
-    );
+    // Fast path: serve a pre-baked per-timestep dot frame, generating the
+    // `{fileId}.dots.json` file once (deduped) on first request. This replaces
+    // re-streaming + parsing the whole .pat file on every frame.
+    if (papdataId) {
+      try {
+        const papdata = (await getCachedPapdata(papdataId)) as {
+          places?: Record<string, unknown>;
+        };
+        const placeIds = Object.keys(papdata.places ?? {});
+        if (placeIds.length > 0) {
+          await ensureDotsFile(fileId, placeIds);
+        }
+      } catch (bakeError) {
+        console.warn('people-map: dot frame generation failed:', bakeError);
+      }
+      const baked = await readDotsPayload(fileId, requested);
+      if (baked) {
+        return Response.json(
+          { data: baked },
+          { headers: { 'Cache-Control': 'private, max-age=30' } }
+        );
+      }
+    }
+
+    // Fallback: live per-request computation (counts-only runs, or if baking
+    // is unavailable).
+    const data = await buildPeopleMapPayload(fileId, requested, papdataId);
     return Response.json(
       { data },
       { headers: { 'Cache-Control': 'private, max-age=30' } }

--- a/src/app/api/simdata/[id]/people-map/route.ts
+++ b/src/app/api/simdata/[id]/people-map/route.ts
@@ -1,5 +1,13 @@
 import type { NextRequest } from 'next/server';
-import { readDbJson } from '@/lib/db-files';
+import { resolveDbDataPath } from '@/lib/db-files';
+import { streamJsonObjectEntries } from '@/lib/json-stream';
+import {
+  getPatternMeta,
+  isNumericTimestep,
+  type PatternMeta,
+  placesFromNumeric
+} from '@/lib/numeric-movement';
+import { getCachedPapdata } from '@/lib/papdata-cache';
 import { prisma } from '@/lib/prisma';
 import type {
   DiseaseStateTimestep,
@@ -12,7 +20,6 @@ const ACTIVE_INFECTION_MASK = 1 | 2 | 4 | 8;
 const RECOVERED_MASK = 16;
 const MAX_PEOPLE_DOTS = 12_000;
 const CACHE_LIMIT = 160;
-const RAW_RUN_CACHE_LIMIT = 1;
 
 type PeopleMapPerson = {
   id: string;
@@ -33,23 +40,17 @@ type PeopleMapPayload = {
   total_people: number;
   returned_people: number;
   sample_rate: number;
+  source: 'person' | 'aggregate';
   locations: PeopleMapLocation[];
 };
 
-type TimeKey = {
+type SelectedTimestep<T> = {
   time: number;
   key: string;
-};
-
-type RawRunData = {
-  simData: Record<string, DiseaseStateTimestep>;
-  patternData: Record<string, PatternTimestep>;
-  simTimes: TimeKey[];
-  patternTimes: TimeKey[];
+  value: T;
 };
 
 const responseCache = new Map<string, PeopleMapPayload>();
-const rawRunCache = new Map<string, RawRunData>();
 
 function cachePayload(key: string, payload: PeopleMapPayload) {
   responseCache.set(key, payload);
@@ -60,18 +61,6 @@ function cachePayload(key: string, payload: PeopleMapPayload) {
   const oldestKey = responseCache.keys().next().value;
   if (oldestKey) {
     responseCache.delete(oldestKey);
-  }
-}
-
-function cacheRawRunData(fileId: string, data: RawRunData) {
-  rawRunCache.set(fileId, data);
-  if (rawRunCache.size <= RAW_RUN_CACHE_LIMIT) {
-    return;
-  }
-
-  const oldestKey = rawRunCache.keys().next().value;
-  if (oldestKey) {
-    rawRunCache.delete(oldestKey);
   }
 }
 
@@ -118,55 +107,6 @@ function buildRecoveredSet(timestep: DiseaseStateTimestep | null) {
   return recovered;
 }
 
-function getSortedTimeKeys(data: Record<string, unknown>) {
-  return Object.keys(data)
-    .map((key) => ({ key, time: Number(key) }))
-    .filter((entry) => Number.isFinite(entry.time))
-    .sort((left, right) => left.time - right.time);
-}
-
-async function loadRawRunData(fileId: string) {
-  const cached = rawRunCache.get(fileId);
-  if (cached) {
-    rawRunCache.delete(fileId);
-    rawRunCache.set(fileId, cached);
-    return cached;
-  }
-
-  const [simData, patternData] = await Promise.all([
-    readDbJson<Record<string, DiseaseStateTimestep>>(fileId, '.sim'),
-    readDbJson<Record<string, PatternTimestep>>(fileId, '.pat')
-  ]);
-
-  const data = {
-    simData,
-    patternData,
-    simTimes: getSortedTimeKeys(simData),
-    patternTimes: getSortedTimeKeys(patternData)
-  } satisfies RawRunData;
-
-  cacheRawRunData(fileId, data);
-  return data;
-}
-
-function findTimeIndexAtOrBefore(times: TimeKey[], targetTime: number) {
-  let low = 0;
-  let high = times.length - 1;
-  let best = -1;
-
-  while (low <= high) {
-    const middle = Math.floor((low + high) / 2);
-    if (times[middle].time <= targetTime) {
-      best = middle;
-      low = middle + 1;
-    } else {
-      high = middle - 1;
-    }
-  }
-
-  return best;
-}
-
 function shouldIncludePerson(
   personId: string,
   infected: boolean,
@@ -181,9 +121,193 @@ function shouldIncludePerson(
   return hashString(personId) % sampleRate === 0;
 }
 
+function toNonNegativeCount(value: unknown) {
+  const count = Number(value);
+  if (!Number.isFinite(count) || count <= 0) {
+    return 0;
+  }
+  return Math.trunc(count);
+}
+
+function hasAggregatePlacesOnly(
+  patternValue: PatternTimestep
+): patternValue is PatternTimestep & { p: number[] } {
+  return (
+    Array.isArray(patternValue.p) &&
+    !Array.isArray(patternValue.loc) &&
+    Object.keys(patternValue.places ?? {}).length === 0
+  );
+}
+
+async function loadSortedPlaceIds(papdataId: string) {
+  const papdata = await getCachedPapdata(papdataId);
+  return Object.keys(papdata.places).sort((a, b) => Number(a) - Number(b));
+}
+
+function addAggregatePeople(
+  people: PeopleMapPerson[],
+  placeId: string,
+  status: 'i' | 'u',
+  count: number
+) {
+  const infected = status === 'i';
+  for (let index = 0; index < count; index += 1) {
+    people.push({
+      id: `agg:${placeId}:${status}:${index}`,
+      infected,
+      newly_infected: false,
+      recovered: false
+    });
+  }
+}
+
+async function buildAggregatePeopleMapPayload(
+  patternTime: SelectedTimestep<PatternTimestep & { p: number[] }>,
+  requestedTime: number,
+  papdataId: string
+): Promise<PeopleMapPayload> {
+  const placeIds = await loadSortedPlaceIds(papdataId);
+  const countsByPlace: {
+    placeId: string;
+    population: number;
+    infected: number;
+  }[] = [];
+
+  let totalPeople = 0;
+  const placeCount = Math.min(
+    placeIds.length,
+    Math.floor(patternTime.value.p.length / 2)
+  );
+  for (let index = 0; index < placeCount; index += 1) {
+    const population = toNonNegativeCount(patternTime.value.p[index * 2]);
+    if (population === 0) {
+      continue;
+    }
+
+    const infected = Math.min(
+      population,
+      toNonNegativeCount(patternTime.value.p[index * 2 + 1])
+    );
+    totalPeople += population;
+    countsByPlace.push({
+      placeId: placeIds[index],
+      population,
+      infected
+    });
+  }
+
+  const sampleRate = Math.max(1, Math.ceil(totalPeople / MAX_PEOPLE_DOTS));
+  let returnedPeople = 0;
+  const locations: PeopleMapLocation[] = [];
+
+  for (const { placeId, population, infected } of countsByPlace) {
+    const uninfected = population - infected;
+    const infectedSamples =
+      infected > 0
+        ? Math.min(infected, Math.max(1, Math.ceil(infected / sampleRate)))
+        : 0;
+    const uninfectedSamples =
+      uninfected > 0
+        ? Math.min(
+            uninfected,
+            Math.max(1, Math.ceil(uninfected / sampleRate))
+          )
+        : 0;
+    const sampledPeople: PeopleMapPerson[] = [];
+
+    addAggregatePeople(sampledPeople, placeId, 'i', infectedSamples);
+    addAggregatePeople(sampledPeople, placeId, 'u', uninfectedSamples);
+
+    if (sampledPeople.length > 0) {
+      returnedPeople += sampledPeople.length;
+      locations.push({
+        type: 'places',
+        id: placeId,
+        people: sampledPeople
+      });
+    }
+  }
+
+  return {
+    time: patternTime.time,
+    requested_time: requestedTime,
+    total_people: totalPeople,
+    returned_people: returnedPeople,
+    sample_rate: sampleRate,
+    source: 'aggregate',
+    locations
+  } satisfies PeopleMapPayload;
+}
+
+async function loadSelectedSimTimestep(fileId: string, requestedTime: number) {
+  const { path, gzipped } = await resolveDbDataPath(fileId, '.sim');
+  const entries = streamJsonObjectEntries<DiseaseStateTimestep>(path, gzipped);
+  let current: SelectedTimestep<DiseaseStateTimestep> | null = null;
+  let previous: SelectedTimestep<DiseaseStateTimestep> | null = null;
+
+  for await (const { key, value } of entries) {
+    const time = Number(key);
+    if (!Number.isFinite(time)) {
+      continue;
+    }
+
+    if (time > requestedTime && current) {
+      break;
+    }
+
+    if (time <= requestedTime) {
+      previous = current;
+      current = { key, time, value };
+    }
+  }
+
+  if (!current) {
+    throw new Error('No simulation timestep found.');
+  }
+
+  return { current, previous };
+}
+
+async function loadSelectedPatternTimestep(fileId: string, targetTime: number) {
+  const { path, gzipped } = await resolveDbDataPath(fileId, '.pat');
+  const entries = streamJsonObjectEntries<PatternTimestep | PatternMeta>(
+    path,
+    gzipped
+  );
+  let current: SelectedTimestep<PatternTimestep> | null = null;
+  let meta: PatternMeta | null = null;
+
+  for await (const { key, value } of entries) {
+    if (key === 'meta') {
+      meta = getPatternMeta({ meta: value });
+      continue;
+    }
+
+    const time = Number(key);
+    if (!Number.isFinite(time)) {
+      continue;
+    }
+
+    if (time > targetTime && current) {
+      break;
+    }
+
+    if (time <= targetTime) {
+      current = { key, time, value: value as PatternTimestep };
+    }
+  }
+
+  if (!current) {
+    throw new Error('No movement timestep found.');
+  }
+
+  return { current, meta };
+}
+
 async function buildPeopleMapPayload(
   fileId: string,
-  requestedTime: number
+  requestedTime: number,
+  papdataId: string | null
 ): Promise<PeopleMapPayload> {
   const cacheKey = `${fileId}:${requestedTime}`;
   const cached = responseCache.get(cacheKey);
@@ -191,40 +315,52 @@ async function buildPeopleMapPayload(
     return cached;
   }
 
-  const rawRunData = await loadRawRunData(fileId);
-  const simTimeIndex = findTimeIndexAtOrBefore(
-    rawRunData.simTimes,
-    requestedTime
-  );
-  if (simTimeIndex < 0) {
-    throw new Error('No simulation timestep found.');
+  let { current: patternTime, meta: patternMeta } =
+    await loadSelectedPatternTimestep(fileId, requestedTime);
+
+  if (hasAggregatePlacesOnly(patternTime.value)) {
+    if (!papdataId) {
+      throw new Error('No papdata file is available for aggregate places.');
+    }
+    const payload = await buildAggregatePeopleMapPayload(
+      patternTime as SelectedTimestep<PatternTimestep & { p: number[] }>,
+      requestedTime,
+      papdataId
+    );
+    cachePayload(cacheKey, payload);
+    return payload;
   }
 
-  const simTime = rawRunData.simTimes[simTimeIndex];
-  const patternTimeIndex = findTimeIndexAtOrBefore(
-    rawRunData.patternTimes,
-    simTime.time
+  const { current: simTime, previous } = await loadSelectedSimTimestep(
+    fileId,
+    patternTime.time
   );
-  if (patternTimeIndex < 0) {
-    throw new Error('No movement timestep found.');
+
+  if (simTime.time !== patternTime.time) {
+    const alignedPattern = await loadSelectedPatternTimestep(
+      fileId,
+      simTime.time
+    );
+    patternTime = alignedPattern.current;
+    patternMeta = alignedPattern.meta ?? patternMeta;
   }
 
-  const previousSimTime =
-    simTimeIndex > 0 ? rawRunData.simTimes[simTimeIndex - 1] : null;
-  const patternTime = rawRunData.patternTimes[patternTimeIndex];
-  const simValue = rawRunData.simData[simTime.key];
-  const previousSimValue = previousSimTime
-    ? rawRunData.simData[previousSimTime.key]
-    : null;
-  const patternValue = rawRunData.patternData[patternTime.key];
-  if (!simValue || !patternValue) {
-    throw new Error('Missing timestep data.');
-  }
+  const simValue = simTime.value;
+  const previousSimValue = previous?.value ?? null;
+  const patternValue = patternTime.value;
 
   const infectedNow = buildActiveInfectedSet(simValue);
   const infectedBefore = buildActiveInfectedSet(previousSimValue);
   const recoveredNow = buildRecoveredSet(simValue);
-  const places = patternValue.places ?? {};
+  // SoA-engine runs ship per-location occupancy as the compact numeric `loc`
+  // stream; reconstruct the {placeId: [pids]} shape this view expects. Legacy
+  // runs already carry `places` directly.
+  let places = patternValue.places ?? {};
+  if (Object.keys(places).length === 0 && isNumericTimestep(patternValue)) {
+    if (patternMeta) {
+      places = placesFromNumeric(patternValue.loc, patternMeta);
+    }
+  }
   let totalPeople = 0;
   for (const people of Object.values(places)) {
     totalPeople += Array.isArray(people) ? people.length : 0;
@@ -281,6 +417,7 @@ async function buildPeopleMapPayload(
     total_people: totalPeople,
     returned_people: returnedPeople,
     sample_rate: sampleRate,
+    source: 'person',
     locations
   } satisfies PeopleMapPayload;
 
@@ -305,7 +442,7 @@ export async function GET(
 
   const simdata = await prisma.simData.findUnique({
     where: { id: id.value },
-    select: { file_id: true }
+    select: { file_id: true, czone: { select: { papdata_id: true } } }
   });
   if (!simdata) {
     return Response.json(
@@ -317,7 +454,8 @@ export async function GET(
   try {
     const data = await buildPeopleMapPayload(
       simdata.file_id,
-      Math.round(requestedTime)
+      Math.round(requestedTime),
+      simdata.czone.papdata_id
     );
     return Response.json(
       { data },

--- a/src/app/api/simdata/[id]/person-path/route.ts
+++ b/src/app/api/simdata/[id]/person-path/route.ts
@@ -1,6 +1,12 @@
 import type { NextRequest } from 'next/server';
 import { readDbJson, resolveDbDataPath } from '@/lib/db-files';
 import { streamJsonObjectEntries } from '@/lib/json-stream';
+import {
+  decodeLocationIndex,
+  getPatternMeta,
+  isNumericTimestep,
+  type PatternMeta
+} from '@/lib/numeric-movement';
 import { prisma } from '@/lib/prisma';
 import {
   getPersonSexLabel,
@@ -130,16 +136,32 @@ async function buildPersonPath(
 
   const points: TimelinePoint[] = [];
   let previousLocation: KnownLocation | null = null;
+  // SoA-engine runs lead with a non-timestep `meta` entry; resolve this
+  // person's index once and decode their location from the compact `loc`
+  // stream. Legacy runs have no `meta`/`loc` and fall back to pid-list search.
+  let meta: PatternMeta | null = null;
+  let personIdx = -1;
   let nextItem = await patternsIterator.next();
 
   while (!nextItem.done) {
-    const minute = Number(nextItem.value.key);
+    const { key, value } = nextItem.value;
+
+    if (key === 'meta') {
+      meta = getPatternMeta({ meta: value });
+      personIdx = meta ? meta.pids.indexOf(personKey) : -1;
+      nextItem = await patternsIterator.next();
+      continue;
+    }
+
+    const minute = Number(key);
     if (Number.isFinite(minute)) {
-      const location = findPersonLocation(
-        nextItem.value.value ?? {},
-        personKey,
-        previousLocation
-      );
+      const timestep = value ?? {};
+      const location: { type: 'homes' | 'places' | 'unknown'; id: string } =
+        meta && isNumericTimestep(timestep)
+          ? personIdx >= 0
+            ? decodeLocationIndex(timestep.loc[personIdx], meta)
+            : { type: 'unknown', id: 'unknown' }
+          : findPersonLocation(timestep, personKey, previousLocation);
       points.push({
         minute,
         location_type: location.type,

--- a/src/app/api/simdata/route.ts
+++ b/src/app/api/simdata/route.ts
@@ -5,7 +5,7 @@ import type { Prisma } from '@/generated/prisma/client';
 import { DB_FOLDER } from '@/lib/db-files';
 import { saveFileStream } from '@/lib/filestream';
 import { prisma } from '@/lib/prisma';
-import { processingProgress, processSimulation } from '@/lib/sim-processor';
+import { clearProcessingStatus, processSimulation } from '@/lib/sim-processor';
 
 export const maxDuration = 300;
 
@@ -83,7 +83,7 @@ export async function POST(request: NextRequest) {
         )
         .catch((e) => {
           console.error('Simulation processing failed:', e);
-          processingProgress.delete(simdata_obj.id);
+          clearProcessingStatus(simdata_obj.id);
           prisma.simData
             .update({
               where: { id: simdata_obj.id },

--- a/src/app/simulator/[run_id]/page.tsx
+++ b/src/app/simulator/[run_id]/page.tsx
@@ -15,7 +15,11 @@ import {
   type ProgressUpdate,
   runSimulation
 } from '@/lib/simulation-runner-client';
-import useMapData, { type PapData, type SimData } from '@/stores/mapdata';
+import useMapData, {
+  type PapData,
+  type PoiPeaks,
+  type SimData
+} from '@/stores/mapdata';
 import useSimSettings, {
   type SimSettings as SimSettingsState
 } from '@/stores/simsettings';
@@ -37,6 +41,8 @@ interface SimRunData {
   simdata: SimData | null;
   papdata: PapData | null;
   hotspots: { [key: string]: number[] } | null;
+  timesteps: number[] | null;
+  poiPeaks: PoiPeaks | null;
   metadata?: unknown;
 }
 
@@ -165,6 +171,8 @@ export default function SimulatorRun() {
   const setSimData = useMapData((state) => state.setSimData);
   const setPapData = useMapData((state) => state.setPapData);
   const setHotspots = useMapData((state) => state.setHotspots);
+  const setTimesteps = useMapData((state) => state.setTimesteps);
+  const setPoiPeaks = useMapData((state) => state.setPoiPeaks);
   const setRunName = useMapData((state) => state.setName);
 
   const { data: session } = useSession();
@@ -231,6 +239,8 @@ export default function SimulatorRun() {
       setSimData(null);
       setSimData(payload.simdata);
       setHotspots(payload.hotspots ?? {});
+      setTimesteps(payload.timesteps);
+      setPoiPeaks(payload.poiPeaks);
       setPapData(payload.papdata);
       setActiveView(view);
     },
@@ -239,8 +249,10 @@ export default function SimulatorRun() {
       disabledPayload,
       interventionPayload,
       setHotspots,
+      setPoiPeaks,
       setPapData,
-      setSimData
+      setSimData,
+      setTimesteps
     ]
   );
 
@@ -308,6 +320,8 @@ export default function SimulatorRun() {
       setProgress(0);
       setSimData(null);
       setPapData(null);
+      setTimesteps(null);
+      setPoiPeaks(null);
       setError(null);
       setInterventionPayload(null);
       setBaselinePayload(null);
@@ -320,7 +334,7 @@ export default function SimulatorRun() {
         // Poll until the map cache is ready (API returns 202 with progress while processing)
         let response: Response;
         while (true) {
-          response = await fetch(`/api/simdata/${run_id}`, { signal });
+          response = await fetch(`/api/simdata/${run_id}/map`, { signal });
           if (response.status !== 202) break;
           const status = await response.json();
           if (typeof status.progress === 'number') {
@@ -330,64 +344,17 @@ export default function SimulatorRun() {
         }
         if (!response.ok) throw new Error('Run not found');
 
-        const reader = response.body?.getReader();
-        if (!reader) throw new Error('No response body');
-        const decoder = new TextDecoder();
-
-        let totalSteps = 0;
-        let fullJsonString = '';
-        let maxTimestamp = 0;
-        let tail = '';
-
-        while (true) {
-          const { done, value } = await reader.read();
-
-          if (done) break;
-
-          const chunk = decoder.decode(value, { stream: true });
-          fullJsonString += chunk;
-
-          const textToScan = tail + chunk;
-          tail = chunk.slice(-50);
-
-          if (totalSteps === 0) {
-            const lengthMatch = textToScan.match(/"length":\s*(\d+)/);
-            if (lengthMatch) {
-              totalSteps = parseInt(lengthMatch[1], 10);
-            }
-          }
-
-          if (totalSteps > 0) {
-            const matches = [...textToScan.matchAll(/"(\d+)":\{"(?:h|p)"/g)];
-
-            for (const match of matches) {
-              const ts = parseInt(match[1], 10);
-              if (!Number.isNaN(ts)) {
-                maxTimestamp = Math.max(maxTimestamp, ts);
-              }
-            }
-
-            if (maxTimestamp > 0) {
-              const currentProgress = Math.min(
-                100,
-                Math.round((maxTimestamp / totalSteps) * 100)
-              );
-              setProgress((old) => Math.max(old, currentProgress));
-            }
-          }
-        }
-
         setProgress(100);
 
-        const simJson = JSON.parse(fullJsonString);
         const {
-          simdata,
           name,
           zone: zoneData,
           hotspots,
           papdata,
+          timesteps,
+          poiPeaks,
           metadata
-        } = simJson.data;
+        } = (await response.json()).data;
 
         setSettings({
           sim_id: +run_id,
@@ -396,11 +363,20 @@ export default function SimulatorRun() {
         });
 
         setSelectedZone(zoneData);
-        setSimData(simdata);
+        setSimData(null);
         setRunName(name);
         setHotspots(hotspots);
         setPapData(papdata);
-        setInterventionPayload({ simdata, papdata, hotspots, metadata });
+        setTimesteps(timesteps);
+        setPoiPeaks(poiPeaks);
+        setInterventionPayload({
+          simdata: null,
+          papdata,
+          hotspots,
+          timesteps,
+          poiPeaks,
+          metadata
+        });
 
         const loadComparisonPayload = async (
           comparisonId: number,
@@ -409,7 +385,7 @@ export default function SimulatorRun() {
           try {
             let comparisonRes: Response;
             while (true) {
-              comparisonRes = await fetch(`/api/simdata/${comparisonId}`, {
+              comparisonRes = await fetch(`/api/simdata/${comparisonId}/map`, {
                 signal
               });
               if (comparisonRes.status !== 202) break;
@@ -418,9 +394,11 @@ export default function SimulatorRun() {
             if (comparisonRes.ok) {
               const comparisonJson = await comparisonRes.json();
               return {
-                simdata: comparisonJson.data.simdata,
+                simdata: null,
                 papdata: comparisonJson.data.papdata,
                 hotspots: comparisonJson.data.hotspots,
+                timesteps: comparisonJson.data.timesteps,
+                poiPeaks: comparisonJson.data.poiPeaks,
                 metadata: comparisonJson.data.metadata
               };
             }
@@ -471,10 +449,12 @@ export default function SimulatorRun() {
     disabledSimId,
     router.replace,
     setHotspots,
+    setPoiPeaks,
     setPapData,
     setRunName,
     setSettings,
-    setSimData
+    setSimData,
+    setTimesteps
   ]);
 
   const handleTogglePoi = useCallback(
@@ -701,6 +681,8 @@ export default function SimulatorRun() {
 
                     setSimData(null);
                     setPapData(null);
+                    setTimesteps(null);
+                    setPoiPeaks(null);
                     setRunName('');
                     setSettings({ sim_id: null });
                     router.push('/simulator');

--- a/src/app/simulator/page.tsx
+++ b/src/app/simulator/page.tsx
@@ -36,12 +36,12 @@ export default function Simulator() {
   // its cached data into the map store and let the caller navigate.
   const reloadExistingRun = async (simId: number): Promise<boolean> => {
     try {
-      const res = await fetch(`/api/simdata/${simId}`);
+      const res = await fetch(`/api/simdata/${simId}/map`);
       if (!res.ok) {
         throw new Error(`Invalid simdata response ${res.status}`);
       }
       const json = await res.json();
-      setSimData(json.data.simdata);
+      setSimData(null);
       setRunName(json.data.name);
       return true;
     } catch (error) {

--- a/src/components/modelmap.tsx
+++ b/src/components/modelmap.tsx
@@ -42,9 +42,13 @@ function getMapFrameCacheKey(simId: number, timestep: number) {
 const EMPTY_HOTSPOTS: Record<string, number[]> = {};
 
 // Max consecutive playback ticks to wait for an unloaded Cases frame before
-// advancing anyway, so a missing/broken frame can't freeze playback. At
-// PLAYBACK_INTERVAL_MS (750ms) this caps a stall at ~7.5s.
-const MAX_BUFFER_HOLDS = 10;
+// advancing anyway. Per-frame people-map fetches are now ~20ms (the dots are
+// pre-baked + served from the in-memory cache), so the deep buffer this used to
+// need (for the old ~0.4-1.7s fetches) just produced long "spaced out" stalls.
+// With PREFETCH_STEPS keeping frames ready, hold at most 1 tick so playback
+// advances at a steady rate. At PLAYBACK_INTERVAL_MS (750ms) this caps a stall
+// at ~1.5s instead of ~7.5s.
+const MAX_BUFFER_HOLDS = 1;
 
 interface ModelMapProps {
   onMarkerClick: (info: { id: string; label: string; type: string }) => void;

--- a/src/components/modelmap.tsx
+++ b/src/components/modelmap.tsx
@@ -37,6 +37,11 @@ function getMapFrameCacheKey(simId: number, timestep: number) {
   return `${simId}:${timestep}`;
 }
 
+// Max consecutive playback ticks to wait for an unloaded Cases frame before
+// advancing anyway, so a missing/broken frame can't freeze playback. At
+// PLAYBACK_INTERVAL_MS (750ms) this caps a stall at ~7.5s.
+const MAX_BUFFER_HOLDS = 10;
+
 interface ModelMapProps {
   onMarkerClick: (info: { id: string; label: string; type: string }) => void;
   simId?: number | null;
@@ -75,12 +80,14 @@ export default function ModelMap({
     null
   );
   const [peopleMapError, setPeopleMapError] = useState<string | null>(null);
+  const [caseDotsVisible, setCaseDotsVisible] = useState(false);
   const peopleMapDataSimId = useRef<number | null>(null);
   const peopleMapCache = useRef<Map<string, PeopleMapData>>(new Map());
   const peopleMapRequests = useRef<Map<string, Promise<PeopleMapData>>>(
     new Map()
   );
   const mapFrameRequests = useRef<Map<string, Promise<SimData>>>(new Map());
+  const bufferHoldsRef = useRef(0);
   const [mapFrameError, setMapFrameError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -94,6 +101,7 @@ export default function ModelMap({
     setPeopleMapData(null);
     setPeopleMapError(null);
     setMapFrameError(null);
+    setCaseDotsVisible(false);
   }, [simId]);
 
   useEffect(() => {
@@ -247,6 +255,32 @@ export default function ModelMap({
     zoneGeoJSON
   ]);
 
+  // Person dots only need static place geometry (lat/lng/footprint/label),
+  // which is identical across timesteps. Deriving it from papData with a zeroed
+  // sim — rather than the per-frame `pois` — lets the dot FeatureCollection memo
+  // skip rebuilding on every count/icon recompute; it now rebuilds only when
+  // occupancy (selectedPeopleMapData) actually changes.
+  const stableDotPois = useMemo(() => {
+    if (!pap_data) {
+      return [];
+    }
+    const base = updateIcons(
+      mapCenter,
+      { h: [], p: [] },
+      pap_data,
+      {},
+      zoneGeoJSON
+    );
+    if (!disabledPoiIds?.size) {
+      return base;
+    }
+    return base.map((poi) =>
+      poi.type === 'places' && disabledPoiIds.has(String(poi.id))
+        ? { ...poi, disabled: true }
+        : poi
+    );
+  }, [disabledPoiIds, mapCenter, pap_data, zoneGeoJSON]);
+
   const selectedMapFrameLoaded =
     selectedTimestep !== null && Boolean(sim_data?.[selectedTimestep]);
 
@@ -373,7 +407,12 @@ export default function ModelMap({
   );
 
   useEffect(() => {
-    if (heatmapMode !== 'people' || !simId || selectedTimestep === null) {
+    if (
+      heatmapMode !== 'people' ||
+      !caseDotsVisible ||
+      !simId ||
+      selectedTimestep === null
+    ) {
       return;
     }
 
@@ -399,10 +438,21 @@ export default function ModelMap({
     return () => {
       active = false;
     };
-  }, [heatmapMode, loadPeopleMapData, selectedTimestep, simId]);
+  }, [
+    caseDotsVisible,
+    heatmapMode,
+    loadPeopleMapData,
+    selectedTimestep,
+    simId
+  ]);
 
   const selectedPeopleMapData = useMemo(() => {
-    if (heatmapMode !== 'people' || !simId || selectedTimestep === null) {
+    if (
+      heatmapMode !== 'people' ||
+      !caseDotsVisible ||
+      !simId ||
+      selectedTimestep === null
+    ) {
       return null;
     }
 
@@ -418,11 +468,12 @@ export default function ModelMap({
         getPeopleMapCacheKey(simId, selectedTimestep)
       ) ?? null
     );
-  }, [heatmapMode, peopleMapData, selectedTimestep, simId]);
+  }, [caseDotsVisible, heatmapMode, peopleMapData, selectedTimestep, simId]);
 
   useEffect(() => {
     if (
       heatmapMode !== 'people' ||
+      !caseDotsVisible ||
       !simId ||
       selectedTimestep === null ||
       availableTimesteps.length === 0 ||
@@ -459,6 +510,7 @@ export default function ModelMap({
     };
   }, [
     availableTimesteps,
+    caseDotsVisible,
     heatmapMode,
     loadPeopleMapData,
     selectedPeopleMapData,
@@ -478,15 +530,41 @@ export default function ModelMap({
           (ts) => ts > currentMinutes
         );
         if (nextIndex === -1) return prev;
-        return availableTimesteps[nextIndex] / 60;
+        const nextTimestep = availableTimesteps[nextIndex];
+        // Buffer like a video player: when the Cases dots are showing, don't
+        // advance to a frame whose per-person data hasn't loaded yet. The
+        // /people-map fetch (~0.4-1.7s) is slower than PLAYBACK_INTERVAL_MS, so
+        // advancing eagerly blanks the dots ("Loading cases..."). Holding on the
+        // current (already-loaded) frame keeps the dots on screen until the next
+        // frame is cached.
+        const nextFrameReady =
+          heatmapMode !== 'people' ||
+          !caseDotsVisible ||
+          !simId ||
+          peopleMapError !== null ||
+          peopleMapCache.current.has(getPeopleMapCacheKey(simId, nextTimestep));
+        if (!nextFrameReady && bufferHoldsRef.current < MAX_BUFFER_HOLDS) {
+          bufferHoldsRef.current += 1;
+          return prev;
+        }
+        bufferHoldsRef.current = 0;
+        return nextTimestep / 60;
       });
     }, PLAYBACK_INTERVAL_MS);
 
     return () => clearInterval(interval);
-  }, [isPlaying, availableTimesteps]);
+  }, [
+    isPlaying,
+    availableTimesteps,
+    heatmapMode,
+    caseDotsVisible,
+    simId,
+    peopleMapError
+  ]);
 
   const peopleMapLoading =
     heatmapMode === 'people' &&
+    caseDotsVisible &&
     !!simId &&
     selectedTimestep !== null &&
     !selectedPeopleMapData &&
@@ -506,10 +584,10 @@ export default function ModelMap({
 
   const personStatusDotGeoJSON = useMemo<PersonStatusDotFeatureCollection>(
     () =>
-      heatmapMode === 'people'
-        ? makePersonStatusDotGeoJSON(pois, selectedPeopleMapData)
+      heatmapMode === 'people' && caseDotsVisible
+        ? makePersonStatusDotGeoJSON(stableDotPois, selectedPeopleMapData)
         : { type: 'FeatureCollection', features: [] },
-    [heatmapMode, selectedPeopleMapData, pois]
+    [caseDotsVisible, heatmapMode, selectedPeopleMapData, stableDotPois]
   );
 
   useEffect(() => {
@@ -549,18 +627,22 @@ export default function ModelMap({
       </div>
       {heatmapMode === 'people' && (
         <div className="people-map-key">
-          <span className="people-map-key-item">
-            <span className="people-map-swatch people-map-swatch-blue" />
-            Uninfected
-          </span>
+          {caseDotsVisible && (
+            <span className="people-map-key-item">
+              <span className="people-map-swatch people-map-swatch-blue" />
+              Uninfected
+            </span>
+          )}
           <span className="people-map-key-item">
             <span className="people-map-swatch people-map-swatch-red" />
             Infected
           </span>
-          <span className="people-map-key-item">
-            <span className="people-map-swatch people-map-swatch-recovered" />
-            Recovered
-          </span>
+          {caseDotsVisible && (
+            <span className="people-map-key-item">
+              <span className="people-map-swatch people-map-swatch-recovered" />
+              Recovered
+            </span>
+          )}
           {selectedPeopleMapData && selectedPeopleMapData.sample_rate > 1 && (
             <span className="people-map-key-note">
               sampled 1 in {selectedPeopleMapData.sample_rate}
@@ -591,6 +673,7 @@ export default function ModelMap({
         peopleDotGeoJSON={peopleDotGeoJSON}
         peopleDotColor={peopleDotColor}
         personStatusDotGeoJSON={personStatusDotGeoJSON}
+        onCaseDotsVisibilityChange={setCaseDotsVisible}
       />
       <div className="modelmap_current_time">
         {new Date(

--- a/src/components/modelmap.tsx
+++ b/src/components/modelmap.tsx
@@ -37,6 +37,10 @@ function getMapFrameCacheKey(simId: number, timestep: number) {
   return `${simId}:${timestep}`;
 }
 
+// Stable empty default so the `pois` memo isn't invalidated by a fresh `{}`
+// reference on every render while hotspots are still loading.
+const EMPTY_HOTSPOTS: Record<string, number[]> = {};
+
 // Max consecutive playback ticks to wait for an unloaded Cases frame before
 // advancing anyway, so a missing/broken frame can't freeze playback. At
 // PLAYBACK_INTERVAL_MS (750ms) this caps a stall at ~7.5s.
@@ -63,7 +67,7 @@ export default function ModelMap({
 }: ModelMapProps) {
   const sim_data = useMapData((state) => state.simdata);
   const pap_data = useMapData((state) => state.papdata);
-  const hotspots = useMapData((state) => state.hotspots) || {};
+  const hotspots = useMapData((state) => state.hotspots) ?? EMPTY_HOTSPOTS;
   const timesteps = useMapData((state) => state.timesteps);
   const setSimData = useMapData((state) => state.setSimData);
   const [zoneGeoJSON, setZoneGeoJSON] = useState<GeoJSONData | null>(null);
@@ -225,14 +229,19 @@ export default function ModelMap({
     [simId]
   );
 
+  // Only the *current* frame's data feeds the icons. Depending on this slice
+  // rather than the whole `sim_data` object keeps prefetching/merging future
+  // frames — which replaces the `sim_data` reference on every store write —
+  // from needlessly recomputing the current frame's POIs.
+  const currentFrameData =
+    selectedTimestep !== null
+      ? (sim_data?.[selectedTimestep.toString()] ?? null)
+      : null;
+
   const pois = useMemo(() => {
-    const dataForTime =
-      selectedTimestep !== null
-        ? sim_data?.[selectedTimestep.toString()]
-        : null;
     const nextPois = updateIcons(
       mapCenter,
-      dataForTime,
+      currentFrameData,
       pap_data,
       hotspots,
       zoneGeoJSON
@@ -250,8 +259,7 @@ export default function ModelMap({
     hotspots,
     mapCenter,
     pap_data,
-    sim_data,
-    selectedTimestep,
+    currentFrameData,
     zoneGeoJSON
   ]);
 
@@ -339,16 +347,23 @@ export default function ModelMap({
 
     let active = true;
     const preloadUpcoming = async () => {
-      for (const timestep of upcomingTimesteps) {
-        if (!active) return;
-        try {
-          const nextSimData = await loadMapFrameData(timestep);
-          if (active) {
-            setSimData(nextSimData);
-          }
-        } catch (error) {
-          console.warn('Failed to preload map frame data:', error);
-        }
+      // Fetch the upcoming frames concurrently instead of serially, then merge
+      // them in a single store update.
+      const results = await Promise.all(
+        upcomingTimesteps.map((timestep) =>
+          loadMapFrameData(timestep).catch((error) => {
+            console.warn('Failed to preload map frame data:', error);
+            return null;
+          })
+        )
+      );
+      if (!active) return;
+      const merged: SimData = Object.assign(
+        {},
+        ...results.filter((r): r is SimData => r !== null)
+      );
+      if (Object.keys(merged).length > 0) {
+        setSimData(merged);
       }
     };
 
@@ -494,14 +509,16 @@ export default function ModelMap({
 
     let active = true;
     const preloadUpcoming = async () => {
-      for (const timestep of upcomingTimesteps) {
-        if (!active) return;
-        try {
-          await loadPeopleMapData(timestep);
-        } catch (error) {
-          console.warn('Failed to preload person-level map data:', error);
-        }
-      }
+      if (!active) return;
+      // Warm the cache for upcoming frames concurrently so the playback buffer
+      // (MAX_BUFFER_HOLDS) stops stalling on serial ~0.4-1.7s fetches.
+      await Promise.all(
+        upcomingTimesteps.map((timestep) =>
+          loadPeopleMapData(timestep).catch((error) => {
+            console.warn('Failed to preload person-level map data:', error);
+          })
+        )
+      );
     };
 
     preloadUpcoming();

--- a/src/components/modelmap.tsx
+++ b/src/components/modelmap.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import useMapData from '@/stores/mapdata';
+import useMapData, { type SimData } from '@/stores/mapdata';
 
 import 'maplibre-gl/dist/maplibre-gl.css';
 import '@/styles/modelmap.css';
@@ -33,6 +33,10 @@ import {
 } from '@/features/model-map/map-storage';
 import MapLegend from './maplegend';
 
+function getMapFrameCacheKey(simId: number, timestep: number) {
+  return `${simId}:${timestep}`;
+}
+
 interface ModelMapProps {
   onMarkerClick: (info: { id: string; label: string; type: string }) => void;
   simId?: number | null;
@@ -55,6 +59,8 @@ export default function ModelMap({
   const sim_data = useMapData((state) => state.simdata);
   const pap_data = useMapData((state) => state.papdata);
   const hotspots = useMapData((state) => state.hotspots) || {};
+  const timesteps = useMapData((state) => state.timesteps);
+  const setSimData = useMapData((state) => state.setSimData);
   const [zoneGeoJSON, setZoneGeoJSON] = useState<GeoJSONData | null>(null);
 
   const [maxHours, setMaxHours] = useState(1);
@@ -74,6 +80,8 @@ export default function ModelMap({
   const peopleMapRequests = useRef<Map<string, Promise<PeopleMapData>>>(
     new Map()
   );
+  const mapFrameRequests = useRef<Map<string, Promise<SimData>>>(new Map());
+  const [mapFrameError, setMapFrameError] = useState<string | null>(null);
 
   useEffect(() => {
     resetModelMapLayoutCaches();
@@ -85,6 +93,7 @@ export default function ModelMap({
     peopleMapDataSimId.current = null;
     setPeopleMapData(null);
     setPeopleMapError(null);
+    setMapFrameError(null);
   }, [simId]);
 
   useEffect(() => {
@@ -133,12 +142,15 @@ export default function ModelMap({
   }, [selectedZone]);
 
   const availableTimesteps = useMemo(() => {
+    if (timesteps?.length) {
+      return timesteps;
+    }
     if (!sim_data) return [];
     return Object.keys(sim_data)
       .map(Number)
       .filter((n) => !Number.isNaN(n))
       .sort((a, b) => a - b);
-  }, [sim_data]);
+  }, [sim_data, timesteps]);
 
   const findNearestTimestep = useCallback(
     (targetMinutes: number) => {
@@ -163,6 +175,47 @@ export default function ModelMap({
     const targetMinutes = currentTime * 60;
     return findNearestTimestep(targetMinutes);
   }, [currentTime, findNearestTimestep]);
+
+  const loadMapFrameData = useCallback(
+    async (timestep: number) => {
+      if (!simId) {
+        throw new Error('Missing simulation id.');
+      }
+
+      const timestepKey = timestep.toString();
+      const currentSimData = useMapData.getState().simdata;
+      if (currentSimData?.[timestepKey]) {
+        return { [timestepKey]: currentSimData[timestepKey] } satisfies SimData;
+      }
+
+      const cacheKey = getMapFrameCacheKey(simId, timestep);
+      const existingRequest = mapFrameRequests.current.get(cacheKey);
+      if (existingRequest) {
+        return existingRequest;
+      }
+
+      const request = fetch(`/api/simdata/${simId}/map?time=${timestep}`)
+        .then(async (response) => {
+          if (!response.ok) {
+            throw new Error(`Map frame request failed: ${response.status}`);
+          }
+          return response.json() as Promise<{ data?: { simdata?: SimData } }>;
+        })
+        .then((json) => {
+          if (!json.data?.simdata) {
+            throw new Error('Map frame response did not include simdata.');
+          }
+          return json.data.simdata;
+        })
+        .finally(() => {
+          mapFrameRequests.current.delete(cacheKey);
+        });
+
+      mapFrameRequests.current.set(cacheKey, request);
+      return request;
+    },
+    [simId]
+  );
 
   const pois = useMemo(() => {
     const dataForTime =
@@ -192,6 +245,90 @@ export default function ModelMap({
     sim_data,
     selectedTimestep,
     zoneGeoJSON
+  ]);
+
+  const selectedMapFrameLoaded =
+    selectedTimestep !== null && Boolean(sim_data?.[selectedTimestep]);
+
+  useEffect(() => {
+    if (!simId || selectedTimestep === null || selectedMapFrameLoaded) {
+      return;
+    }
+
+    let active = true;
+    setMapFrameError(null);
+
+    loadMapFrameData(selectedTimestep)
+      .then((nextSimData) => {
+        if (active) {
+          setSimData(nextSimData);
+        }
+      })
+      .catch((error) => {
+        if (!active) {
+          return;
+        }
+        console.warn('Failed to load map frame data:', error);
+        setMapFrameError('Map frame is still loading.');
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [
+    loadMapFrameData,
+    selectedMapFrameLoaded,
+    selectedTimestep,
+    setSimData,
+    simId
+  ]);
+
+  useEffect(() => {
+    if (
+      !simId ||
+      selectedTimestep === null ||
+      availableTimesteps.length === 0 ||
+      !selectedMapFrameLoaded
+    ) {
+      return;
+    }
+
+    const selectedIndex = availableTimesteps.indexOf(selectedTimestep);
+    if (selectedIndex === -1) {
+      return;
+    }
+
+    const upcomingTimesteps = availableTimesteps.slice(
+      selectedIndex + 1,
+      selectedIndex + 1 + PEOPLE_MAP_PREFETCH_STEPS
+    );
+
+    let active = true;
+    const preloadUpcoming = async () => {
+      for (const timestep of upcomingTimesteps) {
+        if (!active) return;
+        try {
+          const nextSimData = await loadMapFrameData(timestep);
+          if (active) {
+            setSimData(nextSimData);
+          }
+        } catch (error) {
+          console.warn('Failed to preload map frame data:', error);
+        }
+      }
+    };
+
+    preloadUpcoming();
+    return () => {
+      active = false;
+    };
+  }, [
+    availableTimesteps,
+    loadMapFrameData,
+    selectedMapFrameLoaded,
+    selectedTimestep,
+    setSimData,
+    simId
   ]);
 
   const loadPeopleMapData = useCallback(
@@ -264,12 +401,32 @@ export default function ModelMap({
     };
   }, [heatmapMode, loadPeopleMapData, selectedTimestep, simId]);
 
+  const selectedPeopleMapData = useMemo(() => {
+    if (heatmapMode !== 'people' || !simId || selectedTimestep === null) {
+      return null;
+    }
+
+    if (
+      peopleMapDataSimId.current === simId &&
+      peopleMapData?.requested_time === selectedTimestep
+    ) {
+      return peopleMapData;
+    }
+
+    return (
+      peopleMapCache.current.get(
+        getPeopleMapCacheKey(simId, selectedTimestep)
+      ) ?? null
+    );
+  }, [heatmapMode, peopleMapData, selectedTimestep, simId]);
+
   useEffect(() => {
     if (
       heatmapMode !== 'people' ||
       !simId ||
       selectedTimestep === null ||
-      availableTimesteps.length === 0
+      availableTimesteps.length === 0 ||
+      !selectedPeopleMapData
     ) {
       return;
     }
@@ -284,15 +441,27 @@ export default function ModelMap({
       selectedIndex + 1 + PEOPLE_MAP_PREFETCH_STEPS
     );
 
-    for (const timestep of upcomingTimesteps) {
-      loadPeopleMapData(timestep).catch((error) => {
-        console.warn('Failed to preload person-level map data:', error);
-      });
-    }
+    let active = true;
+    const preloadUpcoming = async () => {
+      for (const timestep of upcomingTimesteps) {
+        if (!active) return;
+        try {
+          await loadPeopleMapData(timestep);
+        } catch (error) {
+          console.warn('Failed to preload person-level map data:', error);
+        }
+      }
+    };
+
+    preloadUpcoming();
+    return () => {
+      active = false;
+    };
   }, [
     availableTimesteps,
     heatmapMode,
     loadPeopleMapData,
+    selectedPeopleMapData,
     selectedTimestep,
     simId
   ]);
@@ -316,33 +485,24 @@ export default function ModelMap({
     return () => clearInterval(interval);
   }, [isPlaying, availableTimesteps]);
 
+  const peopleMapLoading =
+    heatmapMode === 'people' &&
+    !!simId &&
+    selectedTimestep !== null &&
+    !selectedPeopleMapData &&
+    !peopleMapError;
+
   const peopleDotColor = heatmapMode === 'infection' ? '#dc2626' : '#2563eb';
 
   const peopleDotGeoJSON = useMemo<PeopleDotFeatureCollection>(() => {
+    if (peopleMapLoading) {
+      return makePeopleDotGeoJSON(pois, 'population');
+    }
     if (heatmapMode !== 'population' && heatmapMode !== 'infection') {
       return { type: 'FeatureCollection', features: [] };
     }
     return makePeopleDotGeoJSON(pois, heatmapMode);
-  }, [pois, heatmapMode]);
-
-  const selectedPeopleMapData = useMemo(() => {
-    if (heatmapMode !== 'people' || !simId || selectedTimestep === null) {
-      return null;
-    }
-
-    if (
-      peopleMapDataSimId.current === simId &&
-      peopleMapData?.requested_time === selectedTimestep
-    ) {
-      return peopleMapData;
-    }
-
-    return (
-      peopleMapCache.current.get(
-        getPeopleMapCacheKey(simId, selectedTimestep)
-      ) ?? null
-    );
-  }, [heatmapMode, peopleMapData, selectedTimestep, simId]);
+  }, [pois, heatmapMode, peopleMapLoading]);
 
   const personStatusDotGeoJSON = useMemo<PersonStatusDotFeatureCollection>(
     () =>
@@ -353,21 +513,18 @@ export default function ModelMap({
   );
 
   useEffect(() => {
-    if (sim_data) {
-      const keys = Object.keys(sim_data)
-        .map(Number)
-        .filter((n) => !Number.isNaN(n));
-      setMaxHours(keys.length > 0 ? Math.max(...keys) / 60 : 1);
-    }
-  }, [sim_data]);
+    setMaxHours(
+      availableTimesteps.length > 0 ? Math.max(...availableTimesteps) / 60 : 1
+    );
+  }, [availableTimesteps]);
 
   useEffect(() => {
-    if (!sim_data || maxHours <= 1) return;
+    if (availableTimesteps.length === 0 || maxHours <= 1) return;
     setCurrentTime((prev) => {
       if (!Number.isFinite(prev)) return 1;
       return Math.min(Math.max(prev, 1), maxHours);
     });
-  }, [maxHours, sim_data]);
+  }, [availableTimesteps.length, maxHours]);
 
   return (
     <div className="modelmap_panel">
@@ -409,8 +566,17 @@ export default function ModelMap({
               sampled 1 in {selectedPeopleMapData.sample_rate}
             </span>
           )}
+          {selectedPeopleMapData?.source === 'aggregate' && (
+            <span className="people-map-key-note">aggregate cases</span>
+          )}
           {peopleMapError && (
             <span className="people-map-key-note">{peopleMapError}</span>
+          )}
+          {mapFrameError && (
+            <span className="people-map-key-note">{mapFrameError}</span>
+          )}
+          {peopleMapLoading && (
+            <span className="people-map-key-note">Loading cases...</span>
           )}
         </div>
       )}

--- a/src/components/poi-rankings.tsx
+++ b/src/components/poi-rankings.tsx
@@ -227,10 +227,27 @@ export default function PoiRankings({
   const [activeView, setActiveView] = useState<RankingView>('pois');
   const simdata = useMapData((s) => s.simdata);
   const papdata = useMapData((s) => s.papdata);
+  const poiPeaks = useMapData((s) => s.poiPeaks);
 
   const poiStats = useMemo<PoiStat[]>(() => {
-    if (!simdata || !papdata?.places?.length) return [];
+    if (!papdata?.places?.length || (!poiPeaks && !simdata)) return [];
     const places = papdata.places;
+
+    if (poiPeaks) {
+      return places.map((place) => {
+        const peak = poiPeaks[String(place.id)];
+        return {
+          id: String(place.id),
+          label: place.label || `Place #${place.id}`,
+          category: place.top_category || 'Uncategorized',
+          peakInfected: peak?.infected ?? 0,
+          popAtPeak: peak?.population ?? 0
+        };
+      });
+    }
+
+    if (!simdata) return [];
+
     const count = places.length;
     const peak = new Array<number>(count).fill(0);
     const popAtPeak = new Array<number>(count).fill(0);
@@ -254,7 +271,7 @@ export default function PoiRankings({
       peakInfected: peak[index],
       popAtPeak: popAtPeak[index]
     }));
-  }, [simdata, papdata]);
+  }, [simdata, papdata, poiPeaks]);
 
   const poiRows = useMemo<RankRow[]>(() => {
     return poiStats

--- a/src/features/model-map/clustered-map.tsx
+++ b/src/features/model-map/clustered-map.tsx
@@ -94,6 +94,12 @@ export default function ClusteredMap({
   const [mapInstance, setMapInstance] = useState<ModelMapInstance | null>(null);
   const [popupInfo, setPopupInfo] = useState<PopupInfo | null>(null);
   const hasFitBounds = useRef(false);
+  const showPeopleDotLayer =
+    heatmapMode === 'population' ||
+    heatmapMode === 'infection' ||
+    (heatmapMode === 'people' &&
+      personStatusDotGeoJSON.features.length === 0 &&
+      peopleDotGeoJSON.features.length > 0);
 
   useEffect(() => {
     if (!mapInstance || !pois.length || hasFitBounds.current) return;
@@ -139,13 +145,12 @@ export default function ClusteredMap({
           isMarkers ? 'visible' : 'none'
         );
     }
-    const isDots = heatmapMode === 'population' || heatmapMode === 'infection';
     for (const id of ['people-dots-places']) {
       if (mapInstance.getLayer(id))
         mapInstance.setLayoutProperty(
           id,
           'visibility',
-          isDots ? 'visible' : 'none'
+          showPeopleDotLayer ? 'visible' : 'none'
         );
     }
     const isPeople = heatmapMode === 'people';
@@ -174,7 +179,7 @@ export default function ClusteredMap({
           isPeople ? 'visible' : 'none'
         );
     }
-  }, [heatmapMode, mapInstance]);
+  }, [heatmapMode, mapInstance, showPeopleDotLayer]);
 
   const handleMapLoad = (event: MapLoadEvent) => {
     const map = event.target as ModelMapInstance;
@@ -415,10 +420,7 @@ export default function ClusteredMap({
             filter={['!=', ['get', 'loc_type'], 'homes']}
             layout={
               {
-                visibility:
-                  heatmapMode === 'population' || heatmapMode === 'infection'
-                    ? 'visible'
-                    : 'none'
+                visibility: showPeopleDotLayer ? 'visible' : 'none'
               } as const
             }
             paint={{

--- a/src/features/model-map/clustered-map.tsx
+++ b/src/features/model-map/clustered-map.tsx
@@ -12,6 +12,8 @@ import 'maplibre-gl/dist/maplibre-gl.css';
 import '@/styles/modelmap.css';
 import EmojiOverlay from '@/features/model-map/emoji-overlay';
 import {
+  CASE_CLUSTER_MAX_ZOOM,
+  CASE_DETAIL_MIN_ZOOM,
   CLUSTER_COLOR_EXPRESSION,
   type HeatmapMode,
   PERSON_STATUS_DOT_RADIUS,
@@ -47,6 +49,7 @@ interface ClusteredMapProps {
   peopleDotGeoJSON: PeopleDotFeatureCollection;
   peopleDotColor: string;
   personStatusDotGeoJSON: PersonStatusDotFeatureCollection;
+  onCaseDotsVisibilityChange?: (visible: boolean) => void;
 }
 
 function asPointCoordinate(value: unknown): [number, number] | null {
@@ -88,16 +91,25 @@ export default function ClusteredMap({
   heatmapMode,
   peopleDotGeoJSON,
   peopleDotColor,
-  personStatusDotGeoJSON
+  personStatusDotGeoJSON,
+  onCaseDotsVisibilityChange
 }: ClusteredMapProps) {
   const mapRef = useRef<MapRef>(null);
   const [mapInstance, setMapInstance] = useState<ModelMapInstance | null>(null);
   const [popupInfo, setPopupInfo] = useState<PopupInfo | null>(null);
+  const [caseDotsZoom, setCaseDotsZoom] = useState(false);
+  const [caseDetailZoom, setCaseDetailZoom] = useState(false);
   const hasFitBounds = useRef(false);
+  // Cases view tiers: clustered infection bubbles when zoomed out, individual
+  // person dots once past CASE_CLUSTER_MAX_ZOOM, and POI footprints/labels once
+  // past CASE_DETAIL_MIN_ZOOM.
+  const showCaseClusterLayer = heatmapMode === 'people' && !caseDotsZoom;
+  const showCaseDotsLayer = heatmapMode === 'people' && caseDotsZoom;
+  const showCaseDetailLayer = heatmapMode === 'people' && caseDetailZoom;
   const showPeopleDotLayer =
     heatmapMode === 'population' ||
     heatmapMode === 'infection' ||
-    (heatmapMode === 'people' &&
+    (showCaseDotsLayer &&
       personStatusDotGeoJSON.features.length === 0 &&
       peopleDotGeoJSON.features.length > 0);
 
@@ -130,6 +142,35 @@ export default function ClusteredMap({
 
   useEffect(() => {
     if (!mapInstance) return;
+
+    const updateCaseZoom = () => {
+      const zoom = mapInstance.getZoom();
+      const nextDots = zoom >= CASE_CLUSTER_MAX_ZOOM;
+      const nextDetail = zoom >= CASE_DETAIL_MIN_ZOOM;
+      setCaseDotsZoom((previous) => (previous === nextDots ? previous : nextDots));
+      setCaseDetailZoom((previous) =>
+        previous === nextDetail ? previous : nextDetail
+      );
+    };
+
+    updateCaseZoom();
+    mapInstance.on('zoom', updateCaseZoom);
+    mapInstance.on('moveend', updateCaseZoom);
+
+    return () => {
+      mapInstance.off('zoom', updateCaseZoom);
+      mapInstance.off('moveend', updateCaseZoom);
+    };
+  }, [mapInstance]);
+
+  // Notify the parent of dots-visibility from an effect (not inside the zoom
+  // setState updater) so we never call ModelMap's setState mid-render.
+  useEffect(() => {
+    onCaseDotsVisibilityChange?.(caseDotsZoom);
+  }, [caseDotsZoom, onCaseDotsVisibilityChange]);
+
+  useEffect(() => {
+    if (!mapInstance) return;
     const markerLayers = [
       'clusters',
       'cluster-count',
@@ -153,7 +194,18 @@ export default function ClusteredMap({
           showPeopleDotLayer ? 'visible' : 'none'
         );
     }
-    const isPeople = heatmapMode === 'people';
+    for (const id of [
+      'case-clusters-circle',
+      'case-clusters-count',
+      'case-clusters-point'
+    ]) {
+      if (mapInstance.getLayer(id))
+        mapInstance.setLayoutProperty(
+          id,
+          'visibility',
+          showCaseClusterLayer ? 'visible' : 'none'
+        );
+    }
     for (const id of [
       'poi-footprint-fill',
       'poi-footprint-outline',
@@ -163,7 +215,7 @@ export default function ClusteredMap({
         mapInstance.setLayoutProperty(
           id,
           'visibility',
-          isPeople ? 'visible' : 'none'
+          showCaseDetailLayer ? 'visible' : 'none'
         );
     }
     for (const id of [
@@ -176,10 +228,17 @@ export default function ClusteredMap({
         mapInstance.setLayoutProperty(
           id,
           'visibility',
-          isPeople ? 'visible' : 'none'
+          showCaseDotsLayer ? 'visible' : 'none'
         );
     }
-  }, [heatmapMode, mapInstance, showPeopleDotLayer]);
+  }, [
+    heatmapMode,
+    mapInstance,
+    showCaseClusterLayer,
+    showCaseDetailLayer,
+    showCaseDotsLayer,
+    showPeopleDotLayer
+  ]);
 
   const handleMapLoad = (event: MapLoadEvent) => {
     const map = event.target as ModelMapInstance;
@@ -219,7 +278,9 @@ export default function ClusteredMap({
       if (clusterId === undefined) return;
       const clusterCoordinates = getFeaturePointCoordinate(feature);
       if (!clusterCoordinates) return;
-      const source = map.getSource('points');
+      const source = map.getSource(
+        heatmapMode === 'people' ? 'case-clusters' : 'points'
+      );
       if (!source?.getClusterExpansionZoom) return;
       source.getClusterExpansionZoom(clusterId).then((zoom: number) => {
         map.easeTo({
@@ -306,6 +367,8 @@ export default function ClusteredMap({
           'clusters',
           'unclustered-point-circle',
           'unclustered-point-emoji',
+          'case-clusters-circle',
+          'case-clusters-point',
           'poi-footprint-fill',
           'poi-footprint-outline',
           'poi-footprint-labels'
@@ -347,6 +410,91 @@ export default function ClusteredMap({
             />
           </Source>
         ) : null}
+        <Source
+          id="case-clusters"
+          type="geojson"
+          data={geojson}
+          cluster={true}
+          clusterMaxZoom={14}
+          clusterRadius={60}
+          clusterMinPoints={2}
+          clusterProperties={POINTS_CLUSTER_PROPERTIES}
+        >
+          <Layer
+            id="case-clusters-circle"
+            type="circle"
+            filter={['has', 'point_count']}
+            maxzoom={CASE_CLUSTER_MAX_ZOOM}
+            layout={
+              {
+                visibility: showCaseClusterLayer ? 'visible' : 'none'
+              } as const
+            }
+            paint={{
+              'circle-color': clusterColor,
+              'circle-radius': [
+                'interpolate',
+                ['linear'],
+                ['sqrt', ['to-number', ['get', 'population']]],
+                0,
+                8,
+                10,
+                16,
+                40,
+                26,
+                100,
+                38
+              ] as const,
+              'circle-opacity': 0.85,
+              'circle-stroke-width': 1,
+              'circle-stroke-color': '#fff'
+            }}
+          />
+          <Layer
+            id="case-clusters-count"
+            type="symbol"
+            filter={['has', 'point_count']}
+            maxzoom={CASE_CLUSTER_MAX_ZOOM}
+            layout={
+              {
+                visibility: showCaseClusterLayer ? 'visible' : 'none',
+                'text-field': ['get', 'population'],
+                'text-size': 12,
+                'text-allow-overlap': true,
+                'text-font': ['Open Sans Regular']
+              } as const
+            }
+            paint={{ 'text-color': '#fff', 'text-opacity': 0.95 }}
+          />
+          <Layer
+            id="case-clusters-point"
+            type="circle"
+            filter={['!', ['has', 'point_count']]}
+            maxzoom={CASE_CLUSTER_MAX_ZOOM}
+            layout={
+              {
+                visibility: showCaseClusterLayer ? 'visible' : 'none'
+              } as const
+            }
+            paint={{
+              'circle-color': clusterColor,
+              'circle-radius': [
+                'interpolate',
+                ['linear'],
+                ['sqrt', ['to-number', ['get', 'population']]],
+                0,
+                4,
+                10,
+                7,
+                40,
+                11
+              ] as const,
+              'circle-opacity': 0.85,
+              'circle-stroke-width': 1,
+              'circle-stroke-color': '#fff'
+            }}
+          />
+        </Source>
         <Source
           id="points"
           type="geojson"
@@ -417,6 +565,7 @@ export default function ClusteredMap({
           <Layer
             id="people-dots-places"
             type="circle"
+            minzoom={CASE_CLUSTER_MAX_ZOOM}
             filter={['!=', ['get', 'loc_type'], 'homes']}
             layout={
               {
@@ -447,10 +596,10 @@ export default function ClusteredMap({
           <Layer
             id="poi-footprint-fill"
             type="fill"
-            minzoom={13}
+            minzoom={CASE_DETAIL_MIN_ZOOM}
             layout={
               {
-                visibility: heatmapMode === 'people' ? 'visible' : 'none'
+                visibility: showCaseDetailLayer ? 'visible' : 'none'
               } as const
             }
             paint={{
@@ -469,10 +618,10 @@ export default function ClusteredMap({
           <Layer
             id="poi-footprint-outline"
             type="line"
-            minzoom={13}
+            minzoom={CASE_DETAIL_MIN_ZOOM}
             layout={
               {
-                visibility: heatmapMode === 'people' ? 'visible' : 'none'
+                visibility: showCaseDetailLayer ? 'visible' : 'none'
               } as const
             }
             paint={{
@@ -508,6 +657,7 @@ export default function ClusteredMap({
           <Layer
             id="person-status-uninfected"
             type="circle"
+            minzoom={CASE_CLUSTER_MAX_ZOOM}
             filter={[
               'all',
               ['==', ['get', 'infected'], false],
@@ -515,7 +665,7 @@ export default function ClusteredMap({
             ]}
             layout={
               {
-                visibility: heatmapMode === 'people' ? 'visible' : 'none'
+                visibility: showCaseDotsLayer ? 'visible' : 'none'
               } as const
             }
             paint={{
@@ -528,6 +678,7 @@ export default function ClusteredMap({
           <Layer
             id="person-status-recovered"
             type="circle"
+            minzoom={CASE_CLUSTER_MAX_ZOOM}
             filter={[
               'all',
               ['==', ['get', 'infected'], false],
@@ -535,7 +686,7 @@ export default function ClusteredMap({
             ]}
             layout={
               {
-                visibility: heatmapMode === 'people' ? 'visible' : 'none'
+                visibility: showCaseDotsLayer ? 'visible' : 'none'
               } as const
             }
             paint={{
@@ -548,10 +699,11 @@ export default function ClusteredMap({
           <Layer
             id="person-status-infected"
             type="circle"
+            minzoom={CASE_CLUSTER_MAX_ZOOM}
             filter={['==', ['get', 'infected'], true]}
             layout={
               {
-                visibility: heatmapMode === 'people' ? 'visible' : 'none'
+                visibility: showCaseDotsLayer ? 'visible' : 'none'
               } as const
             }
             paint={{
@@ -564,10 +716,11 @@ export default function ClusteredMap({
           <Layer
             id="person-status-disabled"
             type="circle"
+            minzoom={CASE_CLUSTER_MAX_ZOOM}
             filter={['==', ['get', 'disabled'], true]}
             layout={
               {
-                visibility: heatmapMode === 'people' ? 'visible' : 'none'
+                visibility: showCaseDotsLayer ? 'visible' : 'none'
               } as const
             }
             paint={{
@@ -582,10 +735,10 @@ export default function ClusteredMap({
           <Layer
             id="poi-footprint-labels"
             type="symbol"
-            minzoom={13.2}
+            minzoom={CASE_DETAIL_MIN_ZOOM}
             layout={
               {
-                visibility: heatmapMode === 'people' ? 'visible' : 'none',
+                visibility: showCaseDetailLayer ? 'visible' : 'none',
                 'text-field': ['get', 'label'],
                 'text-size': [
                   'interpolate',

--- a/src/features/model-map/map-constants.ts
+++ b/src/features/model-map/map-constants.ts
@@ -63,7 +63,10 @@ export type HeatmapMode = 'markers' | 'people' | 'population' | 'infection';
 // HeatmapMode values so the rendering paths remain available if reintroduced.
 export const HEATMAP_MODES: HeatmapMode[] = ['markers', 'people'];
 export const PLAYBACK_INTERVAL_MS = 750;
-export const PEOPLE_MAP_PREFETCH_STEPS = 4;
+// Prefetch this many upcoming Cases frames so playback never stalls waiting on a
+// fetch. Fetches are ~20ms now, so a deeper buffer is cheap and keeps the slider
+// advancing at a steady rate.
+export const PEOPLE_MAP_PREFETCH_STEPS = 8;
 export const CASE_DETAIL_MIN_ZOOM = 12.8;
 // Cases view hands off from clustered infection bubbles (zoomed out) to
 // individual person dots at this zoom; POI footprints/labels appear later, at

--- a/src/features/model-map/map-constants.ts
+++ b/src/features/model-map/map-constants.ts
@@ -64,6 +64,11 @@ export type HeatmapMode = 'markers' | 'people' | 'population' | 'infection';
 export const HEATMAP_MODES: HeatmapMode[] = ['markers', 'people'];
 export const PLAYBACK_INTERVAL_MS = 750;
 export const PEOPLE_MAP_PREFETCH_STEPS = 4;
+export const CASE_DETAIL_MIN_ZOOM = 12.8;
+// Cases view hands off from clustered infection bubbles (zoomed out) to
+// individual person dots at this zoom; POI footprints/labels appear later, at
+// CASE_DETAIL_MIN_ZOOM.
+export const CASE_CLUSTER_MAX_ZOOM = 12.0;
 
 export function applyAlpha(hex: string, alpha: number) {
   const bigint = parseInt(hex.replace('#', ''), 16);

--- a/src/features/model-map/map-types.ts
+++ b/src/features/model-map/map-types.ts
@@ -241,8 +241,14 @@ export type ModelMapInstance = {
   getLayer: (id: string) => unknown;
   getSource: (id: string) => MapSourceApi | undefined;
   getZoom: () => number;
-  off: (eventName: 'render', listener: () => void) => void;
-  on: (eventName: 'render', listener: () => void) => void;
+  off: (
+    eventName: 'render' | 'zoom' | 'moveend',
+    listener: () => void
+  ) => void;
+  on: (
+    eventName: 'render' | 'zoom' | 'moveend',
+    listener: () => void
+  ) => void;
   project: (coordinate: [number, number]) => { x: number; y: number };
   queryRenderedFeatures: (
     geometry?: unknown,

--- a/src/features/model-map/map-types.ts
+++ b/src/features/model-map/map-types.ts
@@ -130,6 +130,7 @@ export type PeopleMapData = {
   total_people: number;
   returned_people: number;
   sample_rate: number;
+  source?: 'person' | 'aggregate';
   locations: PeopleMapLocation[];
 };
 

--- a/src/lib/db-files.test.mjs
+++ b/src/lib/db-files.test.mjs
@@ -1,0 +1,35 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const dir = await mkdtemp(join(tmpdir(), 'dbfiles-'));
+process.env.DB_FOLDER = dir + '/';
+
+const { resolveDbDataPath } = await import('./db-files.ts');
+
+test('resolves .gz as gzipped JSON', async () => {
+  await writeFile(join(dir, 'jsonzone.gz'), Buffer.from('gz'));
+  const r = await resolveDbDataPath('jsonzone');
+  assert.equal(r.gzipped, true);
+  assert.ok(r.path.endsWith('jsonzone.gz'));
+});
+
+test('resolves .bin as raw (not gzipped) binary patterns', async () => {
+  await writeFile(join(dir, 'binzone.bin'), Buffer.from('DLNOPAT1...'));
+  const r = await resolveDbDataPath('binzone');
+  assert.equal(r.gzipped, false);
+  assert.ok(r.path.endsWith('binzone.bin'));
+});
+
+test('.gz wins when both exist (single-format per zone in practice)', async () => {
+  await writeFile(join(dir, 'both.gz'), Buffer.from('gz'));
+  await writeFile(join(dir, 'both.bin'), Buffer.from('DLNOPAT1'));
+  const r = await resolveDbDataPath('both');
+  assert.ok(r.path.endsWith('both.gz'));
+});
+
+test.after(async () => {
+  await rm(dir, { recursive: true, force: true });
+});

--- a/src/lib/db-files.ts
+++ b/src/lib/db-files.ts
@@ -21,6 +21,14 @@ export async function resolveDbDataPath(
     return { path: gzPath, gzipped: true };
   } catch {}
 
+  // Binary patterns (DLNOPAT) are stored raw under `.bin` — already
+  // zstd-compressed, so served as-is (not gunzipped).
+  const binPath = `${basePath}.bin`;
+  try {
+    await access(binPath, constants.F_OK);
+    return { path: binPath, gzipped: false };
+  } catch {}
+
   await access(basePath, constants.F_OK);
   return { path: basePath, gzipped: false };
 }

--- a/src/lib/map-cache.ts
+++ b/src/lib/map-cache.ts
@@ -1,0 +1,318 @@
+import { open, readFile, stat } from 'node:fs/promises';
+
+const PAPDATA_MARKER = ',"papdata":';
+const SIMDATA_MARKER = ',"simdata":';
+const HOTSPOTS_MARKER = ',"hotspots":';
+const CACHE_LIMIT = 4;
+
+export type MapCacheFrame = {
+  h: number[];
+  p: number[];
+};
+
+export type PoiPeak = {
+  infected: number;
+  population: number;
+};
+
+export type PoiPeaks = Record<string, PoiPeak>;
+
+type FrameIndex = {
+  key: string;
+  time: number;
+  byteStart: number;
+  byteLength: number;
+};
+
+export type MapCacheManifest = {
+  papdata: unknown;
+  hotspots: Record<string, number[]>;
+  timesteps: number[];
+  poiPeaks: PoiPeaks;
+};
+
+type CachedManifest = MapCacheManifest & {
+  frames: FrameIndex[];
+  mtimeMs: number;
+  size: number;
+  lastAccess: number;
+};
+
+const manifestCache = new Map<string, CachedManifest>();
+
+function cacheManifest(filePath: string, manifest: CachedManifest) {
+  manifestCache.set(filePath, manifest);
+  if (manifestCache.size <= CACHE_LIMIT) {
+    return;
+  }
+
+  let oldestKey = '';
+  let oldestAccess = Infinity;
+  for (const [key, cached] of manifestCache) {
+    if (cached.lastAccess < oldestAccess) {
+      oldestKey = key;
+      oldestAccess = cached.lastAccess;
+    }
+  }
+
+  if (oldestKey) {
+    manifestCache.delete(oldestKey);
+  }
+}
+
+function findJsonValueEnd(input: string, start: number) {
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+
+  for (let index = start; index < input.length; index += 1) {
+    const char = input[index];
+
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === '\\') {
+        escaped = true;
+      } else if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (char === '"') {
+      inString = true;
+      continue;
+    }
+
+    if (char === '{' || char === '[') {
+      depth += 1;
+      continue;
+    }
+
+    if (char === '}' || char === ']') {
+      depth -= 1;
+      if (depth === 0) {
+        return index + 1;
+      }
+    }
+  }
+
+  throw new Error('Could not find JSON value end in map cache.');
+}
+
+function toNonNegativeCount(value: unknown) {
+  const count = Number(value);
+  if (!Number.isFinite(count) || count <= 0) {
+    return 0;
+  }
+  return Math.trunc(count);
+}
+
+function getPapdataPlaces(papdata: unknown) {
+  if (!papdata || typeof papdata !== 'object') {
+    return [];
+  }
+
+  const places = (papdata as { places?: unknown }).places;
+  return Array.isArray(places) ? places : [];
+}
+
+function getPlaceId(place: unknown, index: number) {
+  if (place && typeof place === 'object' && 'id' in place) {
+    const id = (place as { id?: unknown }).id;
+    if (id !== undefined && id !== null) {
+      return String(id);
+    }
+  }
+  return String(index);
+}
+
+function updatePoiPeaks(
+  poiPeaks: PoiPeaks,
+  places: unknown[],
+  frame: MapCacheFrame
+) {
+  for (let index = 0; index < places.length; index += 1) {
+    const infected = toNonNegativeCount(frame.p?.[index * 2 + 1]);
+    if (infected === 0) {
+      continue;
+    }
+
+    const placeId = getPlaceId(places[index], index);
+    const current = poiPeaks[placeId];
+    if (current && current.infected >= infected) {
+      continue;
+    }
+
+    poiPeaks[placeId] = {
+      infected,
+      population: toNonNegativeCount(frame.p?.[index * 2])
+    };
+  }
+}
+
+async function buildManifest(filePath: string, mtimeMs: number, size: number) {
+  const raw = await readFile(filePath, 'utf8');
+  const papdataIndex = raw.indexOf(PAPDATA_MARKER);
+  const simdataIndex = raw.indexOf(SIMDATA_MARKER);
+  const hotspotsIndex = raw.lastIndexOf(HOTSPOTS_MARKER);
+
+  if (papdataIndex < 0 || simdataIndex < 0 || hotspotsIndex < 0) {
+    throw new Error('Map cache does not contain expected sections.');
+  }
+
+  const papdataStart = papdataIndex + PAPDATA_MARKER.length;
+  const simdataStart = simdataIndex + SIMDATA_MARKER.length;
+  const simdataContentStart = simdataStart + 1;
+  const simdataContentEnd = hotspotsIndex - 1;
+  const hotspotsStart = hotspotsIndex + HOTSPOTS_MARKER.length;
+
+  if (raw[simdataStart] !== '{' || raw[simdataContentEnd] !== '}') {
+    throw new Error('Map cache simdata section is malformed.');
+  }
+
+  const papdata = JSON.parse(raw.slice(papdataStart, simdataIndex)) as unknown;
+  const hotspots = JSON.parse(raw.slice(hotspotsStart)) as Record<
+    string,
+    number[]
+  >;
+  const places = getPapdataPlaces(papdata);
+  const frames: FrameIndex[] = [];
+  const timesteps: number[] = [];
+  const poiPeaks: PoiPeaks = {};
+  const simdataContentByteStart = Buffer.byteLength(
+    raw.slice(0, simdataContentStart),
+    'utf8'
+  );
+
+  let position = simdataContentStart;
+  while (position < simdataContentEnd) {
+    while (raw[position] === ',' || /\s/.test(raw[position] ?? '')) {
+      position += 1;
+    }
+    if (position >= simdataContentEnd) {
+      break;
+    }
+
+    if (raw[position] !== '"') {
+      throw new Error('Map cache frame key is malformed.');
+    }
+
+    const keyStart = position + 1;
+    const keyEnd = raw.indexOf('"', keyStart);
+    const key = raw.slice(keyStart, keyEnd);
+    const colon = raw.indexOf(':', keyEnd + 1);
+    const valueStart = colon + 1;
+    const valueEnd = findJsonValueEnd(raw, valueStart);
+    const time = Number(key);
+
+    if (Number.isFinite(time)) {
+      const byteStart =
+        simdataContentByteStart + (valueStart - simdataContentStart);
+      const byteLength = valueEnd - valueStart;
+      frames.push({ key, time, byteStart, byteLength });
+      timesteps.push(time);
+      updatePoiPeaks(
+        poiPeaks,
+        places,
+        JSON.parse(raw.slice(valueStart, valueEnd)) as MapCacheFrame
+      );
+    }
+
+    position = valueEnd;
+  }
+
+  const manifest = {
+    papdata,
+    hotspots,
+    timesteps,
+    poiPeaks,
+    frames,
+    mtimeMs,
+    size,
+    lastAccess: Date.now()
+  } satisfies CachedManifest;
+
+  cacheManifest(filePath, manifest);
+  return manifest;
+}
+
+async function getCachedManifest(filePath: string) {
+  const cacheStat = await stat(filePath);
+  const cached = manifestCache.get(filePath);
+  if (
+    cached &&
+    cached.mtimeMs === cacheStat.mtimeMs &&
+    cached.size === cacheStat.size
+  ) {
+    cached.lastAccess = Date.now();
+    return cached;
+  }
+
+  return buildManifest(filePath, cacheStat.mtimeMs, cacheStat.size);
+}
+
+function findNearestFrame(frames: FrameIndex[], requestedTime: number) {
+  if (frames.length === 0) {
+    return null;
+  }
+
+  let nearest = frames[0];
+  for (const frame of frames) {
+    if (
+      Math.abs(frame.time - requestedTime) <
+      Math.abs(nearest.time - requestedTime)
+    ) {
+      nearest = frame;
+    }
+    if (frame.time > requestedTime) {
+      break;
+    }
+  }
+
+  return nearest;
+}
+
+export async function loadMapCacheManifest(
+  filePath: string
+): Promise<MapCacheManifest> {
+  const { papdata, hotspots, timesteps, poiPeaks } =
+    await getCachedManifest(filePath);
+  return { papdata, hotspots, timesteps, poiPeaks };
+}
+
+export async function loadMapCacheFrame(
+  filePath: string,
+  requestedTime: number
+) {
+  const manifest = await getCachedManifest(filePath);
+  const frameIndex = findNearestFrame(manifest.frames, requestedTime);
+  if (!frameIndex) {
+    throw new Error('No map timestep found.');
+  }
+
+  const file = await open(filePath, 'r');
+  try {
+    const buffer = Buffer.alloc(frameIndex.byteLength);
+    let bytesRead = 0;
+    while (bytesRead < frameIndex.byteLength) {
+      const result = await file.read(
+        buffer,
+        bytesRead,
+        frameIndex.byteLength - bytesRead,
+        frameIndex.byteStart + bytesRead
+      );
+      if (result.bytesRead === 0) {
+        throw new Error('Unexpected end of map cache frame.');
+      }
+      bytesRead += result.bytesRead;
+    }
+    return {
+      time: frameIndex.time,
+      requested_time: requestedTime,
+      frame: JSON.parse(buffer.toString('utf8')) as MapCacheFrame
+    };
+  } finally {
+    await file.close();
+  }
+}

--- a/src/lib/numeric-movement.ts
+++ b/src/lib/numeric-movement.ts
@@ -1,0 +1,81 @@
+import type { PatternMeta, PatternTimestep } from './simulation-data';
+
+export type { PatternMeta } from './simulation-data';
+
+/**
+ * Reconstruct per-person location from the SoA engine's compact numeric
+ * movement stream. The engine emits, per timestep, a `loc` array
+ * (`loc[personIdx] = locationIdx`, -1 = unplaced) plus a one-time `meta` entry
+ * mapping indices back to ids. This keeps the per-person map views working
+ * without the engine ever materializing pid lists (the cost the numeric
+ * snapshot exists to avoid). Legacy runs keep their `{homes,places:{id:[pids]}}`
+ * shape and bypass these helpers.
+ */
+
+/** A timestep is in numeric form when it carries the per-person `loc` array. */
+export function isNumericTimestep(
+  value: PatternTimestep | null | undefined
+): value is PatternTimestep & { loc: number[] } {
+  return !!value && Array.isArray(value.loc);
+}
+
+/** Read `meta` from a parsed patterns object (non-timestep key), if present. */
+export function getPatternMeta(
+  patternData: Record<string, unknown>
+): PatternMeta | null {
+  const meta = patternData?.meta as PatternMeta | undefined;
+  if (
+    meta &&
+    Array.isArray(meta.pids) &&
+    Array.isArray(meta.loc_ids) &&
+    typeof meta.n_homes === 'number'
+  ) {
+    return meta;
+  }
+  return null;
+}
+
+/**
+ * Reconstruct `{ placeId: [pids] }` for a numeric timestep (places only — homes
+ * are skipped, matching what the people-map view renders).
+ */
+export function placesFromNumeric(
+  loc: number[],
+  meta: PatternMeta
+): Record<string, string[]> {
+  const { pids, loc_ids, n_homes } = meta;
+  const places: Record<string, string[]> = {};
+  for (let personIdx = 0; personIdx < loc.length; personIdx += 1) {
+    const locIdx = loc[personIdx];
+    // -1 (unplaced) and home indices (< n_homes) are not rendered as place dots.
+    if (locIdx < n_homes) continue;
+    const placeId = loc_ids[locIdx];
+    if (placeId === undefined) continue;
+    const pid = pids[personIdx];
+    if (pid === undefined) continue;
+    let people = places[placeId];
+    if (!people) {
+      people = [];
+      places[placeId] = people;
+    }
+    people.push(pid);
+  }
+  return places;
+}
+
+/** Decode a single location index into its `{type, id}` (homes or places). */
+export function decodeLocationIndex(
+  locIdx: number | undefined,
+  meta: PatternMeta
+): { type: 'homes' | 'places' | 'unknown'; id: string } {
+  if (locIdx === undefined || locIdx < 0) {
+    return { type: 'unknown', id: 'unknown' };
+  }
+  const id = meta.loc_ids[locIdx];
+  if (id === undefined) {
+    return { type: 'unknown', id: 'unknown' };
+  }
+  return locIdx < meta.n_homes
+    ? { type: 'homes', id }
+    : { type: 'places', id };
+}

--- a/src/lib/people-map-cache.ts
+++ b/src/lib/people-map-cache.ts
@@ -278,40 +278,6 @@ export async function ensureDotsFile(
   return pending;
 }
 
-/**
- * Bake the dots file in the background from already-parsed data, WITHOUT
- * blocking the caller. Registers the bake in the inflight map so a concurrent
- * `ensureDotsFile` (e.g. the user opening the Cases view) dedupes against it
- * instead of starting a second bake. Used by sim-processor so the run view can
- * unblock as soon as the charts + map cache are ready, while the (heavier) dot
- * frames finish a moment later in the background.
- */
-export function bakeDotsInBackground(
-  fileId: string,
-  simData: Record<string, DiseaseStateTimestep>,
-  patData: Record<string, PatternTimestep>,
-  placeIds: string[]
-): void {
-  if (inflightGeneration.has(fileId)) return;
-  // writeDotsFile's loop is synchronous CPU work, so calling it without await
-  // still blocks the caller until it finishes. Defer it to a later macrotask
-  // (setImmediate) so processSimulation returns and the run's stats/map persist
-  // first — the run view unblocks without waiting on the dot frames.
-  const pending = new Promise<boolean>((resolve) => {
-    setImmediate(() => {
-      writeDotsFile(fileId, simData, patData, placeIds)
-        .then(resolve)
-        .catch((err) => {
-          console.warn('bakeDotsInBackground: dot frame pre-bake failed:', err);
-          resolve(false);
-        });
-    });
-  }).finally(() => {
-    inflightGeneration.delete(fileId);
-  });
-  inflightGeneration.set(fileId, pending);
-}
-
 function cacheDots(filePath: string, entry: CachedDots) {
   dotsCache.set(filePath, entry);
   if (dotsCache.size <= DOTS_CACHE_LIMIT) {

--- a/src/lib/people-map-cache.ts
+++ b/src/lib/people-map-cache.ts
@@ -126,6 +126,29 @@ function fillPlaceCounts(
   meta: PatternMeta | null,
   placeIndex: Map<string, number>
 ) {
+  // Fast path: the SoA engine emits per-place [infected, recovered] dot counts
+  // (`pdots`) alongside the per-place [count, ...] (`p`) array, so read them
+  // directly instead of reconstructing per person from `loc` + the sim
+  // snapshot. Byte-identical to the per-person bake (the engine computes the
+  // same recovered-precedence counts). `pdots`/`p` are places-ordered
+  // (loc_ids[n_homes:]).
+  const numeric = patternValue as unknown as { p?: number[]; pdots?: number[] };
+  if (meta && Array.isArray(numeric.pdots) && Array.isArray(numeric.p)) {
+    const { loc_ids, n_homes } = meta;
+    const p = numeric.p;
+    const pdots = numeric.pdots;
+    const nPlaces = loc_ids.length - n_homes;
+    for (let j = 0; j < nPlaces; j += 1) {
+      const idx = placeIndex.get(loc_ids[n_homes + j]);
+      if (idx === undefined) continue;
+      const base = idx * 3;
+      out[base] = p[j * 2] || 0;
+      out[base + 1] = pdots[j * 2] || 0;
+      out[base + 2] = pdots[j * 2 + 1] || 0;
+    }
+    return;
+  }
+
   const infected = buildMaskedSet(simValue, ACTIVE_INFECTION_MASK);
   const recovered = buildMaskedSet(simValue, RECOVERED_MASK);
   const places = getPlaces(patternValue, meta);
@@ -253,6 +276,40 @@ export async function ensureDotsFile(
     inflightGeneration.set(fileId, pending);
   }
   return pending;
+}
+
+/**
+ * Bake the dots file in the background from already-parsed data, WITHOUT
+ * blocking the caller. Registers the bake in the inflight map so a concurrent
+ * `ensureDotsFile` (e.g. the user opening the Cases view) dedupes against it
+ * instead of starting a second bake. Used by sim-processor so the run view can
+ * unblock as soon as the charts + map cache are ready, while the (heavier) dot
+ * frames finish a moment later in the background.
+ */
+export function bakeDotsInBackground(
+  fileId: string,
+  simData: Record<string, DiseaseStateTimestep>,
+  patData: Record<string, PatternTimestep>,
+  placeIds: string[]
+): void {
+  if (inflightGeneration.has(fileId)) return;
+  // writeDotsFile's loop is synchronous CPU work, so calling it without await
+  // still blocks the caller until it finishes. Defer it to a later macrotask
+  // (setImmediate) so processSimulation returns and the run's stats/map persist
+  // first — the run view unblocks without waiting on the dot frames.
+  const pending = new Promise<boolean>((resolve) => {
+    setImmediate(() => {
+      writeDotsFile(fileId, simData, patData, placeIds)
+        .then(resolve)
+        .catch((err) => {
+          console.warn('bakeDotsInBackground: dot frame pre-bake failed:', err);
+          resolve(false);
+        });
+    });
+  }).finally(() => {
+    inflightGeneration.delete(fileId);
+  });
+  inflightGeneration.set(fileId, pending);
 }
 
 function cacheDots(filePath: string, entry: CachedDots) {

--- a/src/lib/people-map-cache.ts
+++ b/src/lib/people-map-cache.ts
@@ -1,0 +1,423 @@
+// Pre-baked per-timestep "dot" frames for the Cases map.
+//
+// The /people-map route used to stream + gunzip + JSON-parse the whole (often
+// 70MB+) .pat file from the start on every request to find one timestep — ~3s
+// per frame, which made Cases playback crawl. Instead we bake a compact
+// per-place [population, infected, recovered] frame for every timestep ONCE
+// (lazily on first request, and at sim-processing time for new runs) into
+// `{fileId}.dots.json`, then synthesize the sampled-dot payload from those
+// counts. Frames are tiny (~a few MB total) so the whole file is parsed into a
+// small LRU cache and served by key lookup — no per-request file streaming.
+//
+// Dots are a sampled, non-interactive visualization (the person dots aren't
+// clickable; person-path uses its own id input), so synthesizing dots from
+// counts is visually identical to the old real-person sampling.
+
+import { access, readFile, rename, stat, writeFile } from 'node:fs/promises';
+import { DB_FOLDER, readDbJson } from './db-files';
+import {
+  getPatternMeta,
+  isNumericTimestep,
+  type PatternMeta,
+  placesFromNumeric
+} from './numeric-movement';
+import type {
+  DiseaseStateTimestep,
+  PatternTimestep
+} from './simulation-data';
+
+const ACTIVE_INFECTION_MASK = 1 | 2 | 4 | 8;
+const RECOVERED_MASK = 16;
+const MAX_PEOPLE_DOTS = 12_000;
+const DOTS_FILE_VERSION = 1;
+const DOTS_CACHE_LIMIT = 4;
+
+export type PeopleMapPerson = {
+  id: string;
+  infected: boolean;
+  newly_infected: boolean;
+  recovered: boolean;
+};
+
+export type PeopleMapLocation = {
+  type: 'places';
+  id: string;
+  people: PeopleMapPerson[];
+};
+
+export type PeopleMapPayload = {
+  time: number;
+  requested_time: number;
+  total_people: number;
+  returned_people: number;
+  sample_rate: number;
+  source: 'person' | 'aggregate';
+  locations: PeopleMapLocation[];
+};
+
+// On-disk shape of `{fileId}.dots.json`. `frames[minutes]` holds a flat
+// [pop, infected, recovered, pop, infected, recovered, ...] array aligned to
+// `place_ids` order.
+type DotsFile = {
+  version: number;
+  place_ids: string[];
+  frames: Record<string, number[]>;
+};
+
+type CachedDots = {
+  placeIds: string[];
+  frames: Record<string, number[]>;
+  sortedTimes: number[];
+  mtimeMs: number;
+  size: number;
+  lastAccess: number;
+};
+
+const dotsCache = new Map<string, CachedDots>();
+const inflightGeneration = new Map<string, Promise<boolean>>();
+// fileIds whose patterns carry no per-person data (counts-only) and so can't be
+// baked — remembered so we don't re-parse the whole file every request.
+const unbakeableFileIds = new Set<string>();
+
+function dotsPath(fileId: string) {
+  return `${DB_FOLDER}${fileId}.dots.json`;
+}
+
+function buildMaskedSet(
+  timestep: DiseaseStateTimestep | null | undefined,
+  mask: number
+) {
+  const set = new Set<string>();
+  if (!timestep) return set;
+  for (const people of Object.values(timestep)) {
+    for (const [personId, stateBitmask] of Object.entries(people)) {
+      if ((Number(stateBitmask) & mask) !== 0) {
+        set.add(personId);
+      }
+    }
+  }
+  return set;
+}
+
+/** Per-person reconstruction of `{ placeId: [pids] }` for one pattern timestep. */
+function getPlaces(
+  patternValue: PatternTimestep,
+  meta: PatternMeta | null
+): Record<string, string[]> {
+  const places = patternValue.places ?? {};
+  if (Object.keys(places).length > 0) {
+    return places;
+  }
+  if (isNumericTimestep(patternValue) && meta) {
+    return placesFromNumeric(patternValue.loc, meta);
+  }
+  return {};
+}
+
+/**
+ * Fill `out` (length placeIds.length * 3) with [pop, infected, recovered] per
+ * place for one timestep, using the same disease-state masks the live route
+ * uses (recovered takes precedence over active infection).
+ */
+function fillPlaceCounts(
+  out: number[],
+  simValue: DiseaseStateTimestep,
+  patternValue: PatternTimestep,
+  meta: PatternMeta | null,
+  placeIndex: Map<string, number>
+) {
+  const infected = buildMaskedSet(simValue, ACTIVE_INFECTION_MASK);
+  const recovered = buildMaskedSet(simValue, RECOVERED_MASK);
+  const places = getPlaces(patternValue, meta);
+
+  for (const [placeId, pids] of Object.entries(places)) {
+    const idx = placeIndex.get(placeId);
+    if (idx === undefined || !Array.isArray(pids)) {
+      continue;
+    }
+    let pop = 0;
+    let inf = 0;
+    let rec = 0;
+    for (const rawPersonId of pids) {
+      const personId = String(rawPersonId);
+      pop += 1;
+      if (recovered.has(personId)) {
+        rec += 1;
+      } else if (infected.has(personId)) {
+        inf += 1;
+      }
+    }
+    const base = idx * 3;
+    out[base] = pop;
+    out[base + 1] = inf;
+    out[base + 2] = rec;
+  }
+}
+
+function patternsHavePerPersonData(
+  patData: Record<string, PatternTimestep>
+): boolean {
+  let checked = 0;
+  for (const [key, value] of Object.entries(patData)) {
+    if (key === 'meta' || !Number.isFinite(Number(key))) continue;
+    if (
+      isNumericTimestep(value) ||
+      Object.keys(value?.places ?? {}).length > 0
+    ) {
+      return true;
+    }
+    if (++checked >= 8) break;
+  }
+  return false;
+}
+
+/**
+ * Compute every timestep's compact dot frame from already-parsed sim + pattern
+ * data and write `{fileId}.dots.json` atomically. Returns false (without
+ * writing) when the run is counts-only and can't be baked.
+ */
+export async function writeDotsFile(
+  fileId: string,
+  simData: Record<string, DiseaseStateTimestep>,
+  patData: Record<string, PatternTimestep>,
+  placeIds: string[]
+): Promise<boolean> {
+  if (!patternsHavePerPersonData(patData)) {
+    unbakeableFileIds.add(fileId);
+    return false;
+  }
+
+  const meta = getPatternMeta(patData as Record<string, unknown>);
+  const placeIndex = new Map(placeIds.map((id, index) => [id, index]));
+  const frames: Record<string, number[]> = {};
+
+  for (const [skey, svalue] of Object.entries(simData)) {
+    const pvalue = patData[skey];
+    if (!pvalue || !Number.isFinite(Number(skey))) {
+      continue;
+    }
+    const frame = new Array<number>(placeIds.length * 3).fill(0);
+    fillPlaceCounts(frame, svalue, pvalue, meta, placeIndex);
+    frames[skey] = frame;
+  }
+
+  const payload: DotsFile = {
+    version: DOTS_FILE_VERSION,
+    place_ids: placeIds,
+    frames
+  };
+
+  const targetPath = dotsPath(fileId);
+  const tmpPath = `${targetPath}.tmp`;
+  await writeFile(tmpPath, JSON.stringify(payload));
+  await rename(tmpPath, targetPath);
+  dotsCache.delete(targetPath);
+  return true;
+}
+
+async function generateDotsFile(
+  fileId: string,
+  placeIds: string[]
+): Promise<boolean> {
+  const [simData, patData] = await Promise.all([
+    readDbJson<Record<string, DiseaseStateTimestep>>(fileId, '.sim'),
+    readDbJson<Record<string, PatternTimestep>>(fileId, '.pat')
+  ]);
+  return writeDotsFile(fileId, simData, patData, placeIds);
+}
+
+/**
+ * Ensure `{fileId}.dots.json` exists, generating it once (deduped) from the
+ * source files if needed. Returns false when the run can't be baked (the route
+ * then falls back to the live computation).
+ */
+export async function ensureDotsFile(
+  fileId: string,
+  placeIds: string[]
+): Promise<boolean> {
+  if (unbakeableFileIds.has(fileId)) {
+    return false;
+  }
+  try {
+    await access(dotsPath(fileId));
+    return true;
+  } catch {
+    // not generated yet
+  }
+
+  let pending = inflightGeneration.get(fileId);
+  if (!pending) {
+    pending = generateDotsFile(fileId, placeIds).finally(() => {
+      inflightGeneration.delete(fileId);
+    });
+    inflightGeneration.set(fileId, pending);
+  }
+  return pending;
+}
+
+function cacheDots(filePath: string, entry: CachedDots) {
+  dotsCache.set(filePath, entry);
+  if (dotsCache.size <= DOTS_CACHE_LIMIT) {
+    return;
+  }
+  let oldestKey = '';
+  let oldestAccess = Infinity;
+  for (const [key, value] of dotsCache) {
+    if (value.lastAccess < oldestAccess) {
+      oldestKey = key;
+      oldestAccess = value.lastAccess;
+    }
+  }
+  if (oldestKey) {
+    dotsCache.delete(oldestKey);
+  }
+}
+
+async function loadDots(fileId: string): Promise<CachedDots | null> {
+  const filePath = dotsPath(fileId);
+  let fileStat: Awaited<ReturnType<typeof stat>>;
+  try {
+    fileStat = await stat(filePath);
+  } catch {
+    return null;
+  }
+
+  const cached = dotsCache.get(filePath);
+  if (
+    cached &&
+    cached.mtimeMs === fileStat.mtimeMs &&
+    cached.size === fileStat.size
+  ) {
+    cached.lastAccess = Date.now();
+    return cached;
+  }
+
+  const parsed = JSON.parse(await readFile(filePath, 'utf8')) as DotsFile;
+  if (parsed.version !== DOTS_FILE_VERSION || !parsed.frames) {
+    return null;
+  }
+  const sortedTimes = Object.keys(parsed.frames)
+    .map(Number)
+    .filter((value) => Number.isFinite(value))
+    .sort((a, b) => a - b);
+
+  const entry: CachedDots = {
+    placeIds: parsed.place_ids ?? [],
+    frames: parsed.frames,
+    sortedTimes,
+    mtimeMs: fileStat.mtimeMs,
+    size: fileStat.size,
+    lastAccess: Date.now()
+  };
+  cacheDots(filePath, entry);
+  return entry;
+}
+
+function findNearestTime(sortedTimes: number[], requestedTime: number) {
+  if (sortedTimes.length === 0) return null;
+  let nearest = sortedTimes[0];
+  for (const time of sortedTimes) {
+    if (Math.abs(time - requestedTime) < Math.abs(nearest - requestedTime)) {
+      nearest = time;
+    }
+    if (time > requestedTime) break;
+  }
+  return nearest;
+}
+
+/** Build the sampled dot payload from a place-count frame (synthetic people). */
+function synthesizePayload(
+  placeIds: string[],
+  frame: number[],
+  time: number,
+  requestedTime: number
+): PeopleMapPayload {
+  let totalPeople = 0;
+  for (let index = 0; index < placeIds.length; index += 1) {
+    totalPeople += frame[index * 3] || 0;
+  }
+  const sampleRate = Math.max(1, Math.ceil(totalPeople / MAX_PEOPLE_DOTS));
+
+  let returnedPeople = 0;
+  const locations: PeopleMapLocation[] = [];
+
+  for (let index = 0; index < placeIds.length; index += 1) {
+    const base = index * 3;
+    const population = frame[base] || 0;
+    if (population === 0) {
+      continue;
+    }
+    const infected = Math.min(population, frame[base + 1] || 0);
+    const recovered = Math.min(population - infected, frame[base + 2] || 0);
+    const uninfected = Math.max(0, population - infected - recovered);
+    const placeId = placeIds[index];
+
+    // Match the live route's semantics: every infected/recovered person is
+    // shown; only susceptibles are downsampled.
+    const uninfectedSamples =
+      uninfected > 0 ? Math.max(1, Math.ceil(uninfected / sampleRate)) : 0;
+    const people: PeopleMapPerson[] = [];
+    for (let k = 0; k < infected; k += 1) {
+      people.push({
+        id: `i:${placeId}:${k}`,
+        infected: true,
+        newly_infected: false,
+        recovered: false
+      });
+    }
+    for (let k = 0; k < recovered; k += 1) {
+      people.push({
+        id: `r:${placeId}:${k}`,
+        infected: false,
+        newly_infected: false,
+        recovered: true
+      });
+    }
+    for (let k = 0; k < uninfectedSamples; k += 1) {
+      people.push({
+        id: `u:${placeId}:${k}`,
+        infected: false,
+        newly_infected: false,
+        recovered: false
+      });
+    }
+
+    if (people.length > 0) {
+      returnedPeople += people.length;
+      locations.push({ type: 'places', id: placeId, people });
+    }
+  }
+
+  return {
+    time,
+    requested_time: requestedTime,
+    total_people: totalPeople,
+    returned_people: returnedPeople,
+    sample_rate: sampleRate,
+    source: 'person',
+    locations
+  };
+}
+
+/**
+ * Serve a pre-baked people-map frame for `requestedTime`, or null if the baked
+ * file is unavailable (caller falls back to the live computation).
+ */
+export async function readDotsPayload(
+  fileId: string,
+  requestedTime: number
+): Promise<PeopleMapPayload | null> {
+  const dots = await loadDots(fileId);
+  if (!dots) {
+    return null;
+  }
+  const nearest = findNearestTime(dots.sortedTimes, requestedTime);
+  if (nearest === null) {
+    return null;
+  }
+  const frame = dots.frames[String(nearest)];
+  if (!frame) {
+    return null;
+  }
+  return synthesizePayload(dots.placeIds, frame, nearest, requestedTime);
+}

--- a/src/lib/sim-processor.ts
+++ b/src/lib/sim-processor.ts
@@ -1,7 +1,7 @@
 import { readFile, rename, writeFile } from 'node:fs/promises';
 import { gunzipSync } from 'node:zlib';
 import { getCachedPapdata } from './papdata-cache';
-import { writeDotsFile } from './people-map-cache';
+import { bakeDotsInBackground } from './people-map-cache';
 import {
   AGE_RANGE_LABELS,
   ALL_STATE_NAMES,
@@ -365,24 +365,19 @@ export async function processSimulation(opts: ProcessOpts): Promise<ChartData> {
   await rename(tmpMapCachePath, mapCachePath);
   logPerfTiming('processSimulation map cache write', stageStart);
 
-  // Pre-bake compact per-timestep dot frames ({fileId}.dots.json) so Cases
-  // playback serves frames instantly instead of re-streaming the .pat file on
-  // every request. Best-effort: on failure the route lazily generates them on
-  // first open.
-  stageStart = nowMs();
-  setProcessingStatus(simDataId, 92, 'Writing case map frames...');
+  // Kick off the compact per-timestep dot frames ({fileId}.dots.json) in the
+  // BACKGROUND rather than awaiting them: the map cache + charts are ready now,
+  // so the run view can unblock immediately while the (heavier) dot bake
+  // finishes a moment later. It registers in the inflight map so a lazy Cases-
+  // view open dedupes against it instead of re-baking. On failure the route
+  // lazily generates the frames on first open.
   const dotsFileId = mapCachePath
     .split('/')
     .pop()
     ?.replace(/\.map\.json$/, '');
   if (dotsFileId) {
-    try {
-      await writeDotsFile(dotsFileId, simData, patData, placeIds);
-    } catch (dotsError) {
-      console.warn('processSimulation: dot frame pre-bake failed:', dotsError);
-    }
+    bakeDotsInBackground(dotsFileId, simData, patData, placeIds);
   }
-  logPerfTiming('processSimulation dot frame pre-bake', stageStart);
 
   setProcessingStatus(simDataId, 100, 'Finalizing simulation...');
   clearProcessingStatus(simDataId);

--- a/src/lib/sim-processor.ts
+++ b/src/lib/sim-processor.ts
@@ -1,6 +1,7 @@
 import { readFile, rename, writeFile } from 'node:fs/promises';
 import { gunzipSync } from 'node:zlib';
 import { getCachedPapdata } from './papdata-cache';
+import { writeDotsFile } from './people-map-cache';
 import {
   AGE_RANGE_LABELS,
   ALL_STATE_NAMES,
@@ -38,6 +39,34 @@ interface ProcessOpts {
 
 /** In-memory progress tracker for active processing jobs (simDataId -> 0-100). */
 export const processingProgress = new Map<number, number>();
+export const processingStatus = new Map<
+  number,
+  { progress: number; message: string }
+>();
+
+export function setProcessingStatus(
+  simDataId: number,
+  progress: number,
+  message: string
+) {
+  const clamped = Math.max(0, Math.min(100, Math.round(progress)));
+  processingProgress.set(simDataId, clamped);
+  processingStatus.set(simDataId, { progress: clamped, message });
+}
+
+export function clearProcessingStatus(simDataId: number) {
+  processingProgress.delete(simDataId);
+  processingStatus.delete(simDataId);
+}
+
+export function getProcessingStatus(simDataId: number) {
+  return (
+    processingStatus.get(simDataId) ?? {
+      progress: processingProgress.get(simDataId) ?? 0,
+      message: 'Processing simulation data...'
+    }
+  );
+}
 
 /**
  * Single-pass processor that streams simdata + patterns files once and produces:
@@ -56,7 +85,7 @@ export async function processSimulation(opts: ProcessOpts): Promise<ChartData> {
     mapCachePath,
     totalLength
   } = opts;
-  processingProgress.set(simDataId, 0);
+  setProcessingStatus(simDataId, 0, 'Processing simulation results...');
 
   // Load papdata from shared cache (avoids redundant gunzip)
   let stageStart = nowMs();
@@ -300,9 +329,10 @@ export async function processSimulation(opts: ProcessOpts): Promise<ChartData> {
     accum('processSimulation/global_stats_aggregation', tStage);
 
     if (totalLength > 0) {
-      processingProgress.set(
+      setProcessingStatus(
         simDataId,
-        Math.min(99, Math.round((+skey / totalLength) * 100))
+        Math.min(84, Math.round((+skey / totalLength) * 84)),
+        'Processing simulation results...'
       );
     }
   }
@@ -315,8 +345,6 @@ export async function processSimulation(opts: ProcessOpts): Promise<ChartData> {
       console.info(`[perf] ${label}: ${(perfAccum[label] / 1000).toFixed(3)}s`);
     }
   }
-
-  processingProgress.delete(simDataId);
 
   // Finalize map cache.
   //
@@ -332,9 +360,32 @@ export async function processSimulation(opts: ProcessOpts): Promise<ChartData> {
   cacheParts.push(`},"hotspots":${JSON.stringify(hotspots)}`);
   stageStart = nowMs();
   const tmpMapCachePath = `${mapCachePath}.tmp`;
+  setProcessingStatus(simDataId, 85, 'Writing map cache...');
   await writeFile(tmpMapCachePath, cacheParts.join(''));
   await rename(tmpMapCachePath, mapCachePath);
   logPerfTiming('processSimulation map cache write', stageStart);
+
+  // Pre-bake compact per-timestep dot frames ({fileId}.dots.json) so Cases
+  // playback serves frames instantly instead of re-streaming the .pat file on
+  // every request. Best-effort: on failure the route lazily generates them on
+  // first open.
+  stageStart = nowMs();
+  setProcessingStatus(simDataId, 92, 'Writing case map frames...');
+  const dotsFileId = mapCachePath
+    .split('/')
+    .pop()
+    ?.replace(/\.map\.json$/, '');
+  if (dotsFileId) {
+    try {
+      await writeDotsFile(dotsFileId, simData, patData, placeIds);
+    } catch (dotsError) {
+      console.warn('processSimulation: dot frame pre-bake failed:', dotsError);
+    }
+  }
+  logPerfTiming('processSimulation dot frame pre-bake', stageStart);
+
+  setProcessingStatus(simDataId, 100, 'Finalizing simulation...');
+  clearProcessingStatus(simDataId);
   logPerfTiming('processSimulation total', totalStart);
 
   return globalStats;

--- a/src/lib/sim-processor.ts
+++ b/src/lib/sim-processor.ts
@@ -174,54 +174,81 @@ export async function processSimulation(opts: ProcessOpts): Promise<ChartData> {
     const time = +skey / 60;
     matchedTimesteps++;
 
-    // === MAP CACHE: build infected set, homes/places arrays ===
+    // === MAP CACHE: per-location [count, infected] arrays ===
+    // The SoA engine emits these directly as { h: [...], p: [...] } (numeric
+    // format), already aligned to homeIds/placeIds order — use them as-is.
+    // Older runs emit { homes/places: {id: [pids]} }, computed here.
     let tStage = nowMs();
-    const curinfected = new Set<string>();
-    for (const people of Object.values(svalue)) {
-      for (const key of Object.keys(people as Record<string, unknown>)) {
-        curinfected.add(key);
-      }
-    }
-    accum('processSimulation/build_infected_set', tStage);
+    let homesArray: number[];
+    let placesArray: number[];
+    const numericPattern = Array.isArray(
+      (pvalue as unknown as { h?: unknown }).h
+    );
 
-    tStage = nowMs();
-    const homesArray: number[] = [];
-    for (const id of homeIds) {
-      const pop: string[] | undefined = pvalue.homes?.[id];
-      if (pop) {
-        let inf = 0;
-        for (const v of pop) {
-          if (curinfected.has(v)) inf++;
-        }
-        homesArray.push(pop.length, inf);
-      } else {
-        homesArray.push(0, 0);
-      }
-    }
-    accum('processSimulation/build_homes_array', tStage);
-
-    tStage = nowMs();
-    const placesArray: number[] = [];
-    for (const id of placeIds) {
-      const pop: string[] | undefined = pvalue.places?.[id];
-      if (pop) {
-        let inf = 0;
-        for (const v of pop) {
-          if (curinfected.has(v)) inf++;
-        }
-        placesArray.push(pop.length, inf);
+    if (numericPattern) {
+      const np = pvalue as unknown as { h: number[]; p: number[] };
+      homesArray = np.h;
+      placesArray = np.p;
+      // Hotspot tracking from the numeric places array (inf at index 2*i+1).
+      for (let i = 0; i < placeIds.length; i++) {
+        const id = placeIds[i];
+        const inf = placesArray[i * 2 + 1] || 0;
         const prevInf = prevInfected[id] || 0;
         if (inf > 0 && prevInf > 0 && inf >= prevInf * 5) {
           if (!hotspots[id]) hotspots[id] = [];
           hotspots[id].push(Number(skey));
         }
         prevInfected[id] = inf;
-      } else {
-        placesArray.push(0, 0);
-        prevInfected[id] = 0;
       }
+      accum('processSimulation/numeric_passthrough', tStage);
+    } else {
+      const curinfected = new Set<string>();
+      for (const people of Object.values(svalue)) {
+        for (const key of Object.keys(people as Record<string, unknown>)) {
+          curinfected.add(key);
+        }
+      }
+      accum('processSimulation/build_infected_set', tStage);
+
+      tStage = nowMs();
+      homesArray = [];
+      for (const id of homeIds) {
+        const pop: string[] | undefined = pvalue.homes?.[id];
+        if (pop) {
+          let inf = 0;
+          for (const v of pop) {
+            if (curinfected.has(v)) inf++;
+          }
+          homesArray.push(pop.length, inf);
+        } else {
+          homesArray.push(0, 0);
+        }
+      }
+      accum('processSimulation/build_homes_array', tStage);
+
+      tStage = nowMs();
+      placesArray = [];
+      for (const id of placeIds) {
+        const pop: string[] | undefined = pvalue.places?.[id];
+        if (pop) {
+          let inf = 0;
+          for (const v of pop) {
+            if (curinfected.has(v)) inf++;
+          }
+          placesArray.push(pop.length, inf);
+          const prevInf = prevInfected[id] || 0;
+          if (inf > 0 && prevInf > 0 && inf >= prevInf * 5) {
+            if (!hotspots[id]) hotspots[id] = [];
+            hotspots[id].push(Number(skey));
+          }
+          prevInfected[id] = inf;
+        } else {
+          placesArray.push(0, 0);
+          prevInfected[id] = 0;
+        }
+      }
+      accum('processSimulation/build_places_array', tStage);
     }
-    accum('processSimulation/build_places_array', tStage);
 
     tStage = nowMs();
     if (!first) cacheParts.push(',');

--- a/src/lib/sim-processor.ts
+++ b/src/lib/sim-processor.ts
@@ -1,7 +1,7 @@
 import { readFile, rename, writeFile } from 'node:fs/promises';
 import { gunzipSync } from 'node:zlib';
 import { getCachedPapdata } from './papdata-cache';
-import { bakeDotsInBackground } from './people-map-cache';
+import { writeDotsFile } from './people-map-cache';
 import {
   AGE_RANGE_LABELS,
   ALL_STATE_NAMES,
@@ -365,19 +365,25 @@ export async function processSimulation(opts: ProcessOpts): Promise<ChartData> {
   await rename(tmpMapCachePath, mapCachePath);
   logPerfTiming('processSimulation map cache write', stageStart);
 
-  // Kick off the compact per-timestep dot frames ({fileId}.dots.json) in the
-  // BACKGROUND rather than awaiting them: the map cache + charts are ready now,
-  // so the run view can unblock immediately while the (heavier) dot bake
-  // finishes a moment later. It registers in the inflight map so a lazy Cases-
-  // view open dedupes against it instead of re-baking. On failure the route
-  // lazily generates the frames on first open.
+  // Pre-bake compact per-timestep dot frames ({fileId}.dots.json) so the Cases
+  // view has them ready the moment the run appears (no first-open / early-
+  // playback gap). Cheap now that the engine emits per-place dot counts (the
+  // bake is a passthrough). Best-effort: on failure the route lazily generates
+  // them on first open.
+  stageStart = nowMs();
+  setProcessingStatus(simDataId, 92, 'Writing case map frames...');
   const dotsFileId = mapCachePath
     .split('/')
     .pop()
     ?.replace(/\.map\.json$/, '');
   if (dotsFileId) {
-    bakeDotsInBackground(dotsFileId, simData, patData, placeIds);
+    try {
+      await writeDotsFile(dotsFileId, simData, patData, placeIds);
+    } catch (dotsError) {
+      console.warn('processSimulation: dot frame pre-bake failed:', dotsError);
+    }
   }
+  logPerfTiming('processSimulation dot frame pre-bake', stageStart);
 
   setProcessingStatus(simDataId, 100, 'Finalizing simulation...');
   clearProcessingStatus(simDataId);

--- a/src/lib/simulation-data.ts
+++ b/src/lib/simulation-data.ts
@@ -66,8 +66,26 @@ export type PapData = {
 export type LocationOccupancy = Record<string, string[]>;
 
 export type PatternTimestep = {
+  // Legacy pid-list shape (pre-SoA-engine runs).
   homes?: LocationOccupancy;
   places?: LocationOccupancy;
+  // SoA-engine numeric shape: per-location [count, infected] arrays (h/p) and
+  // the per-person location stream (loc[personIdx] = locationIdx, -1 unplaced).
+  // Decoded via the file's one-time `meta` entry (see PatternMeta).
+  h?: number[];
+  p?: number[];
+  loc?: number[];
+};
+
+/**
+ * One-time decode tables emitted by the SoA engine under the non-timestep
+ * `meta` key of the patterns file. Lets per-person consumers reconstruct
+ * who-is-where from the compact numeric `loc` stream.
+ */
+export type PatternMeta = {
+  pids: string[]; // person index -> person id
+  loc_ids: string[]; // location index -> location id (homes first, then places)
+  n_homes: number; // loc index < n_homes is a home, otherwise a place
 };
 
 export type DiseaseStateTimestep = Record<string, Record<string, number>>;

--- a/src/lib/simulation-runner-client.ts
+++ b/src/lib/simulation-runner-client.ts
@@ -38,6 +38,52 @@ async function readResponseMessage(response: Response) {
 
 export type ProgressUpdate = { value?: number; message?: string };
 
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitForSavedRunReady(
+  simId: number,
+  onProgress: (update: ProgressUpdate) => void
+) {
+  onProgress({ value: 90, message: 'Processing simulation results...' });
+
+  while (true) {
+    const response = await fetch(`/api/simdata/${simId}/map`, {
+      cache: 'no-store'
+    });
+
+    if (response.status !== 202) {
+      if (!response.ok) {
+        throw new Error(await readResponseMessage(response));
+      }
+      break;
+    }
+
+    const payload = await response.json().catch(() => null);
+    const progress =
+      payload && typeof payload === 'object'
+        ? Number((payload as { progress?: unknown }).progress)
+        : NaN;
+    const message =
+      payload &&
+      typeof payload === 'object' &&
+      typeof (payload as { message?: unknown }).message === 'string'
+        ? (payload as { message: string }).message
+        : 'Processing simulation results...';
+
+    onProgress({
+      value: Number.isFinite(progress)
+        ? Math.max(90, Math.min(99, Math.round(90 + progress * 0.09)))
+        : 90,
+      message
+    });
+    await sleep(2000);
+  }
+
+  onProgress({ value: 100, message: 'Simulation complete.' });
+}
+
 export async function runSimulation(
   settings: SimSettingsState,
   onProgress: (update: ProgressUpdate) => void
@@ -110,7 +156,7 @@ export async function runSimulation(
             );
           }
 
-          onProgress({ value: 100, message: 'Simulation complete.' });
+          await waitForSavedRunReady(simId, onProgress);
           return simId;
         } else if (msg.type === 'error') {
           throw new Error(msg.message);
@@ -132,6 +178,6 @@ export async function runSimulation(
     throw new Error('Simulation finished but no saved run ID was returned.');
   }
 
-  onProgress({ value: 100, message: 'Simulation complete.' });
+  await waitForSavedRunReady(simId, onProgress);
   return simId;
 }

--- a/src/stores/mapdata.ts
+++ b/src/stores/mapdata.ts
@@ -54,6 +54,13 @@ interface MapDataStore {
   setPoiPeaks: (poiPeaks: PoiPeaks | null) => void;
 }
 
+// Cap how many on-demand map frames the store retains. Frames stream in during
+// playback (one per timestep), so without a bound the store grows to the whole
+// run (~100MB+ at 50k). Evicted frames are transparently re-fetched on demand,
+// and the timeline is driven by the independent `timesteps` list, so pruning
+// never shrinks the slider.
+const MAX_SIM_FRAMES = 64;
+
 const useMapData = create<MapDataStore>((set) => ({
   name: '',
   simdata: null,
@@ -71,11 +78,41 @@ const useMapData = create<MapDataStore>((set) => ({
       set({ simdata: null, hotspots: null, timesteps: null, poiPeaks: null });
       return;
     }
-    set((state) => ({
-      simdata: state.simdata
+    set((state) => {
+      const merged: SimData = state.simdata
         ? { ...state.simdata, ...newSimData }
-        : (newSimData as SimData)
-    }));
+        : { ...(newSimData as SimData) };
+
+      const keys = Object.keys(merged);
+      if (keys.length <= MAX_SIM_FRAMES) {
+        return { simdata: merged };
+      }
+
+      // Keep the window of frames nearest the most recently written frame (the
+      // playhead/prefetch region). The current frame's value reference is
+      // preserved across prunes, so memoized consumers don't recompute.
+      const anchor = Object.keys(newSimData).reduce(
+        (max, key) => Math.max(max, Number(key)),
+        Number.NEGATIVE_INFINITY
+      );
+      const keep = new Set(
+        keys
+          .slice()
+          .sort(
+            (a, b) =>
+              Math.abs(Number(a) - anchor) - Math.abs(Number(b) - anchor)
+          )
+          .slice(0, MAX_SIM_FRAMES)
+      );
+
+      const pruned: SimData = {};
+      for (const key of keys) {
+        if (keep.has(key)) {
+          pruned[key] = merged[key];
+        }
+      }
+      return { simdata: pruned };
+    });
   },
 
   setPapData: (papdata) => {

--- a/src/stores/mapdata.ts
+++ b/src/stores/mapdata.ts
@@ -30,16 +30,28 @@ export type SimData = {
   };
 };
 
+export type PoiPeaks = Record<
+  string,
+  {
+    infected: number;
+    population: number;
+  }
+>;
+
 interface MapDataStore {
   name: string;
   simdata: SimData | null;
   papdata: PapData | null;
   hotspots: { [key: string]: number[] } | null;
+  timesteps: number[] | null;
+  poiPeaks: PoiPeaks | null;
 
   setName: (name: string) => void;
   setSimData: (simdata: SimData | null) => void;
   setPapData: (papdata: PapData | null) => void;
   setHotspots: (hotspots: { [key: string]: number[] }) => void;
+  setTimesteps: (timesteps: number[] | null) => void;
+  setPoiPeaks: (poiPeaks: PoiPeaks | null) => void;
 }
 
 const useMapData = create<MapDataStore>((set) => ({
@@ -47,6 +59,8 @@ const useMapData = create<MapDataStore>((set) => ({
   simdata: null,
   papdata: null,
   hotspots: null,
+  timesteps: null,
+  poiPeaks: null,
 
   setName: (name) => {
     set({ name });
@@ -54,7 +68,7 @@ const useMapData = create<MapDataStore>((set) => ({
 
   setSimData: (newSimData) => {
     if (newSimData === null) {
-      set({ simdata: null, hotspots: null });
+      set({ simdata: null, hotspots: null, timesteps: null, poiPeaks: null });
       return;
     }
     set((state) => ({
@@ -70,6 +84,14 @@ const useMapData = create<MapDataStore>((set) => ({
 
   setHotspots: (hotspots) => {
     set({ hotspots });
+  },
+
+  setTimesteps: (timesteps) => {
+    set({ timesteps });
+  },
+
+  setPoiPeaks: (poiPeaks) => {
+    set({ poiPeaks });
   }
 }));
 


### PR DESCRIPTION
## What this ships
The Fullstack side of the engine-performance + Cases-map work (pairs with [Simulation#17](https://github.com/Delineo-Disease-Modeling/Simulation/pull/17)).

- **Consume numeric SoA movement** — read the engine's compact numeric `{h,p,loc}` snapshot (and reconstruct per-person views from it) instead of pid-list movement.
- **Binary patterns transport** — store/serve binary (`DLNOPAT`) patterns alongside JSON via magic-byte sniffing (`.bin` vs `.gz`); format-agnostic, both coexist.
- **Cases map rework** — clustered dots → individual person dots, on-demand map-frame loading, pre-baked per-timestep dot frames (`{fileId}.dots.json`).
- **Per-place dot passthrough** — when the engine emits per-place `pdots`, the dot bake reads them directly (no per-person reconstruction loop). Byte-identical to the per-person bake; the old path stays as the legacy fallback. Background processing on store ~9-10s → ~5.6s; cold people-map bake 6.1s → 2.9s.
- **Playback** — bake dots before the run view appears (no early-playback gap) and relax the now-obsolete fetch buffer (frames are ~20ms now), so Cases playback advances at a steady rate.

## Validation
- Dot frames proven **byte-identical** to the per-person bake across a full 720-step run (1843 places, 0 mismatches), through the real `placeIds` remap.
- Node + TS checks clean; verified end-to-end against the live stack locally.

## ⚠️ Deploy notes (main autodeploys to the public site)
- Pairs with [Simulation#17](https://github.com/Delineo-Disease-Modeling/Simulation/pull/17) — deploy together. The binary patterns transport is back-compat (sniffs format), and the dot passthrough falls back to per-person for runs without `pdots`.
- The Algorithms binary-patterns **producer** is a separate repo/PR; consumer + transport here are safe to deploy first (auto-detect both formats). Please review before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)