### PR TITLE
Cases map: stop POI outline flicker, drop Cases popup, guard emoji NaN

### DIFF
--- a/src/app/simulator/[run_id]/page.tsx
+++ b/src/app/simulator/[run_id]/page.tsx
@@ -180,6 +180,9 @@ export default function SimulatorRun() {
 
   const [selectedZone, setSelectedZone] = useState<typeof zone>(null);
   const [selectedLoc, setSelectedLoc] = useState<SelectedLoc | null>(null);
+  const [focusPoi, setFocusPoi] = useState<{ id: string; nonce: number } | null>(
+    null
+  );
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [progress, setProgress] = useState(0);
@@ -578,6 +581,21 @@ export default function SimulatorRun() {
     setSelectedLoc({ id, label, type });
   };
 
+  // Selecting a POI from the hotspot rankings scopes the chart (as a marker
+  // click does) AND flies the Cases map to that POI. The bumped nonce lets a
+  // repeat click on the same POI re-trigger the fly-to.
+  const handleSelectPoiFromRankings = (loc: {
+    id: string;
+    label: string;
+    type: string;
+  }) => {
+    handleMarkerClick(loc);
+    setFocusPoi((previous) => ({
+      id: loc.id,
+      nonce: (previous?.nonce ?? 0) + 1
+    }));
+  };
+
   const onReset = () => {
     setSelectedLoc(null);
   };
@@ -782,6 +800,7 @@ export default function SimulatorRun() {
             simId={activeSimId}
             disabledPoiIds={effectiveDisabledPoiIds}
             onMarkerClick={handleMarkerClick}
+            focusPoi={focusPoi}
           />
         </section>
 
@@ -796,7 +815,7 @@ export default function SimulatorRun() {
         <PersonPathPanel simId={activeSimId} />
 
         <PoiRankings
-          onSelectPoi={handleMarkerClick}
+          onSelectPoi={handleSelectPoiFromRankings}
           disabledPoiIds={effectiveDisabledPoiIds}
           disabledCategories={disabledCategories}
           effectiveDisabledPoiCount={effectiveDisabledPoiIds.size}

--- a/src/components/modelmap.tsx
+++ b/src/components/modelmap.tsx
@@ -54,6 +54,9 @@ interface ModelMapProps {
   onMarkerClick: (info: { id: string; label: string; type: string }) => void;
   simId?: number | null;
   disabledPoiIds?: ReadonlySet<string>;
+  // A POI to fly the Cases map to (e.g. clicked in the hotspot rankings). The
+  // `nonce` changes on every request so repeat clicks on the same POI re-fly.
+  focusPoi?: { id: string; nonce: number } | null;
   selectedZone: {
     latitude: number;
     longitude: number;
@@ -66,6 +69,7 @@ interface ModelMapProps {
 export default function ModelMap({
   onMarkerClick,
   disabledPoiIds,
+  focusPoi,
   simId,
   selectedZone
 }: ModelMapProps) {
@@ -96,6 +100,7 @@ export default function ModelMap({
   );
   const mapFrameRequests = useRef<Map<string, Promise<SimData>>>(new Map());
   const bufferHoldsRef = useRef(0);
+  const panelRef = useRef<HTMLDivElement>(null);
   const [mapFrameError, setMapFrameError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -127,6 +132,15 @@ export default function ModelMap({
       heatmapMode
     );
   }, [heatmapMode, simId]);
+
+  // When a POI is selected from the hotspot rankings, surface it on the Cases
+  // map: switch to the Cases ("people") view, scroll the map into view (the
+  // rankings sit below it), and let ClusteredMap handle the fly-to.
+  useEffect(() => {
+    if (!focusPoi) return;
+    setHeatmapMode('people');
+    panelRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }, [focusPoi]);
 
   useEffect(() => {
     const cbgList = selectedZone?.cbg_list?.filter(Boolean) ?? [];
@@ -626,7 +640,7 @@ export default function ModelMap({
   }, [availableTimesteps.length, maxHours]);
 
   return (
-    <div className="modelmap_panel">
+    <div className="modelmap_panel" ref={panelRef}>
       <div className="heatmap-toggle">
         <MapLegend icon_lookup={iconLookup} />
         <div className="heatmap-toggle-group">
@@ -664,6 +678,12 @@ export default function ModelMap({
               Recovered
             </span>
           )}
+          {disabledPoiIds && disabledPoiIds.size > 0 && (
+            <span className="people-map-key-item">
+              <span className="people-map-swatch people-map-swatch-disabled" />
+              Disabled
+            </span>
+          )}
           {selectedPeopleMapData && selectedPeopleMapData.sample_rate > 1 && (
             <span className="people-map-key-note">
               sampled 1 in {selectedPeopleMapData.sample_rate}
@@ -687,6 +707,7 @@ export default function ModelMap({
         currentTime={currentTime}
         mapCenter={mapCenter}
         pois={pois}
+        stablePois={stableDotPois}
         zoneGeoJSON={zoneGeoJSON}
         hotspots={hotspots as Record<string, number[]>}
         onMarkerClick={onMarkerClick}
@@ -695,6 +716,7 @@ export default function ModelMap({
         peopleDotColor={peopleDotColor}
         personStatusDotGeoJSON={personStatusDotGeoJSON}
         onCaseDotsVisibilityChange={setCaseDotsVisible}
+        focusPoi={focusPoi}
       />
       <div className="modelmap_current_time">
         {new Date(

--- a/src/features/model-map/clustered-map.tsx
+++ b/src/features/model-map/clustered-map.tsx
@@ -42,6 +42,10 @@ interface ClusteredMapProps {
   currentTime: number;
   mapCenter: [number, number];
   pois: MapPoi[];
+  // Timestep-invariant POI geometry (footprints/labels) — derived from a zeroed
+  // sim so it doesn't change every playback tick. Feeds the footprint/label
+  // layers; the live per-frame `pois` still feeds clusters/markers and popups.
+  stablePois: MapPoi[];
   zoneGeoJSON: GeoJSONData | null;
   hotspots: Record<string, number[]>;
   onMarkerClick: (info: { id: string; label: string; type: string }) => void;
@@ -50,6 +54,7 @@ interface ClusteredMapProps {
   peopleDotColor: string;
   personStatusDotGeoJSON: PersonStatusDotFeatureCollection;
   onCaseDotsVisibilityChange?: (visible: boolean) => void;
+  focusPoi?: { id: string; nonce: number } | null;
 }
 
 function asPointCoordinate(value: unknown): [number, number] | null {
@@ -85,6 +90,7 @@ export default function ClusteredMap({
   currentTime: _currentTime,
   mapCenter,
   pois,
+  stablePois,
   zoneGeoJSON,
   hotspots,
   onMarkerClick,
@@ -92,7 +98,8 @@ export default function ClusteredMap({
   peopleDotGeoJSON,
   peopleDotColor,
   personStatusDotGeoJSON,
-  onCaseDotsVisibilityChange
+  onCaseDotsVisibilityChange,
+  focusPoi
 }: ClusteredMapProps) {
   const mapRef = useRef<MapRef>(null);
   const [mapInstance, setMapInstance] = useState<ModelMapInstance | null>(null);
@@ -100,6 +107,7 @@ export default function ClusteredMap({
   const [caseDotsZoom, setCaseDotsZoom] = useState(false);
   const [caseDetailZoom, setCaseDetailZoom] = useState(false);
   const hasFitBounds = useRef(false);
+  const lastFocusNonce = useRef<number | null>(null);
   // Cases view tiers: clustered infection bubbles when zoomed out, individual
   // person dots once past CASE_CLUSTER_MAX_ZOOM, and POI footprints/labels once
   // past CASE_DETAIL_MIN_ZOOM.
@@ -139,6 +147,29 @@ export default function ClusteredMap({
     }
     hasFitBounds.current = true;
   }, [mapInstance, pois]);
+
+  // Fly the map to a POI requested from the hotspot rankings. Guarded on the
+  // nonce so it runs once per click (this effect also re-runs when `pois`/the
+  // map settle); if the POI isn't loaded yet we leave the nonce unhandled so a
+  // later `pois` update retries the fly-to.
+  useEffect(() => {
+    if (!focusPoi || !mapInstance) return;
+    if (lastFocusNonce.current === focusPoi.nonce) return;
+    const poi = pois.find(
+      (candidate) =>
+        candidate.type === 'places' &&
+        String(candidate.id) === String(focusPoi.id)
+    );
+    if (!poi || !Number.isFinite(poi.latitude) || !Number.isFinite(poi.longitude)) {
+      return;
+    }
+    lastFocusNonce.current = focusPoi.nonce;
+    mapInstance.easeTo({
+      center: [poi.longitude, poi.latitude],
+      zoom: Math.max(mapInstance.getZoom(), 16),
+      duration: 700
+    });
+  }, [focusPoi, mapInstance, pois]);
 
   useEffect(() => {
     if (!mapInstance) return;
@@ -250,13 +281,19 @@ export default function ClusteredMap({
   }, []);
 
   const geojson = useMemo(() => makeGeoJSON(pois), [pois]);
+  // Footprints + labels are visually timestep-invariant (their paint/layout read
+  // only `disabled`/`label`), so derive them from the stable POI geometry rather
+  // than the per-frame `pois`. Building from `pois` re-set both sources every
+  // playback tick — their features bake in per-frame counts — forcing a full
+  // polygon re-tessellation + label collision pass that, on large/sampled runs,
+  // overran the frame interval and made the outlines/labels flicker.
   const poiFootprintGeoJSON = useMemo(
-    () => makePoiFootprintGeoJSON(pois),
-    [pois]
+    () => makePoiFootprintGeoJSON(stablePois),
+    [stablePois]
   );
   const poiLabelGeoJSON = useMemo(
-    () => makeGeoJSON(pois.filter((poi) => poi.type === 'places')),
-    [pois]
+    () => makeGeoJSON(stablePois.filter((poi) => poi.type === 'places')),
+    [stablePois]
   );
 
   // Hotspot hours for the open popup, read from the same `hotspots` prop the
@@ -308,6 +345,8 @@ export default function ClusteredMap({
       zoom: Math.max(map.getZoom(), 15),
       duration: 600
     });
+    // Only the Markers source (live per-frame `pois`) opens this popup, so its
+    // feature props already carry current counts.
     setPopupInfo(null);
     setTimeout(
       () =>
@@ -368,10 +407,10 @@ export default function ClusteredMap({
           'unclustered-point-circle',
           'unclustered-point-emoji',
           'case-clusters-circle',
-          'case-clusters-point',
-          'poi-footprint-fill',
-          'poi-footprint-outline',
-          'poi-footprint-labels'
+          'case-clusters-point'
+          // POI footprint/label layers are intentionally NOT interactive: in the
+          // Cases view the name label is shown inline and the popup is reserved
+          // for the Markers view. (Case clusters above stay clickable to zoom in.)
         ]}
         onClick={handleClick}
       >

--- a/src/features/model-map/emoji-overlay.tsx
+++ b/src/features/model-map/emoji-overlay.tsx
@@ -35,6 +35,7 @@ export default function EmojiOverlay({
         const props = f.properties;
         if (!props || props.cluster || !props.icon) return;
         const [lng, lat] = f.geometry.coordinates;
+        if (!Number.isFinite(lng) || !Number.isFinite(lat)) return;
         const pixel = map.project([lng, lat]);
         const infectionRatio = Number.parseFloat(
           String(props.infection_ratio || 0)

--- a/src/styles/modelmap.css
+++ b/src/styles/modelmap.css
@@ -237,6 +237,10 @@ div.mapcontainer {
   background: #16a34a;
 }
 
+.people-map-swatch-disabled {
+  background: #111827;
+}
+
 .people-map-key-note {
   color: #4b5563;
   white-space: nowrap;


### PR DESCRIPTION
Fix the POI outline/label flicker during Cases playback on large ("sampled 1 in N") runs: the footprint + label sources were rebuilt from the per-frame `pois` every tick (their features bake in per-frame counts), so MapLibre re-ran a full setData -> polygon re-tessellation + label collision pass each step; on large runs this overran the frame interval and blanked the layers. Derive them from timestep-invariant `stableDotPois` (new `stablePois` prop) so they only update when geometry/disabled actually changes.

Remove the POI popup in the Cases view (it could stick open and freeze the map, and the inline name covers it): POI footprint/label layers are no longer in interactiveLayerIds. The popup stays in Markers view, whose source carries live counts, so handleClick reads counts from feature props again (dropped the now-unneeded live-count lookup).

Guard a pre-existing crash: emoji-overlay called map.project() on POIs with non-finite coords ("Invalid LngLat (NaN, NaN)"), blanking the Markers view. Skip non-finite coordinates.

Also wires the POI-rankings selection to fly the Cases map to the POI (focusPoi) and adds a disabled swatch style.