### PR TITLE
Render disabled POIs as empty markers, not black case dots

### DIFF
--- a/src/app/simulator/[run_id]/page.tsx
+++ b/src/app/simulator/[run_id]/page.tsx
@@ -3,7 +3,7 @@
 import dynamic from 'next/dynamic';
 import { ArrowLeft, Check, Save } from 'lucide-react';
 import { useParams, useRouter, useSearchParams } from 'next/navigation';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import ComparisonSummary from '@/components/comparison-summary';
 import EditDeleteActions from '@/components/edit-delete-actions';
 import LoginModal from '@/components/login-modal';
@@ -60,6 +60,9 @@ function formatRunDate(value?: string | null) {
   }
   return new Date(value).toLocaleDateString();
 }
+
+// Stable identity so gating the map overlay off doesn't churn ModelMap's memo.
+const EMPTY_DISABLED_POI_IDS: ReadonlySet<string> = new Set();
 
 function getDisabledPoiIdsFromMetadata(metadata: unknown) {
   if (!metadata || typeof metadata !== 'object') {
@@ -225,6 +228,10 @@ export default function SimulatorRun() {
     null
   );
   const [disabledRunError, setDisabledRunError] = useState<string | null>(null);
+  // Set when the user kicks off a disabled rerun, so the page auto-switches to
+  // the rerouted run once its payload loads instead of leaving them on the
+  // original (un-rerouted) run with a stale view.
+  const autoShowDisabledRef = useRef(false);
 
   const activeSimId =
     activeView === 'disabled' && disabledSimId != null
@@ -344,6 +351,16 @@ export default function SimulatorRun() {
     setDisabledCategories(new Set());
     setDisabledPoiIds(new Set(metadataDisabledIds));
   }, [disabledPayload?.metadata]);
+
+  // After a disabled rerun completes and its payload loads, switch the map to
+  // the rerouted run so the user sees the actual effect of disabling rather
+  // than the original run with a (now-gated) disabled overlay.
+  useEffect(() => {
+    if (autoShowDisabledRef.current && disabledPayload) {
+      autoShowDisabledRef.current = false;
+      showRun('disabled');
+    }
+  }, [disabledPayload, showRun]);
 
   useEffect(() => {
     if (!run_id) {
@@ -591,6 +608,8 @@ export default function SimulatorRun() {
       const comparisonId = await runSimulation(comparisonSettings, onProgress);
       const params = new URLSearchParams(searchParams.toString());
       params.set('disabled', String(comparisonId));
+      // Land the user on the rerouted run once it finishes loading.
+      autoShowDisabledRef.current = true;
       router.push(`/simulator/${interventionSimId}?${params.toString()}`);
     } catch (e) {
       console.error(e);
@@ -836,7 +855,13 @@ export default function SimulatorRun() {
             key={activeSimId}
             selectedZone={selectedZone}
             simId={activeSimId}
-            disabledPoiIds={effectiveDisabledPoiIds}
+            // Only paint POIs as disabled on the run that actually rerouted
+            // them; the intervention/baseline runs still placed people there.
+            disabledPoiIds={
+              activeView === 'disabled'
+                ? effectiveDisabledPoiIds
+                : EMPTY_DISABLED_POI_IDS
+            }
             onMarkerClick={handleMarkerClick}
             focusPoi={focusPoi}
           />

--- a/src/features/model-map/clustered-map.tsx
+++ b/src/features/model-map/clustered-map.tsx
@@ -252,8 +252,7 @@ export default function ClusteredMap({
     for (const id of [
       'person-status-uninfected',
       'person-status-recovered',
-      'person-status-infected',
-      'person-status-disabled'
+      'person-status-infected'
     ]) {
       if (mapInstance.getLayer(id))
         mapInstance.setLayoutProperty(
@@ -370,12 +369,6 @@ export default function ClusteredMap({
     ['==', ['get', 'disabled'], true],
     DISABLED_POI_COLOR,
     clusterColor
-  ] as unknown as string;
-  const peopleDotPaintColor = [
-    'case',
-    ['==', ['get', 'disabled'], true],
-    DISABLED_POI_COLOR,
-    peopleDotColor
   ] as unknown as string;
   const footprintPaintColor = [
     'case',
@@ -625,7 +618,7 @@ export default function ClusteredMap({
                 18,
                 6
               ] as const,
-              'circle-color': peopleDotPaintColor,
+              'circle-color': peopleDotColor,
               'circle-opacity': 0.72,
               'circle-stroke-width': 0
             }}
@@ -752,23 +745,8 @@ export default function ClusteredMap({
               'circle-stroke-width': 0
             }}
           />
-          <Layer
-            id="person-status-disabled"
-            type="circle"
-            minzoom={CASE_CLUSTER_MAX_ZOOM}
-            filter={['==', ['get', 'disabled'], true]}
-            layout={
-              {
-                visibility: showCaseDotsLayer ? 'visible' : 'none'
-              } as const
-            }
-            paint={{
-              'circle-radius': PERSON_STATUS_DOT_RADIUS,
-              'circle-color': DISABLED_POI_COLOR,
-              'circle-opacity': 0.88,
-              'circle-stroke-width': 0
-            }}
-          />
+          {/* Disabled POIs emit no person dots (suppressed in map-data); their
+              "disabled" state shows as the black footprint/marker, not dots. */}
         </Source>
         <Source id="poi-label-points" type="geojson" data={poiLabelGeoJSON}>
           <Layer

--- a/src/features/model-map/map-data.test.mjs
+++ b/src/features/model-map/map-data.test.mjs
@@ -70,8 +70,7 @@ test('makePeopleDotGeoJSON ignores homes and places dots inside place footprints
         footprint: square,
         icon: '🏥',
         population: 3,
-        infected: 2,
-        disabled: true
+        infected: 2
       }
     ],
     'population'
@@ -79,7 +78,7 @@ test('makePeopleDotGeoJSON ignores homes and places dots inside place footprints
 
   assert.equal(data.features.length, 3);
   assert.equal(data.features[0].properties.loc_id, 'p1');
-  assert.equal(data.features[0].properties.disabled, true);
+  assert.equal(data.features[0].properties.disabled, false);
   for (const feature of data.features) {
     const [lng, lat] = feature.geometry.coordinates;
     assert.equal(pointInGeometry(lng, lat, square), true);
@@ -87,6 +86,80 @@ test('makePeopleDotGeoJSON ignores homes and places dots inside place footprints
 });
 
 test('makePersonStatusDotGeoJSON keeps person dots stable inside place footprints', () => {
+  const pois = [
+    {
+      type: 'places',
+      id: 'p1',
+      latitude: 0.5,
+      longitude: 0.5,
+      label: 'Clinic',
+      description: '3 people\n2 infected',
+      footprint: square,
+      icon: '🏥',
+      population: 3,
+      infected: 2
+    }
+  ];
+  const peopleMap = {
+    time: 60,
+    requested_time: 60,
+    total_people: 2,
+    returned_people: 2,
+    sample_rate: 1,
+    locations: [
+      {
+        type: 'places',
+        id: 'p1',
+        people: [
+          { id: 'a', infected: false, newly_infected: false },
+          { id: 'b', infected: true, newly_infected: true }
+        ]
+      }
+    ]
+  };
+
+  const first = makePersonStatusDotGeoJSON(pois, peopleMap);
+  const second = makePersonStatusDotGeoJSON(pois, peopleMap);
+
+  assert.deepEqual(first, second);
+  assert.equal(first.features.length, 2);
+  assert.equal(first.features[1].properties.person_id, 'b');
+  assert.equal(first.features[1].properties.infected, true);
+  assert.equal(first.features[1].properties.newly_infected, true);
+  assert.equal(first.features[1].properties.disabled, false);
+  for (const feature of first.features) {
+    const [lng, lat] = feature.geometry.coordinates;
+    assert.equal(pointInGeometry(lng, lat, square), true);
+  }
+});
+
+test('makePeopleDotGeoJSON suppresses dots at disabled POIs', () => {
+  resetModelMapLayoutCaches();
+
+  const data = makePeopleDotGeoJSON(
+    [
+      {
+        type: 'places',
+        id: 'p1',
+        latitude: 0.5,
+        longitude: 0.5,
+        label: 'Clinic',
+        description: '3 people\n2 infected',
+        footprint: square,
+        icon: '🏥',
+        population: 3,
+        infected: 2,
+        disabled: true
+      }
+    ],
+    'population'
+  );
+
+  // A disabled POI renders as an empty black marker, never as people dots.
+  assert.equal(data.features.length, 0);
+});
+
+test('makePersonStatusDotGeoJSON suppresses dots at disabled POIs', () => {
   const pois = [
     {
       type: 'places',
@@ -120,19 +193,10 @@ test('makePersonStatusDotGeoJSON keeps person dots stable inside place footprint
     ]
   };
 
-  const first = makePersonStatusDotGeoJSON(pois, peopleMap);
-  const second = makePersonStatusDotGeoJSON(pois, peopleMap);
+  const result = makePersonStatusDotGeoJSON(pois, peopleMap);
 
-  assert.deepEqual(first, second);
-  assert.equal(first.features.length, 2);
-  assert.equal(first.features[1].properties.person_id, 'b');
-  assert.equal(first.features[1].properties.infected, true);
-  assert.equal(first.features[1].properties.newly_infected, true);
-  assert.equal(first.features[1].properties.disabled, true);
-  for (const feature of first.features) {
-    const [lng, lat] = feature.geometry.coordinates;
-    assert.equal(pointInGeometry(lng, lat, square), true);
-  }
+  // Disabled POI: no person dots emitted (visitors were rerouted away).
+  assert.equal(result.features.length, 0);
 });
 
 test('makePoiFootprintGeoJSON exposes only place footprints', () => {

--- a/src/features/model-map/map-data.ts
+++ b/src/features/model-map/map-data.ts
@@ -936,6 +936,8 @@ export function makePeopleDotGeoJSON(pois: MapPoi[], mode: string) {
 
     const isHome = poi.type === 'homes';
     if (isHome) continue;
+    // Disabled POIs render as an empty black marker: suppress aggregate dots.
+    if (poi.disabled) continue;
 
     const dotCount = Math.min(
       MAX_PLACE_DOTS_PER_LOCATION,
@@ -1026,6 +1028,11 @@ export function makePersonStatusDotGeoJSON(
       !Number.isFinite(poi.latitude) ||
       !Number.isFinite(poi.longitude)
     ) {
+      continue;
+    }
+    // Disabled POIs render as an empty black marker: suppress their people
+    // dots entirely (visitors were rerouted away) rather than recoloring them.
+    if (poi.disabled) {
       continue;
     }
 


### PR DESCRIPTION
## Problem
Disabling POIs *looked* broken: the cases map showed **black dots at disabled locations** even though those people were supposed to be gone. The backend reroute is correct — the bug was entirely in the map rendering, two issues stacked:

1. **Dots were recolored, not removed.** The dot builders painted every person at a disabled POI black (`disabled` → `DISABLED_POI_COLOR`) instead of suppressing them.
2. **The overlay was applied to the wrong run.** The black "disabled" styling was driven by the local toggle set and applied to whatever run was on screen. Right after a disabled rerun the view stayed on the **original** run (which genuinely placed people at those POIs), so you saw real people recolored black — and the rerouted run was only shown if you manually clicked the map's "Disabled POIs" toggle.

## Fix
- **`map-data.ts`** — `makePersonStatusDotGeoJSON` and `makePeopleDotGeoJSON` now skip disabled POIs entirely. A disabled POI renders as an empty location (black footprint/marker), never as black people dots.
- **`clustered-map.tsx`** — remove the now-dead `person-status-disabled` layer and the dead disabled branch of the people-dots paint; keep the footprint/marker recolor so disabled POIs still read as black.
- **`page.tsx`** — apply the disabled overlay **only on the rerouted ("Disabled POIs") view** (intervention/baseline render unmodified), and **auto-switch** to the rerouted run once it loads so the user immediately sees the effect of disabling.
- **tests** — update two `map-data` tests to the new contract + add two suppression tests.

No backend change needed (reroute already correct on Simulation `main`).

## Verification
- `tsc --noEmit` clean; `biome lint` clean; `map-data` tests **8/8**.
- Live e2e on the local stack (czone-108, disabled "Birch Lake", a 3,613-person hub → new run):
  - View **auto-switched** to "Disabled POIs" after the rerun.
  - Reroute genuinely propagated: that POI's peak occupancy **3,613 → 0**; whole-run peak/total infections **49,736 → 8,448 (↓83%)** from disabling one hub.
  - Live map: `person-status-disabled` layer gone, **0** painted dots carry the `disabled` flag.
  - Gating confirmed: the disabled legend swatch / styling appears **only** on the disabled view, absent on "With interventions".

🤖 Generated with [Claude Code](https://claude.com/claude-code)