### PR TITLE
Admin zone deletion (prune duplicate zones from UI)

### DIFF
--- a/src/app/api/convenience-zones/[czone_id]/route.ts
+++ b/src/app/api/convenience-zones/[czone_id]/route.ts
@@ -1,7 +1,8 @@
 import type { NextRequest } from 'next/server';
-import { jsonMessage, serviceResult } from '@/server/api/responses';
+import { isAdminEmail } from '@/lib/admin';
+import { jsonMessage, serviceResult, unauthorized } from '@/server/api/responses';
 import { parseNonNegativeRouteNumber } from '@/server/api/route-params';
-import { requireSessionUserId } from '@/server/api/session';
+import { getSessionUser, requireSessionUserId } from '@/server/api/session';
 import {
   deleteConvenienceZone,
   getConvenienceZone,
@@ -59,11 +60,17 @@ export async function DELETE(
     return jsonMessage(id.message, id.status);
   }
 
-  const session = await requireSessionUserId(request.headers);
-  if (!session.ok) {
-    return session.response;
+  // Delete is allowed for the zone owner OR an admin (admin cleanup of shared
+  // zones, e.g. pruning duplicates). Cascades the zone's runs + files.
+  const sessionUser = await getSessionUser(request.headers);
+  if (!sessionUser) {
+    return unauthorized();
   }
 
-  const result = await deleteConvenienceZone(id.value, session.userId);
+  const result = await deleteConvenienceZone(
+    id.value,
+    sessionUser.id,
+    isAdminEmail(sessionUser.email)
+  );
   return serviceResult(result);
 }

--- a/src/components/czdict.tsx
+++ b/src/components/czdict.tsx
@@ -1,7 +1,9 @@
 'use client';
 
+import { Trash2 } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 import { useSession } from '@/lib/auth-client';
+import { useIsAdmin } from '@/lib/use-is-admin';
 import type { ConvenienceZone } from '@/stores/simsettings';
 import useSimSettings from '@/stores/simsettings';
 import EditDeleteActions from './edit-delete-actions';
@@ -17,7 +19,33 @@ export default function CzDict({ zone, setZone, locations, setLocations }: CzDic
   const { data: session } = useSession();
   const user = session?.user;
   const userId = user?.id ?? null;
+  const isAdmin = useIsAdmin();
   const setSettings = useSimSettings((state) => state.setSettings);
+
+  // Admins can delete any zone (server-enforced) — used to prune duplicates.
+  // Cascades the zone's runs + files; not undoable.
+  const handleDeleteZone = async (loc: ConvenienceZone) => {
+    if (
+      !window.confirm(
+        `Delete zone "${loc.name}" (pop ${loc.size}) and ALL its runs? This cannot be undone.`
+      )
+    ) {
+      return;
+    }
+    try {
+      const res = await fetch(`/api/convenience-zones/${loc.id}`, {
+        method: 'DELETE'
+      });
+      if (!res.ok) throw new Error(`Delete failed (${res.status})`);
+      setLocations((prev) => prev.filter((l) => l.id !== loc.id));
+      if (zone?.id === loc.id) {
+        setSettings({ zone: null, sim_id: null });
+      }
+    } catch (e) {
+      console.error(e);
+      window.alert('Could not delete zone. Are you signed in as an admin?');
+    }
+  };
 
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState('');
@@ -183,24 +211,36 @@ export default function CzDict({ zone, setZone, locations, setLocations }: CzDic
                 .filter(Boolean)
                 .join(' ');
               return (
-                <button
-                  type="button"
-                  key={loc.id}
-                  className={rowClasses}
-                  onClick={() => {
-                    setZone(loc);
-                    setSettings({ sim_id: null });
-                  }}
-                >
-                  <span className="flex-1 truncate">{loc.name}</span>
-                  <span className="flex-1 text-center">{loc.size}</span>
-                  <span className="flex-1 text-right">
-                    {new Date(loc.created_at).toLocaleDateString()}
-                  </span>
-                  {!loc.ready && (
-                    <span className="sim_table_row_badge">Generating…</span>
+                <div key={loc.id} className="flex items-stretch gap-1">
+                  <button
+                    type="button"
+                    className={`${rowClasses} flex-1`}
+                    onClick={() => {
+                      setZone(loc);
+                      setSettings({ sim_id: null });
+                    }}
+                  >
+                    <span className="flex-1 truncate">{loc.name}</span>
+                    <span className="flex-1 text-center">{loc.size}</span>
+                    <span className="flex-1 text-right">
+                      {new Date(loc.created_at).toLocaleDateString()}
+                    </span>
+                    {!loc.ready && (
+                      <span className="sim_table_row_badge">Generating…</span>
+                    )}
+                  </button>
+                  {isAdmin && (
+                    <button
+                      type="button"
+                      aria-label={`Delete zone ${loc.name}`}
+                      title="Delete zone (and all its runs)"
+                      className="px-2 rounded text-(--color-text-muted) hover:text-red-600 hover:bg-red-50 transition-colors"
+                      onClick={() => handleDeleteZone(loc)}
+                    >
+                      <Trash2 size={15} aria-hidden="true" />
+                    </button>
                   )}
-                </button>
+                </div>
               );
             });
           })()}

