### PR TITLE
Cases dots: serve a whole-run bundle synthesized client-side (fix prod playback blanking)

### DIFF
--- a/src/app/api/simdata/[id]/dots/route.ts
+++ b/src/app/api/simdata/[id]/dots/route.ts
@@ -1,0 +1,147 @@
+import { gzipSync } from 'node:zlib';
+import type { NextRequest } from 'next/server';
+import { getCachedPapdata } from '@/lib/papdata-cache';
+import {
+  ensureDotsFile,
+  getRecentBakeFailure,
+  isFileUnbakeable,
+  loadDotsBundle
+} from '@/lib/people-map-cache';
+import { prisma } from '@/lib/prisma';
+import { gzipPreserialized } from '@/server/api/gzip-json';
+import { jsonMessage } from '@/server/api/responses';
+import { parseNonNegativeRouteNumber } from '@/server/api/route-params';
+
+// Cache the gzipped whole-run bundle so repeat opens (different users/tabs)
+// don't re-gzip the multi-MB payload. Keyed by `${fileId}:${mtimeMs}` so a
+// re-baked dots file invalidates automatically.
+const bundleGzCache = new Map<string, Buffer>();
+const BUNDLE_GZ_CACHE_LIMIT = 4;
+
+function cacheBundleGz(key: string, gz: Buffer) {
+  bundleGzCache.set(key, gz);
+  if (bundleGzCache.size <= BUNDLE_GZ_CACHE_LIMIT) {
+    return;
+  }
+  const oldest = bundleGzCache.keys().next().value;
+  if (oldest) {
+    bundleGzCache.delete(oldest);
+  }
+}
+
+/**
+ * Whole-run compact dots bundle: `{ version, place_ids, frames }`, the parsed
+ * `{fileId}.dots.json`. The Cases map fetches this ONCE and synthesizes every
+ * playback frame client-side, instead of re-fetching a large per-dot JSON each
+ * tick (which blanks the dots over the WAN on prod). Returns 409 with an
+ * `X-Dots-Status` header when the run has no readable baked file; the client
+ * then falls back to the per-frame `/people-map` route.
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id: idRaw } = await params;
+  const id = parseNonNegativeRouteNumber(idRaw, 'id');
+  if (!id.ok) {
+    return jsonMessage(id.message, id.status);
+  }
+
+  const simdata = await prisma.simData.findUnique({
+    where: { id: id.value },
+    select: { file_id: true, czone: { select: { papdata_id: true } } }
+  });
+  if (!simdata) {
+    return Response.json(
+      { message: `Could not find simdata #${id.value}` },
+      { status: 404 }
+    );
+  }
+
+  const fileId = simdata.file_id;
+  const papdataId = simdata.czone.papdata_id;
+
+  try {
+    let dotsStatus = 'fallback:no-papdata';
+    let ensured = false;
+    let bakeThrew = false;
+    if (papdataId) {
+      dotsStatus = 'fallback';
+      try {
+        const papdata = (await getCachedPapdata(papdataId)) as {
+          places?: Record<string, unknown>;
+        };
+        const placeIds = Object.keys(papdata.places ?? {});
+        if (placeIds.length > 0) {
+          ensured = await ensureDotsFile(fileId, placeIds);
+        } else {
+          dotsStatus = 'fallback:no-places';
+        }
+      } catch (bakeError) {
+        bakeThrew = true;
+        const err = bakeError as NodeJS.ErrnoException;
+        console.error('dots: bundle generation failed:', {
+          fileId,
+          code: err?.code,
+          message: err?.message
+        });
+      }
+
+      const bundle = await loadDotsBundle(fileId);
+      if (bundle) {
+        const cacheKey = `${fileId}:${bundle.mtimeMs}`;
+        let gz = bundleGzCache.get(cacheKey);
+        if (!gz) {
+          gz = gzipSync(
+            Buffer.from(
+              JSON.stringify({
+                data: {
+                  version: bundle.version,
+                  place_ids: bundle.place_ids,
+                  frames: bundle.frames
+                }
+              }),
+              'utf8'
+            )
+          );
+          cacheBundleGz(cacheKey, gz);
+        }
+        return gzipPreserialized(request, gz, {
+          'Cache-Control': 'private, max-age=300',
+          'X-Dots-Status': 'baked'
+        });
+      }
+
+      if (dotsStatus === 'fallback') {
+        if (bakeThrew || getRecentBakeFailure(fileId)) {
+          dotsStatus = 'fallback:bake-error';
+        } else if (isFileUnbakeable(fileId)) {
+          dotsStatus = 'fallback:unbakeable';
+        } else if (ensured) {
+          dotsStatus = 'fallback:baked-unreadable';
+        } else {
+          dotsStatus = 'fallback:skipped';
+        }
+      }
+    }
+
+    // No bundle available: tell the client to use the per-frame fallback.
+    const headers: Record<string, string> = { 'X-Dots-Status': dotsStatus };
+    const bakeFailure = getRecentBakeFailure(fileId);
+    if (bakeFailure) {
+      headers['X-Dots-Bake-Error'] = `${bakeFailure.code}: ${bakeFailure.message}`
+        .replace(/[^\x20-\x7E]/g, ' ')
+        .slice(0, 180);
+    }
+    return Response.json(
+      { message: 'No baked dots bundle for this run.' },
+      { status: 409, headers }
+    );
+  } catch (error) {
+    console.error('Dots bundle error:', error);
+    return Response.json(
+      { message: 'Failed to load dots bundle.' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/simdata/[id]/people-map/route.ts
+++ b/src/app/api/simdata/[id]/people-map/route.ts
@@ -19,6 +19,7 @@ import type {
   DiseaseStateTimestep,
   PatternTimestep
 } from '@/lib/simulation-data';
+import { gzipJsonData } from '@/server/api/gzip-json';
 import { jsonMessage } from '@/server/api/responses';
 import { parseNonNegativeRouteNumber } from '@/server/api/route-params';
 
@@ -494,15 +495,10 @@ export async function GET(
       }
       const baked = await readDotsPayload(fileId, requested);
       if (baked) {
-        return Response.json(
-          { data: baked },
-          {
-            headers: {
-              'Cache-Control': 'private, max-age=30',
-              'X-Dots-Status': 'baked'
-            }
-          }
-        );
+        return gzipJsonData(request, baked, {
+          'Cache-Control': 'private, max-age=30',
+          'X-Dots-Status': 'baked'
+        });
       }
       if (dotsStatus === 'fallback') {
         if (bakeThrew || getRecentBakeFailure(fileId)) {
@@ -533,7 +529,7 @@ export async function GET(
         .replace(/[^\x20-\x7E]/g, ' ')
         .slice(0, 180);
     }
-    return Response.json({ data }, { headers });
+    return gzipJsonData(request, data, headers);
   } catch (error) {
     console.error('People map computation error:', error);
     return Response.json(

--- a/src/components/modelmap.tsx
+++ b/src/components/modelmap.tsx
@@ -25,6 +25,7 @@ import {
   resetModelMapLayoutCaches,
   updateIcons
 } from '@/features/model-map/map-data';
+import { type DotsBundle, synthesizeFromBundle } from '@/lib/dots-synth';
 import {
   getMapStorageKey,
   getPeopleMapCacheKey,
@@ -42,13 +43,14 @@ function getMapFrameCacheKey(simId: number, timestep: number) {
 const EMPTY_HOTSPOTS: Record<string, number[]> = {};
 
 // Max consecutive playback ticks to wait for an unloaded Cases frame before
-// advancing anyway. Per-frame people-map fetches are now ~20ms (the dots are
-// pre-baked + served from the in-memory cache), so the deep buffer this used to
-// need (for the old ~0.4-1.7s fetches) just produced long "spaced out" stalls.
-// With PREFETCH_STEPS keeping frames ready, hold at most 1 tick so playback
-// advances at a steady rate. At PLAYBACK_INTERVAL_MS (750ms) this caps a stall
-// at ~1.5s instead of ~7.5s.
-const MAX_BUFFER_HOLDS = 1;
+// advancing anyway. When the whole-run dots bundle is loaded, frames are
+// synthesized client-side (instant) and this buffer is bypassed entirely — it
+// only governs the per-frame /people-map FALLBACK path (runs with no baked
+// bundle), where each fetch can take ~0.4-1.7s over the WAN. Holding long enough
+// to ride out a slow frame keeps the dots on screen instead of blanking to
+// "Loading cases...". At PLAYBACK_INTERVAL_MS (750ms), 6 holds caps a stall at
+// ~4.5s.
+const MAX_BUFFER_HOLDS = 6;
 
 interface ModelMapProps {
   onMarkerClick: (info: { id: string; label: string; type: string }) => void;
@@ -100,6 +102,12 @@ export default function ModelMap({
   );
   const mapFrameRequests = useRef<Map<string, Promise<SimData>>>(new Map());
   const bufferHoldsRef = useRef(0);
+  // Whole-run compact dots bundle: fetched once per run so playback frames are
+  // synthesized client-side instead of re-fetched per tick. Null when the run
+  // has no baked bundle (then the per-frame /people-map path is used).
+  const dotsBundleRef = useRef<DotsBundle | null>(null);
+  const dotsBundleSimId = useRef<number | null>(null);
+  const [dotsBundleReady, setDotsBundleReady] = useState(false);
   const panelRef = useRef<HTMLDivElement>(null);
   const [mapFrameError, setMapFrameError] = useState<string | null>(null);
 
@@ -115,6 +123,9 @@ export default function ModelMap({
     setPeopleMapError(null);
     setMapFrameError(null);
     setCaseDotsVisible(false);
+    dotsBundleRef.current = null;
+    dotsBundleSimId.current = null;
+    setDotsBundleReady(false);
   }, [simId]);
 
   useEffect(() => {
@@ -398,6 +409,72 @@ export default function ModelMap({
     simId
   ]);
 
+  // Fetch the whole-run compact dots bundle ONCE when the Cases view opens, so
+  // playback frames are synthesized client-side (instant) instead of being
+  // re-fetched per tick — the large per-frame payloads choke playback over the
+  // WAN on prod. Runs with no baked bundle return 409 and fall back to the
+  // per-frame /people-map path below.
+  useEffect(() => {
+    if (heatmapMode !== 'people' || !caseDotsVisible || !simId) {
+      return;
+    }
+    if (dotsBundleSimId.current === simId) {
+      return; // already loaded (or attempted) for this run
+    }
+
+    let active = true;
+    const controller = new AbortController();
+    fetch(`/api/simdata/${simId}/dots`, { signal: controller.signal })
+      .then(async (response) => {
+        if (!response.ok) {
+          return null; // 409 (no bundle) / error -> per-frame fallback
+        }
+        const json = (await response.json()) as {
+          data?: { place_ids?: string[]; frames?: Record<string, number[]> };
+        };
+        return json.data ?? null;
+      })
+      .then((data) => {
+        if (!active) {
+          return;
+        }
+        dotsBundleSimId.current = simId;
+        if (
+          data?.place_ids &&
+          data.frames &&
+          Object.keys(data.frames).length > 0
+        ) {
+          const frames = data.frames;
+          const sortedTimes = Object.keys(frames)
+            .map(Number)
+            .filter((value) => Number.isFinite(value))
+            .sort((a, b) => a - b);
+          dotsBundleRef.current = {
+            placeIds: data.place_ids,
+            frames,
+            sortedTimes
+          };
+        } else {
+          dotsBundleRef.current = null;
+        }
+        setDotsBundleReady(Boolean(dotsBundleRef.current));
+      })
+      .catch((error) => {
+        if (!active || controller.signal.aborted) {
+          return;
+        }
+        console.warn('Failed to load dots bundle:', error);
+        dotsBundleSimId.current = simId;
+        dotsBundleRef.current = null;
+        setDotsBundleReady(false);
+      });
+
+    return () => {
+      active = false;
+      controller.abort();
+    };
+  }, [caseDotsVisible, heatmapMode, simId]);
+
   const loadPeopleMapData = useCallback(
     async (timestep: number) => {
       if (!simId) {
@@ -444,7 +521,8 @@ export default function ModelMap({
       heatmapMode !== 'people' ||
       !caseDotsVisible ||
       !simId ||
-      selectedTimestep === null
+      selectedTimestep === null ||
+      dotsBundleReady
     ) {
       return;
     }
@@ -476,7 +554,8 @@ export default function ModelMap({
     heatmapMode,
     loadPeopleMapData,
     selectedTimestep,
-    simId
+    simId,
+    dotsBundleReady
   ]);
 
   const selectedPeopleMapData = useMemo(() => {
@@ -487,6 +566,15 @@ export default function ModelMap({
       selectedTimestep === null
     ) {
       return null;
+    }
+
+    // Whole-run bundle loaded: synthesize the frame locally (zero network).
+    if (
+      dotsBundleReady &&
+      dotsBundleSimId.current === simId &&
+      dotsBundleRef.current
+    ) {
+      return synthesizeFromBundle(dotsBundleRef.current, selectedTimestep);
     }
 
     if (
@@ -501,7 +589,14 @@ export default function ModelMap({
         getPeopleMapCacheKey(simId, selectedTimestep)
       ) ?? null
     );
-  }, [caseDotsVisible, heatmapMode, peopleMapData, selectedTimestep, simId]);
+  }, [
+    caseDotsVisible,
+    heatmapMode,
+    peopleMapData,
+    selectedTimestep,
+    simId,
+    dotsBundleReady
+  ]);
 
   useEffect(() => {
     if (
@@ -510,7 +605,8 @@ export default function ModelMap({
       !simId ||
       selectedTimestep === null ||
       availableTimesteps.length === 0 ||
-      !selectedPeopleMapData
+      !selectedPeopleMapData ||
+      dotsBundleReady // bundle path synthesizes locally — no prefetch needed
     ) {
       return;
     }
@@ -550,7 +646,8 @@ export default function ModelMap({
     loadPeopleMapData,
     selectedPeopleMapData,
     selectedTimestep,
-    simId
+    simId,
+    dotsBundleReady
   ]);
 
   useEffect(() => {
@@ -576,6 +673,7 @@ export default function ModelMap({
           heatmapMode !== 'people' ||
           !caseDotsVisible ||
           !simId ||
+          dotsBundleReady || // bundle path: every frame is synthesized instantly
           peopleMapError !== null ||
           peopleMapCache.current.has(getPeopleMapCacheKey(simId, nextTimestep));
         if (!nextFrameReady && bufferHoldsRef.current < MAX_BUFFER_HOLDS) {
@@ -594,7 +692,8 @@ export default function ModelMap({
     heatmapMode,
     caseDotsVisible,
     simId,
-    peopleMapError
+    peopleMapError,
+    dotsBundleReady
   ]);
 
   const peopleMapLoading =

--- a/src/lib/dots-synth.test.mjs
+++ b/src/lib/dots-synth.test.mjs
@@ -1,0 +1,69 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+const { findNearestTime, synthesizeDotsFrame, synthesizeFromBundle } =
+  await import('./dots-synth.ts');
+
+test('synthesizeDotsFrame shows every infected/recovered, samples susceptibles', () => {
+  // place "10": pop 5, 2 infected, 1 recovered -> 2 susceptible
+  // place "20": pop 0 -> skipped
+  const placeIds = ['10', '20'];
+  const frame = [5, 2, 1, 0, 0, 0];
+  const payload = synthesizeDotsFrame(placeIds, frame, 60, 75);
+
+  assert.equal(payload.time, 60);
+  assert.equal(payload.requested_time, 75);
+  assert.equal(payload.total_people, 5);
+  assert.equal(payload.source, 'person');
+  assert.equal(payload.sample_rate, 1); // tiny pop -> no downsampling
+  assert.equal(payload.locations.length, 1);
+
+  const loc = payload.locations[0];
+  assert.equal(loc.id, '10');
+  assert.equal(loc.type, 'places');
+  const infected = loc.people.filter((p) => p.infected).length;
+  const recovered = loc.people.filter((p) => p.recovered).length;
+  const susceptible = loc.people.filter(
+    (p) => !p.infected && !p.recovered
+  ).length;
+  assert.equal(infected, 2);
+  assert.equal(recovered, 1);
+  assert.equal(susceptible, 2);
+  // synthetic, stable ids the client sorts/positions by
+  assert.ok(loc.people.every((p) => /^[iru]:10:\d+$/.test(p.id)));
+});
+
+test('synthesizeDotsFrame caps infected/recovered to population', () => {
+  // garbage counts (inf+rec > pop) must not exceed pop
+  const payload = synthesizeDotsFrame(['1'], [3, 10, 10], 0, 0);
+  const loc = payload.locations[0];
+  assert.equal(loc.people.length, 3);
+  assert.equal(loc.people.filter((p) => p.infected).length, 3);
+  assert.equal(loc.people.filter((p) => p.recovered).length, 0);
+});
+
+test('findNearestTime returns the closest available frame time', () => {
+  assert.equal(findNearestTime([0, 60, 120], 50), 60);
+  assert.equal(findNearestTime([0, 60, 120], 0), 0);
+  assert.equal(findNearestTime([0, 60, 120], 1000), 120);
+  assert.equal(findNearestTime([], 10), null);
+});
+
+test('synthesizeFromBundle resolves the nearest frame, null when empty', () => {
+  const bundle = {
+    placeIds: ['7'],
+    frames: { 0: [4, 1, 0], 60: [4, 4, 0] },
+    sortedTimes: [0, 60]
+  };
+  const near = synthesizeFromBundle(bundle, 55);
+  assert.equal(near.time, 60);
+  assert.equal(near.locations[0].people.filter((p) => p.infected).length, 4);
+
+  assert.equal(
+    synthesizeFromBundle(
+      { placeIds: [], frames: {}, sortedTimes: [] },
+      10
+    ),
+    null
+  );
+});

--- a/src/lib/dots-synth.ts
+++ b/src/lib/dots-synth.ts
@@ -1,0 +1,140 @@
+// Pure (no Node deps) synthesis of the Cases-map "dot" payload from a compact
+// per-place [population, infected, recovered] frame. Shared by the server
+// (people-map-cache.ts / the /dots + /people-map routes) and the client
+// (modelmap.tsx), so a frame synthesized in the browser is byte-for-byte the
+// same as one synthesized on the server. Person dots are a sampled,
+// non-interactive visualization, so synthetic ids are fine.
+
+const MAX_PEOPLE_DOTS = 12_000;
+
+export type SynthPerson = {
+  id: string;
+  infected: boolean;
+  newly_infected: boolean;
+  recovered: boolean;
+};
+
+export type SynthLocation = {
+  type: 'places';
+  id: string;
+  people: SynthPerson[];
+};
+
+export type SynthPeopleMap = {
+  time: number;
+  requested_time: number;
+  total_people: number;
+  returned_people: number;
+  sample_rate: number;
+  source: 'person';
+  locations: SynthLocation[];
+};
+
+/** A whole-run compact dots bundle (the parsed `{fileId}.dots.json`). */
+export type DotsBundle = {
+  placeIds: string[];
+  frames: Record<string, number[]>;
+  sortedTimes: number[];
+};
+
+export function findNearestTime(sortedTimes: number[], requestedTime: number) {
+  if (sortedTimes.length === 0) return null;
+  let nearest = sortedTimes[0];
+  for (const time of sortedTimes) {
+    if (Math.abs(time - requestedTime) < Math.abs(nearest - requestedTime)) {
+      nearest = time;
+    }
+    if (time > requestedTime) break;
+  }
+  return nearest;
+}
+
+/** Build the sampled dot payload from a place-count frame (synthetic people). */
+export function synthesizeDotsFrame(
+  placeIds: string[],
+  frame: number[],
+  time: number,
+  requestedTime: number
+): SynthPeopleMap {
+  let totalPeople = 0;
+  for (let index = 0; index < placeIds.length; index += 1) {
+    totalPeople += frame[index * 3] || 0;
+  }
+  const sampleRate = Math.max(1, Math.ceil(totalPeople / MAX_PEOPLE_DOTS));
+
+  let returnedPeople = 0;
+  const locations: SynthLocation[] = [];
+
+  for (let index = 0; index < placeIds.length; index += 1) {
+    const base = index * 3;
+    const population = frame[base] || 0;
+    if (population === 0) {
+      continue;
+    }
+    const infected = Math.min(population, frame[base + 1] || 0);
+    const recovered = Math.min(population - infected, frame[base + 2] || 0);
+    const uninfected = Math.max(0, population - infected - recovered);
+    const placeId = placeIds[index];
+
+    // Match the live route's semantics: every infected/recovered person is
+    // shown; only susceptibles are downsampled.
+    const uninfectedSamples =
+      uninfected > 0 ? Math.max(1, Math.ceil(uninfected / sampleRate)) : 0;
+    const people: SynthPerson[] = [];
+    for (let k = 0; k < infected; k += 1) {
+      people.push({
+        id: `i:${placeId}:${k}`,
+        infected: true,
+        newly_infected: false,
+        recovered: false
+      });
+    }
+    for (let k = 0; k < recovered; k += 1) {
+      people.push({
+        id: `r:${placeId}:${k}`,
+        infected: false,
+        newly_infected: false,
+        recovered: true
+      });
+    }
+    for (let k = 0; k < uninfectedSamples; k += 1) {
+      people.push({
+        id: `u:${placeId}:${k}`,
+        infected: false,
+        newly_infected: false,
+        recovered: false
+      });
+    }
+
+    if (people.length > 0) {
+      returnedPeople += people.length;
+      locations.push({ type: 'places', id: placeId, people });
+    }
+  }
+
+  return {
+    time,
+    requested_time: requestedTime,
+    total_people: totalPeople,
+    returned_people: returnedPeople,
+    sample_rate: sampleRate,
+    source: 'person',
+    locations
+  };
+}
+
+/** Synthesize the frame nearest `requestedTime` from a whole-run bundle. */
+export function synthesizeFromBundle(
+  bundle: DotsBundle,
+  requestedTime: number
+): SynthPeopleMap | null {
+  const nearest = findNearestTime(bundle.sortedTimes, requestedTime);
+  if (nearest === null) {
+    return null;
+  }
+  const frame = bundle.frames[String(nearest)];
+  if (!frame) {
+    return null;
+  }
+  return synthesizeDotsFrame(bundle.placeIds, frame, nearest, requestedTime);
+}

