### PR TITLE
Serve scoped per-POI chart from pre-baked dots (fix 90s wait + empty chart)

### DIFF
--- a/src/app/api/simdata/[id]/chartdata/route.ts
+++ b/src/app/api/simdata/[id]/chartdata/route.ts
@@ -2,6 +2,7 @@ import type { NextRequest } from 'next/server';
 import { resolveDbDataPath } from '@/lib/db-files';
 import { streamJsonObjectEntries } from '@/lib/json-stream';
 import { getCachedPapdata } from '@/lib/papdata-cache';
+import { loadDots } from '@/lib/people-map-cache';
 import { prisma } from '@/lib/prisma';
 import {
   AGE_RANGE_LABELS,
@@ -161,6 +162,74 @@ async function computeLocationStats(
   return chartData;
 }
 
+// ── Fast path: per-location chart from the pre-baked `.dots.json` ──────────────
+// computeLocationStats above re-streams the full .pat.gz + .sim.gz (~150MB,
+// ~90s cold) AND only understands the legacy pid-list pattern shape — for the
+// numeric SoA engine format (h/p/loc) `pvalue.places` is undefined, so it
+// streams the whole run only to return an EMPTY chart. The dots bake already
+// holds correct per-place [pop, infected, recovered] per timestep for both
+// formats, so for a `places` scope we build the iot series + a 3-bucket
+// (Susceptible/Infected/Recovered) states series straight from it — a keyed
+// lookup instead of a full re-stream. (ages/sexes aren't derivable from dots,
+// but the UI exposes only the Infectiousness + States tabs.)
+function diseaseKeyFromStats(globalStats: unknown): string {
+  if (globalStats && typeof globalStats === 'object') {
+    const meta = (globalStats as Record<string, unknown>).metadata;
+    const variants =
+      meta && typeof meta === 'object'
+        ? (meta as Record<string, unknown>).variants
+        : undefined;
+    if (
+      Array.isArray(variants) &&
+      variants.length === 1 &&
+      typeof variants[0] === 'string' &&
+      variants[0].trim()
+    ) {
+      return variants[0];
+    }
+  }
+  return 'Infected';
+}
+
+function buildChartFromDots(
+  dots: {
+    placeIds: string[];
+    frames: Record<string, number[]>;
+    sortedTimes: number[];
+  },
+  locId: string,
+  diseaseKey: string
+): ChartData | null {
+  const idx = dots.placeIds.indexOf(locId);
+  if (idx < 0) {
+    return null;
+  }
+  const base = idx * 3;
+  const chartData: ChartData = { iot: [], ages: [], sexes: [], states: [] };
+  for (const minutes of dots.sortedTimes) {
+    const frame = dots.frames[String(minutes)];
+    if (!frame) {
+      continue;
+    }
+    const pop = frame[base] ?? 0;
+    // Match computeLocationStats: only emit a point when the place is occupied.
+    if (pop <= 0) {
+      continue;
+    }
+    const infected = frame[base + 1] ?? 0;
+    const recovered = frame[base + 2] ?? 0;
+    const time = minutes / 60;
+    chartData.iot.push({ time, 'All People': pop, [diseaseKey]: infected });
+    chartData.states.push({
+      time,
+      Susceptible: Math.max(0, pop - infected - recovered),
+      Infected: infected,
+      Recovered: recovered
+    });
+  }
+  return chartData;
+}
+
 export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
@@ -214,6 +283,23 @@ export async function GET(
         { message: 'PapData not available for this zone' },
         { status: 404 }
       );
+    }
+
+    // Fast path: places scope from the pre-baked dots (instant, and works for
+    // numeric SoA runs the slow streamer returns empty for). Fall back to the
+    // full stream for a homes scope or runs baked without a dots file.
+    if (loc_type === 'places') {
+      const dots = await loadDots(simdata.file_id);
+      const fast = dots
+        ? buildChartFromDots(
+            dots,
+            loc_id,
+            diseaseKeyFromStats(simdata.global_stats)
+          )
+        : null;
+      if (fast) {
+        return Response.json({ data: fast });
+      }
     }
 
     const papdata = await getCachedPapdata(papDataId);

--- a/src/lib/people-map-cache.ts
+++ b/src/lib/people-map-cache.ts
@@ -296,7 +296,7 @@ function cacheDots(filePath: string, entry: CachedDots) {
   }
 }
 
-async function loadDots(fileId: string): Promise<CachedDots | null> {
+export async function loadDots(fileId: string): Promise<CachedDots | null> {
   const filePath = dotsPath(fileId);
   let fileStat: Awaited<ReturnType<typeof stat>>;
   try {


### PR DESCRIPTION
## Problem

Clicking a POI scopes the outcome chart, which calls `computeLocationStats` — it **re-streams the full `.pat.gz` + `.sim.gz` (~150MB)** co-iterated over all ~720 timesteps to extract one location's rows: **~90–125s on the first click of any POI** (the in-process 30-entry LRU is wiped on every restart, so the first click always pays).

**Latent bug:** that route only understands the legacy pid-list pattern shape (`pvalue.places`). All current **SoA-engine runs** emit the numeric `{h, p, loc, pdots}` format, where `pvalue.places` is `undefined` — so it streamed 150MB only to return an **empty chart**. Per-POI charts have been both *slow* and *broken* on prod for engine runs.

## Fix

The `.dots.json` bake already holds correct per-place `[pop, infected, recovered]` per timestep for **both** formats. For a `places` scope we now build the chart straight from it — a keyed lookup instead of a full re-stream:
- **iot**: `All People` (pop) + the run's variant (infected)
- **states**: 3-bucket `Susceptible / Infected / Recovered`

Falls back to `computeLocationStats` for a `homes` scope or runs baked without a dots file. `ages`/`sexes` aren't derivable from dots, but the UI exposes only the Infectiousness + States tabs.

## Verified (run 173, numeric SoA, in browser)

- Scoped `/chartdata`: **90,000ms → 151ms (~600×)**
- Previously **empty → real data**: Owasso Little Free Library renders `All People` + `Delta` curves; States tab shows a clean SIR view.
- Works on **all existing runs immediately** — no re-bake (uses dots already on disk).
- `tsc --noEmit` + `biome lint` clean.

## Trade-off

Per-POI **Disease states** is now the 3-bucket SIR view; the finer Infectious/Symptomatic/Hospitalized/Removed split needs the `.sim` stream. Whole-run charts are unchanged. A follow-up could pre-bake a `.locstats.json` for exact all-states per POI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)