--- a/src/components/settings-components.tsx
+++ b/src/components/settings-components.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { Info, Trash2 } from 'lucide-react';
 import { getGuestZoneClaimHeaders } from '@/lib/guest-zone-claims';
+import { useIsAdmin } from '@/lib/use-is-admin';
 import '@/styles/settings-components.css';
 import Slider from './ui/slider';
 
@@ -239,7 +240,7 @@ export function SimRunSelector({
 }: SimRunSelectorProps) {
   const [data, setData] = useState<SimRunType[] | null>(null);
   const [loading, setLoading] = useState(false);
-  const [isAdmin, setIsAdmin] = useState(false);
+  const isAdmin = useIsAdmin();
 
   useEffect(() => {
     if (!czone_id) {
@@ -262,14 +263,6 @@ export function SimRunSelector({
         setLoading(false);
       });
   }, [czone_id]);
-
-  // Admins can delete any run (server-enforced); this just toggles the UI.
-  useEffect(() => {
-    fetch('/api/admin/me')
-      .then((res) => (res.ok ? res.json() : null))
-      .then((json) => setIsAdmin(Boolean(json?.data?.isAdmin)))
-      .catch(() => setIsAdmin(false));
-  }, []);
 
   const handleDeleteRun = async (run: SimRunType) => {
     if (

--- a/src/lib/use-is-admin.ts
+++ b/src/lib/use-is-admin.ts
@@ -1,0 +1,26 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+// Whether the current session is an admin (per DELINEO_ADMIN_EMAILS), used to
+// gate admin-only UI like delete controls. Server still enforces on each route.
+export function useIsAdmin(): boolean {
+  const [isAdmin, setIsAdmin] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    fetch('/api/admin/me')
+      .then((res) => (res.ok ? res.json() : null))
+      .then((json) => {
+        if (active) setIsAdmin(Boolean(json?.data?.isAdmin));
+      })
+      .catch(() => {
+        if (active) setIsAdmin(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  return isAdmin;
+}

--- a/src/server/services/convenience-zones.ts
+++ b/src/server/services/convenience-zones.ts
@@ -1,5 +1,7 @@
+import { unlink } from 'node:fs/promises';
 import { z } from 'zod';
 import type { ConvenienceZone } from '@/generated/prisma/client';
+import { DB_FOLDER } from '@/lib/db-files';
 import { invalidatePapdata } from '@/lib/papdata-cache';
 import { prisma } from '@/lib/prisma';
 import { broadcast } from '@/lib/sse-broadcast';
@@ -260,20 +262,57 @@ export async function updateConvenienceZone(
   }
 }
 
+// Per-run file variants + the zone's papdata/patterns files, removed on disk
+// after the DB cascade deletes the run rows.
+const RUN_FILE_SUFFIXES = [
+  '.sim',
+  '.sim.gz',
+  '.pat',
+  '.pat.gz',
+  '.map.json',
+  '.dots.json'
+];
+
+async function deleteZoneFiles(
+  zone: Pick<ConvenienceZone, 'papdata_id' | 'patterns_id'>,
+  runFileIds: string[]
+) {
+  const paths: string[] = [];
+  for (const fileId of runFileIds) {
+    for (const suffix of RUN_FILE_SUFFIXES) {
+      paths.push(`${DB_FOLDER}${fileId}${suffix}`);
+    }
+  }
+  if (zone.papdata_id) paths.push(`${DB_FOLDER}${zone.papdata_id}.gz`);
+  if (zone.patterns_id) {
+    paths.push(`${DB_FOLDER}${zone.patterns_id}.gz`);
+    paths.push(`${DB_FOLDER}${zone.patterns_id}.bin`);
+  }
+  await Promise.allSettled(paths.map((p) => unlink(p)));
+}
+
 export async function deleteConvenienceZone(
   id: number,
-  userId: string
+  userId: string,
+  isAdmin = false
 ): Promise<ServiceResult<ConvenienceZone>> {
   try {
     const existing = await prisma.convenienceZone.findUnique({ where: { id } });
     if (!existing) {
       return { ok: false, message: 'Not found', status: 404 };
     }
-    if (existing.user_id !== userId) {
+    if (existing.user_id !== userId && !isAdmin) {
       return { ok: false, message: 'Forbidden', status: 403 };
     }
 
+    // Collect run file ids BEFORE the delete cascades the run rows away.
+    const runs = await prisma.simData.findMany({
+      where: { czone_id: id },
+      select: { file_id: true }
+    });
+
     const zone = await prisma.convenienceZone.delete({ where: { id } });
+    await deleteZoneFiles(zone, runs.map((r) => r.file_id));
     if (zone.papdata_id) {
       invalidatePapdata(zone.papdata_id);
     }


### PR DESCRIPTION
Extends admin-only deletion to whole convenience zones so admins can prune duplicates from the UI (no prod DB/shell access needed).

- `DELETE /api/convenience-zones/[id]`: owner OR admin (was owner-only); cleans up the zone's run files + papdata/patterns on disk, not just DB rows.
- Shared `useIsAdmin()` hook; per-zone trash button in the zone list for admins.

Verified locally: admin delete of a non-owned 0-run duplicate → 200 (gone from list + files cleaned); guest → 401; typecheck/lint/tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)