### PR TITLE
Raise Initial Infected cap from 100 to 1000

### DIFF
--- a/src/components/simsettings.tsx
+++ b/src/components/simsettings.tsx
@@ -333,7 +333,7 @@ export default function SimSettings({
               setSettings({ initial_infected_count })
             }
             min={1}
-            max={Math.min(100, zone?.size ?? 100)}
+            max={Math.min(1000, zone?.size ?? 1000)}
             percent={false}
             units=" people"
           />


### PR DESCRIPTION
## Hotfix

Raise the **Initial Infected** seed-count slider cap from 100 to 1000 people.

### Why
The slider in `simsettings.tsx` was bounded at `Math.min(100, zone?.size)`. The backend imposes no upper limit:
- `Simulation/server.py` validates `initial_infected_count` with `minimum: 0` only (no max)
- `Simulation/simulator/world.py` clamps the seed count to the eligible population

So the 100 cap was purely a UI bound. This raises it to `Math.min(1000, zone?.size)`.

### Change
One line in `src/components/simsettings.tsx`.

### Verification
- `pnpm typecheck` — clean
- `pnpm lint` — no new findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)