--- a/src/lib/people-map-cache.ts
+++ b/src/lib/people-map-cache.ts
@@ -15,6 +15,7 @@
 
 import { access, readFile, rename, stat, writeFile } from 'node:fs/promises';
 import { DB_FOLDER, readDbJson, resolveDbDataPath } from './db-files';
+import { findNearestTime, synthesizeDotsFrame } from './dots-synth';
 import { streamJsonObjectEntries } from './json-stream';
 import {
   getPatternMeta,
@@ -29,7 +30,6 @@ import type {
 
 const ACTIVE_INFECTION_MASK = 1 | 2 | 4 | 8;
 const RECOVERED_MASK = 16;
-const MAX_PEOPLE_DOTS = 12_000;
 const DOTS_FILE_VERSION = 1;
 const DOTS_CACHE_LIMIT = 4;
 
@@ -468,89 +468,27 @@ export async function loadDots(fileId: string): Promise<CachedDots | null> {
   return entry;
 }
 
-function findNearestTime(sortedTimes: number[], requestedTime: number) {
-  if (sortedTimes.length === 0) return null;
-  let nearest = sortedTimes[0];
-  for (const time of sortedTimes) {
-    if (Math.abs(time - requestedTime) < Math.abs(nearest - requestedTime)) {
-      nearest = time;
-    }
-    if (time > requestedTime) break;
+/**
+ * Load the whole compact dots bundle for a run (the parsed `{fileId}.dots.json`)
+ * so the client can fetch it ONCE and synthesize every frame locally — no
+ * per-frame /people-map fetch during playback. Returns null when the run has no
+ * (readable) baked file; the caller then falls back to the per-frame route.
+ */
+export async function loadDotsBundle(fileId: string): Promise<{
+  version: number;
+  place_ids: string[];
+  frames: Record<string, number[]>;
+  mtimeMs: number;
+} | null> {
+  const dots = await loadDots(fileId);
+  if (!dots) {
+    return null;
   }
-  return nearest;
-}
-
-/** Build the sampled dot payload from a place-count frame (synthetic people). */
-function synthesizePayload(
-  placeIds: string[],
-  frame: number[],
-  time: number,
-  requestedTime: number
-): PeopleMapPayload {
-  let totalPeople = 0;
-  for (let index = 0; index < placeIds.length; index += 1) {
-    totalPeople += frame[index * 3] || 0;
-  }
-  const sampleRate = Math.max(1, Math.ceil(totalPeople / MAX_PEOPLE_DOTS));
-
-  let returnedPeople = 0;
-  const locations: PeopleMapLocation[] = [];
-
-  for (let index = 0; index < placeIds.length; index += 1) {
-    const base = index * 3;
-    const population = frame[base] || 0;
-    if (population === 0) {
-      continue;
-    }
-    const infected = Math.min(population, frame[base + 1] || 0);
-    const recovered = Math.min(population - infected, frame[base + 2] || 0);
-    const uninfected = Math.max(0, population - infected - recovered);
-    const placeId = placeIds[index];
-
-    // Match the live route's semantics: every infected/recovered person is
-    // shown; only susceptibles are downsampled.
-    const uninfectedSamples =
-      uninfected > 0 ? Math.max(1, Math.ceil(uninfected / sampleRate)) : 0;
-    const people: PeopleMapPerson[] = [];
-    for (let k = 0; k < infected; k += 1) {
-      people.push({
-        id: `i:${placeId}:${k}`,
-        infected: true,
-        newly_infected: false,
-        recovered: false
-      });
-    }
-    for (let k = 0; k < recovered; k += 1) {
-      people.push({
-        id: `r:${placeId}:${k}`,
-        infected: false,
-        newly_infected: false,
-        recovered: true
-      });
-    }
-    for (let k = 0; k < uninfectedSamples; k += 1) {
-      people.push({
-        id: `u:${placeId}:${k}`,
-        infected: false,
-        newly_infected: false,
-        recovered: false
-      });
-    }
-
-    if (people.length > 0) {
-      returnedPeople += people.length;
-      locations.push({ type: 'places', id: placeId, people });
-    }
-  }
-
   return {
-    time,
-    requested_time: requestedTime,
-    total_people: totalPeople,
-    returned_people: returnedPeople,
-    sample_rate: sampleRate,
-    source: 'person',
-    locations
+    version: DOTS_FILE_VERSION,
+    place_ids: dots.placeIds,
+    frames: dots.frames,
+    mtimeMs: dots.mtimeMs
   };
 }
 
@@ -574,5 +512,5 @@ export async function readDotsPayload(
   if (!frame) {
     return null;
   }
-  return synthesizePayload(dots.placeIds, frame, nearest, requestedTime);
+  return synthesizeDotsFrame(dots.placeIds, frame, nearest, requestedTime);
 }

--- a/src/server/api/gzip-json.ts
+++ b/src/server/api/gzip-json.ts
@@ -1,0 +1,89 @@
+import { gunzipSync, gzipSync } from 'node:zlib';
+
+// Min payload worth gzipping (below this the CPU/overhead isn't worth it).
+const GZIP_MIN_BYTES = 1024;
+
+// A Node Buffer/Uint8Array is a valid Response body at runtime (undici), but TS
+// 5.9's generic `Uint8Array<ArrayBufferLike>` doesn't match the DOM `BodyInit`
+// union. Expose a zero-copy view cast to BodyInit (same approach the export
+// routes use for their streams).
+function asBody(buf: Buffer): BodyInit {
+  return new Uint8Array(
+    buf.buffer,
+    buf.byteOffset,
+    buf.byteLength
+  ) as unknown as BodyInit;
+}
+
+/**
+ * JSON response that is gzip-compressed when the client accepts it and the
+ * payload is large enough. The prod TLS proxy does not compress API JSON, so
+ * the Cases-map payloads (hundreds of KB / several MB) ship uncompressed and
+ * choke playback over the WAN — we compress at the app layer instead. Mirrors
+ * `jsonData` (wraps the value in `{ data }`).
+ */
+export function gzipJsonData(
+  request: Request,
+  data: unknown,
+  extraHeaders: Record<string, string> = {}
+): Response {
+  return gzipJson(request, { data }, extraHeaders);
+}
+
+/** Like `gzipJsonData` but sends the value as-is (no `{ data }` envelope). */
+export function gzipJson(
+  request: Request,
+  payload: unknown,
+  extraHeaders: Record<string, string> = {}
+): Response {
+  const body = Buffer.from(JSON.stringify(payload), 'utf8');
+  const acceptsGzip = (request.headers.get('accept-encoding') ?? '').includes(
+    'gzip'
+  );
+
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    Vary: 'Accept-Encoding',
+    ...extraHeaders
+  };
+
+  if (!acceptsGzip || body.byteLength < GZIP_MIN_BYTES) {
+    return new Response(asBody(body), { headers });
+  }
+
+  const gz = gzipSync(body);
+  headers['Content-Encoding'] = 'gzip';
+  return new Response(asBody(gz), { headers });
+}
+
+/**
+ * Serve a pre-gzipped JSON buffer (lets callers cache the gz bytes). Honors
+ * `Accept-Encoding`: a client that doesn't accept gzip gets the decompressed
+ * body instead.
+ */
+export function gzipPreserialized(
+  request: Request,
+  gz: Buffer,
+  extraHeaders: Record<string, string> = {}
+): Response {
+  const acceptsGzip = (request.headers.get('accept-encoding') ?? '').includes(
+    'gzip'
+  );
+  if (!acceptsGzip) {
+    return new Response(asBody(gunzipSync(gz)), {
+      headers: {
+        'Content-Type': 'application/json',
+        Vary: 'Accept-Encoding',
+        ...extraHeaders
+      }
+    });
+  }
+  return new Response(asBody(gz), {
+    headers: {
+      'Content-Type': 'application/json',
+      'Content-Encoding': 'gzip',
+      Vary: 'Accept-Encoding',
+      ...extraHeaders
+    }
+  });
+}


### PR DESCRIPTION
## Problem

On prod, Cases-map dots "appear then disappear" during playback (only on prod, not local). Root cause, confirmed by probing prod live (`X-Dots-Status: baked`):

- The backend bake is fine now — but each populated Cases frame is a **~290 KB per-dot JSON payload, served uncompressed** (the TLS proxy doesn't gzip API JSON) and is **re-fetched every playback tick**.
- On the WAN that transfer is ~0.4–0.7 s/frame, which exceeds the 750 ms playback interval, so the prefetch buffer starves and dots blank to "Loading cases…".
- A prior change (`d2f6175`) also cut `MAX_BUFFER_HOLDS` 10→1 on a "~20 ms from cache" assumption that only counted server compute, not network transfer — removing the anti-blank safety net.
- Local never reproduced because loopback has ~0 latency/transfer cost (it's the network, not the machine).

## Fix

Fetch the compact dots data **once per run** and synthesize every frame **client-side**, eliminating per-frame network during playback.

- **`src/lib/dots-synth.ts`** (new): pure synth shared by server + client, so frames are byte-identical. `people-map-cache.ts` now imports it (drops its duplicate `synthesizePayload`/`findNearestTime`) and exports `loadDotsBundle`.
- **`GET /api/simdata/[id]/dots`** (new): whole-run compact `{ version, place_ids, frames }` bundle, gzipped, with a gz-byte cache keyed by `fileId:mtime`; returns `409` + `X-Dots-Status` for non-bakeable runs.
- **`src/server/api/gzip-json.ts`** (new): gzip API JSON (honors `Accept-Encoding`), mirroring the existing `CompressionStream` pattern. The per-frame `/people-map` responses are now gzipped too.
- **`modelmap.tsx`**: load the bundle once on Cases-view open; `selectedPeopleMapData` synthesizes each frame locally; per-frame fetch + prefetch + buffer-hold are bypassed when the bundle is loaded. `MAX_BUFFER_HOLDS` 1→6 (now governs only the non-bundle fallback path, which is fully intact for non-bakeable runs).

One `/people-map` request still fires on Cases-view open (instant first frame while the bundle downloads); after that, playback is 100% client-side.

## Verification

- **Static:** `tsc --noEmit` clean, biome clean, **31/31** unit tests (4 new synth tests).
- **Backend (run 178, local):** `/dots` → `200`, `content-encoding: gzip`, **249 KB vs 1.44 MB** uncompressed, `X-Dots-Status: baked`, 313 places × 720 frames. Client synth proven **byte-identical** to the server's `/people-map` output (4041/4041 people, 219 locations).
- **Browser:** bundle fetched once; dots painted (`queryRenderedFeatures`: 4 infected + 2 recovered); scrubbing the full timeline (frames 50→150→300→450→600 of 720) made **zero** per-frame requests — `/people-map` flat at 1, `/dots` flat at 2 — and "Loading cases…" never appeared.

## Net effect on prod

Old: ~290 KB **per tick** over the WAN → buffer starves → blank. New: one ~250 KB gzipped fetch per run, then every frame is local.

## Not included

Phase 3 backend robustness (engine/numeric lazy-bake OOM for old/large runs; `ensureDotsFile` existence-trap re-validation) is intentionally out of scope here — those are latent bugs that only affect runs lacking a good pre-baked file, not the playback symptom this PR fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
