### PR TITLE
Keep map dots inside POI footprints (fix point-in-polygon sign bug)

### DIFF
--- a/src/features/model-map/map-data.test.mjs
+++ b/src/features/model-map/map-data.test.mjs
@@ -43,6 +43,49 @@ test('samplePointsInFootprint is deterministic and keeps dots inside the footpri
   }
 });
 
+// A diamond (rotated square) is the unit L1 ball — its edges run diagonally
+// up AND down, which is exactly what the old `Math.max(latJ - latI, 1e-12)`
+// ray-cast got wrong. An axis-aligned square hides the bug (its vertical edges
+// have a zero numerator), so test the diamond against an exact oracle.
+const diamond = {
+  type: 'Polygon',
+  coordinates: [
+    [
+      [0, 1],
+      [1, 0],
+      [0, -1],
+      [-1, 0],
+      [0, 1]
+    ]
+  ]
+};
+
+test('pointInGeometry classifies a polygon with downward edges correctly (sign-bug regression)', () => {
+  const oracle = (x, y) => Math.abs(x) + Math.abs(y) < 1;
+  let checked = 0;
+  let mismatches = 0;
+  for (let gx = -9; gx <= 9; gx += 1) {
+    for (let gy = -9; gy <= 9; gy += 1) {
+      const x = gx / 10;
+      const y = gy / 10;
+      // Skip points sitting exactly on an edge (boundary is ambiguous).
+      if (Math.abs(Math.abs(x) + Math.abs(y) - 1) < 1e-9) continue;
+      checked += 1;
+      if (pointInGeometry(x, y, diamond) !== oracle(x, y)) mismatches += 1;
+    }
+  }
+  assert.ok(checked > 0);
+  assert.equal(mismatches, 0);
+});
+
+test('samplePointsInFootprint keeps every dot inside a diagonally-edged polygon', () => {
+  const points = samplePointsInFootprint(diamond, 40, 7);
+  assert.equal(points.length, 40);
+  for (const [lng, lat] of points) {
+    assert.equal(pointInGeometry(lng, lat, diamond), true);
+  }
+});
+
 test('makePeopleDotGeoJSON ignores homes and places dots inside place footprints', () => {
   resetModelMapLayoutCaches();
 
@@ -130,6 +173,60 @@ test('makePersonStatusDotGeoJSON keeps person dots stable inside place footprint
   for (const feature of first.features) {
     const [lng, lat] = feature.geometry.coordinates;
     assert.equal(pointInGeometry(lng, lat, square), true);
+  }
+});
+
+test('makePersonStatusDotGeoJSON clamps dots inside a sparse footprint (never spills)', () => {
+  resetModelMapLayoutCaches();
+  // A thin diagonal sliver: its area is <1% of its bounding box, so rejection
+  // sampling can't place all `count` points and the shortfall path engages.
+  // Those leftover dots must cycle interior points, not spill into a disk.
+  const sliver = {
+    type: 'Polygon',
+    coordinates: [
+      [
+        [0, 0],
+        [10, 10],
+        [9.97, 10],
+        [-0.03, 0],
+        [0, 0]
+      ]
+    ]
+  };
+  const people = Array.from({ length: 60 }, (_, k) => ({
+    id: `p${k}`,
+    infected: false,
+    newly_infected: false,
+    recovered: false
+  }));
+  const result = makePersonStatusDotGeoJSON(
+    [
+      {
+        type: 'places',
+        id: 's1',
+        latitude: 5,
+        longitude: 5,
+        label: 'Sliver',
+        footprint: sliver,
+        icon: '🏥',
+        population: 60,
+        infected: 0
+      }
+    ],
+    {
+      time: 0,
+      requested_time: 0,
+      total_people: 60,
+      returned_people: 60,
+      sample_rate: 1,
+      locations: [{ type: 'places', id: 's1', people }]
+    }
+  );
+
+  assert.equal(result.features.length, 60);
+  for (const feature of result.features) {
+    const [lng, lat] = feature.geometry.coordinates;
+    assert.equal(pointInGeometry(lng, lat, sliver), true);
   }
 });
 

--- a/src/features/model-map/map-data.ts
+++ b/src/features/model-map/map-data.ts
@@ -74,7 +74,14 @@ const HOME_CIRCLE_RADIUS_MAX = 0.025;
 const HOME_CIRCLE_RADIUS_QUANTILE = 0.95;
 const MAX_PERSON_DOTS = 8000;
 const MAX_PLACE_DOTS_PER_LOCATION = 220;
-const NO_FOOTPRINT_DOT_JITTER_DEGREES = 0.0008;
+// Spread for POIs that have no footprint polygon (only a point). Kept tight so
+// they read as a small cluster on the pin rather than a wide spray of dots that
+// look unanchored. POIs that DO have a footprint never use this — their dots are
+// clamped inside the polygon.
+const NO_FOOTPRINT_DOT_JITTER_DEGREES = 0.00025;
+// Cap on how much the no-footprint disk grows with occupancy (radius scales with
+// sqrt(count)); keeps even busy footprint-less POIs from spraying too far.
+const NO_FOOTPRINT_DISK_MAX_GROWTH = 3;
 
 let householdLocs: Record<string, Coordinate> = {};
 let placeLocs: Record<string, Coordinate> = {};
@@ -230,10 +237,13 @@ function pointInRing(lng: number, lat: number, ring: Coordinate[]) {
   for (let i = 0, j = ring.length - 1; i < ring.length; j = i++) {
     const [lngI, latI] = ring[i];
     const [lngJ, latJ] = ring[j];
+    // The `latI > lat !== latJ > lat` guard means the edge straddles `lat`, so
+    // `latJ - latI` is non-zero here. Dividing by it directly preserves the
+    // sign; a `Math.max(latJ - latI, 1e-12)` would flip the ray-cast on every
+    // downward edge and wrongly classify exterior points as inside.
     const intersects =
       latI > lat !== latJ > lat &&
-      lng <
-        ((lngJ - lngI) * (lat - latI)) / Math.max(latJ - latI, 1e-12) + lngI;
+      lng < ((lngJ - lngI) * (lat - latI)) / (latJ - latI) + lngI;
     if (intersects) inside = !inside;
   }
   return inside;
@@ -355,9 +365,11 @@ function computeDiskLayout(
   if (count <= 0) return [];
   const offsetA = 1 + Math.floor(hashUnit(seed, 11) * 997);
   const offsetB = 1 + Math.floor(hashUnit(seed, 13) * 997);
-  // Scale the disk radius with sqrt(count) so density stays roughly constant
+  // Scale the disk radius with sqrt(count) so density stays roughly constant,
+  // capped so a busy footprint-less POI still reads as a contained cluster.
   const radius =
-    NO_FOOTPRINT_DOT_JITTER_DEGREES * Math.max(1, Math.sqrt(count / 24));
+    NO_FOOTPRINT_DOT_JITTER_DEGREES *
+    Math.min(NO_FOOTPRINT_DISK_MAX_GROWTH, Math.max(1, Math.sqrt(count / 24)));
   const cos = Math.max(Math.cos((centerLat * Math.PI) / 180), 0.35);
   const out: Coordinate[] = new Array(count);
   for (let i = 0; i < count; i++) {
@@ -959,6 +971,7 @@ export function makePeopleDotGeoJSON(pois: MapPoi[], mode: string) {
         placeDotLayouts[footprintKey] = footprintDots;
       }
     }
+    const hasFootprintDots = Boolean(footprintDots && footprintDots.length > 0);
 
     for (let i = 0; i < dotCount; i++) {
       if (features.length >= MAX_PERSON_DOTS) {
@@ -966,18 +979,25 @@ export function makePeopleDotGeoJSON(pois: MapPoi[], mode: string) {
         break;
       }
 
-      const footprintDot =
-        footprintDots && i < footprintDots.length ? footprintDots[i] : null;
-      const angle = hashUnit(baseSeed, i) * Math.PI * 2;
-      const radius =
-        Math.sqrt(hashUnit(baseSeed, i + 100_000)) *
-        NO_FOOTPRINT_DOT_JITTER_DEGREES;
-      const lat = footprintDot
-        ? footprintDot[1]
-        : poi.latitude + Math.sin(angle) * radius;
-      const lng = footprintDot
-        ? footprintDot[0]
-        : poi.longitude + Math.cos(angle) * radius;
+      let lat: number;
+      let lng: number;
+      if (hasFootprintDots) {
+        // Clamp inside the footprint: cycle interior samples if short so a
+        // footprint POI never spills dots outside its polygon.
+        const fp = (footprintDots as Coordinate[])[
+          i % (footprintDots as Coordinate[]).length
+        ];
+        lng = fp[0];
+        lat = fp[1];
+      } else {
+        // No footprint: a tight jitter disk around the POI point.
+        const angle = hashUnit(baseSeed, i) * Math.PI * 2;
+        const radius =
+          Math.sqrt(hashUnit(baseSeed, i + 100_000)) *
+          NO_FOOTPRINT_DOT_JITTER_DEGREES;
+        lat = poi.latitude + Math.sin(angle) * radius;
+        lng = poi.longitude + Math.cos(angle) * radius;
+      }
 
       features.push({
         type: 'Feature',
@@ -1050,17 +1070,24 @@ export function makePersonStatusDotGeoJSON(
         location.type === 'places' && poi.footprint
           ? samplePointsInFootprint(poi.footprint, count, seed)
           : [];
-      const shortfall = Math.max(0, count - footprintPoints.length);
-      const diskPoints =
-        shortfall > 0
-          ? computeDiskLayout(
-              poi.latitude,
-              poi.longitude,
-              shortfall,
-              seed ^ 0x9e3779b1
-            )
-          : [];
-      positions = [...footprintPoints, ...diskPoints];
+      if (footprintPoints.length >= count) {
+        positions = footprintPoints;
+      } else if (footprintPoints.length > 0) {
+        // Footprint POI whose sampling fell short (thin/awkward polygon): cycle
+        // the interior points so dots NEVER spill outside the footprint.
+        positions = Array.from(
+          { length: count },
+          (_, i) => footprintPoints[i % footprintPoints.length]
+        );
+      } else {
+        // No usable footprint: a tight disk around the POI point.
+        positions = computeDiskLayout(
+          poi.latitude,
+          poi.longitude,
+          count,
+          seed ^ 0x9e3779b1
+        );
+      }
       personLayoutCache[layoutKey] = positions;
     }
 


### PR DESCRIPTION
## Problem
On the Cases/Movement map, case & people dots scattered **outside** their building footprints, looking like people standing in streets and parking lots with no anchor.

## Root cause
The ray-cast in `pointInRing` divided by `Math.max(latJ - latI, 1e-12)`. That `Math.max` **throws away the sign on every downward-going edge**, so the point-in-polygon test wrongly classified exterior points as *inside*. `samplePointsInFootprint` uses that test to accept interior samples — so it happily accepted points outside the polygon, and those became dots.

Measured live on prod run 130 (Barnsdall, 10,679 dots at hour 13):
- By the app's own (buggy) test: 98.7% "inside".
- By a correct test: only **54.2% actually inside — 45.8% spilled outside**, worst at large POIs (airport, Hertz, aviation).

An axis-aligned square *hides* the bug (its vertical edges have a zero numerator), which is why existing tests never caught it.

## Fix
1. **`pointInRing`** — divide by `(latJ - latI)` directly. The `latI > lat !== latJ > lat` guard already guarantees a non-zero denominator, so the `Math.max` was both unnecessary and sign-destroying. **This alone takes spill 45.8% → 0% on run 130.**
2. **Clamp — footprinted POIs never spill** (`makePersonStatusDotGeoJSON` + `makePeopleDotGeoJSON`): if rejection-sampling falls short on a thin/low-fill polygon, dots **cycle the interior points** instead of disk-scattering. The disk path now applies *only* to footprint-less POIs.
3. **Shrink the no-footprint disk**: `NO_FOOTPRINT_DOT_JITTER_DEGREES` `0.0008 → 0.00025` (~90 m → ~28 m) + cap its `sqrt(count)` growth, so a footprint-less POI reads as a contained cluster on the pin rather than a wide spray.

## Verification
- Replicated the new sampler against run 130's real footprints + occupancy: spill **45.8% → 0%** (all 10,679 dots inside; 0 places even needed the clamp fallback).
- Tests: oracle-based sign-bug regression (unit diamond), diamond sampling, sparse-sliver clamp. **11/11 pass**, `tsc --noEmit` + `biome lint` clean.

## Notes
- Footprint coverage on real data is ~100% (run 130: 1843/1843 places have footprints), so footprint-less POIs are rare; place name labels show regardless of footprint (only the shaded outline needs a polygon).

🤖 Generated with [Claude Code](https://claude.com/claude-code)