### PR TITLE
Show infection incidence hotspots

### DIFF
--- a/src/app/api/simdata/[id]/map/route.ts
+++ b/src/app/api/simdata/[id]/map/route.ts
@@ -90,7 +90,8 @@ export async function GET(
           papdata: manifest.papdata,
           hotspots: manifest.hotspots,
           timesteps: manifest.timesteps,
-          poiPeaks: manifest.poiPeaks
+          poiPeaks: manifest.poiPeaks,
+          incidence: manifest.incidence
         }
       },
       { headers: { 'Cache-Control': 'private, max-age=30' } }

--- a/src/app/simulator/[run_id]/page.tsx
+++ b/src/app/simulator/[run_id]/page.tsx
@@ -49,6 +49,7 @@ export default function SimulatorRun() {
   const setHotspots = useMapData((state) => state.setHotspots);
   const setTimesteps = useMapData((state) => state.setTimesteps);
   const setPoiPeaks = useMapData((state) => state.setPoiPeaks);
+  const setIncidence = useMapData((state) => state.setIncidence);
   const setRunName = useMapData((state) => state.setName);
 
   const { data: session } = useSession();
@@ -160,6 +161,7 @@ export default function SimulatorRun() {
       setHotspots(payload.hotspots ?? {});
       setTimesteps(payload.timesteps);
       setPoiPeaks(payload.poiPeaks);
+      setIncidence(payload.incidence);
       setPapData(payload.papdata);
       setActiveView(view);
     },
@@ -168,6 +170,7 @@ export default function SimulatorRun() {
       disabledPayload,
       interventionPayload,
       setHotspots,
+      setIncidence,
       setPoiPeaks,
       setPapData,
       setSimData,
@@ -251,6 +254,7 @@ export default function SimulatorRun() {
       setPapData(null);
       setTimesteps(null);
       setPoiPeaks(null);
+      setIncidence(null);
       setError(null);
       setInterventionPayload(null);
       setBaselinePayload(null);
@@ -283,6 +287,7 @@ export default function SimulatorRun() {
           papdata,
           timesteps,
           poiPeaks,
+          incidence,
           metadata
         } = (await response.json()).data;
 
@@ -300,12 +305,14 @@ export default function SimulatorRun() {
         setPapData(papdata);
         setTimesteps(timesteps);
         setPoiPeaks(poiPeaks);
+        setIncidence(incidence ?? null);
         setInterventionPayload({
           simdata: null,
           papdata,
           hotspots,
           timesteps,
           poiPeaks,
+          incidence: incidence ?? null,
           metadata
         });
 
@@ -330,6 +337,7 @@ export default function SimulatorRun() {
                 hotspots: comparisonJson.data.hotspots,
                 timesteps: comparisonJson.data.timesteps,
                 poiPeaks: comparisonJson.data.poiPeaks,
+                incidence: comparisonJson.data.incidence ?? null,
                 metadata: comparisonJson.data.metadata
               };
             }
@@ -381,6 +389,7 @@ export default function SimulatorRun() {
     router.replace,
     setHotspots,
     setPoiPeaks,
+    setIncidence,
     setPapData,
     setRunName,
     setSettings,

--- a/src/app/simulator/[run_id]/run-metadata.test.mjs
+++ b/src/app/simulator/[run_id]/run-metadata.test.mjs
@@ -19,7 +19,10 @@ test('getDisabledPoiIdsFromMetadata is empty for non-objects / missing / non-arr
   assert.deepEqual(getDisabledPoiIdsFromMetadata(null), []);
   assert.deepEqual(getDisabledPoiIdsFromMetadata('x'), []);
   assert.deepEqual(getDisabledPoiIdsFromMetadata({}), []);
-  assert.deepEqual(getDisabledPoiIdsFromMetadata({ disabled_poi_ids: 'a' }), []);
+  assert.deepEqual(
+    getDisabledPoiIdsFromMetadata({ disabled_poi_ids: 'a' }),
+    []
+  );
 });
 
 test('getStringArray trims/filters and nulls on empty or non-array', () => {
@@ -57,6 +60,7 @@ const FALLBACK = {
   dmp_mode: 'off',
   model_path_by_variant: { fv: 'fallback/path' },
   initial_infected_count: 1,
+  initial_infected_ids: [],
   randseed: false,
   interventions: []
 };
@@ -82,6 +86,7 @@ test('getRunSettingsFromMetadata reads valid fields and falls back on invalid on
       dmp_mode: 'auto',
       model_path_by_variant: { a: 'pa' },
       initial_infected_count: 7,
+      initial_infected_ids: [' 10 ', '11', ''],
       randseed: true,
       interventions: [intervention]
     },
@@ -92,6 +97,7 @@ test('getRunSettingsFromMetadata reads valid fields and falls back on invalid on
   assert.equal(out.dmp_mode, 'auto');
   assert.deepEqual(out.model_path_by_variant, { a: 'pa' });
   assert.equal(out.initial_infected_count, 7);
+  assert.deepEqual(out.initial_infected_ids, ['10', '11']);
   assert.equal(out.randseed, true);
   assert.deepEqual(out.interventions, [intervention]);
 });

--- a/src/app/simulator/[run_id]/run-metadata.ts
+++ b/src/app/simulator/[run_id]/run-metadata.ts
@@ -1,7 +1,12 @@
 // Pure helpers + types for the simulator run page: parsing the (untrusted) run
 // metadata blob, run-view labels, and date formatting. No React and no runtime
 // imports (types only), so this stays unit-testable in isolation via node:test.
-import type { PapData, PoiPeaks, SimData } from '@/stores/mapdata';
+import type {
+  PapData,
+  PoiPeaks,
+  RunIncidence,
+  SimData
+} from '@/stores/mapdata';
 import type { SimSettings as SimSettingsState } from '@/stores/simsettings';
 
 export interface SelectedLoc {
@@ -18,6 +23,7 @@ export interface SimRunData {
   hotspots: { [key: string]: number[] } | null;
   timesteps: number[] | null;
   poiPeaks: PoiPeaks | null;
+  incidence: RunIncidence | null;
   metadata?: unknown;
 }
 
@@ -128,6 +134,9 @@ export function getRunSettingsFromMetadata(
       typeof record.initial_infected_count === 'number'
         ? record.initial_infected_count
         : fallback.initial_infected_count,
+    initial_infected_ids:
+      getStringArray(record.initial_infected_ids) ??
+      fallback.initial_infected_ids,
     randseed:
       typeof record.randseed === 'boolean'
         ? record.randseed

--- a/src/components/comparison-summary.tsx
+++ b/src/components/comparison-summary.tsx
@@ -191,19 +191,19 @@ export default function ComparisonSummary({
           ]
         },
         {
-          title: 'Total infected',
+          title: 'New infections',
           rows: [
             {
               label: referenceLabel,
-              value: countFmt(data.reference.totalInfected),
+              value: countFmt(data.reference.newInfections),
               delta: null
             },
             ...data.scenarios.map((s) => ({
               label: s.label,
-              value: countFmt(s.stats.totalInfected),
+              value: countFmt(s.stats.newInfections),
               delta: lowerIsBetterDelta(
-                data.reference.totalInfected,
-                s.stats.totalInfected
+                data.reference.newInfections,
+                s.stats.newInfections
               )
             }))
           ]

--- a/src/components/poi-rankings.tsx
+++ b/src/components/poi-rankings.tsx
@@ -15,6 +15,9 @@ type PoiStat = {
   category: string;
   peakInfected: number;
   popAtPeak: number;
+  // Cumulative infections that actually happened at this POI (true incidence).
+  // 0 when the run predates incidence tracking; ranking then falls back to peak.
+  incidence: number;
 };
 
 type RankRow = {
@@ -50,6 +53,52 @@ function truncate(label: string) {
 
 function formatPoiCount(count: number) {
   return `${count.toLocaleString()} POI${count === 1 ? '' : 's'}`;
+}
+
+// Home vs POI split of where transmission actually occurred (true incidence).
+// In reality most transmission happens at home; this surfaces that split, which
+// the peak infected-present ranking cannot show (everyone is home at night).
+function HomeVsPoiSummary({ home, poi }: { home: number; poi: number }) {
+  const total = home + poi;
+  if (total <= 0) return null;
+
+  const rows = [
+    { key: 'home', label: 'At home', value: home, color: 'var(--color-primary-blue)' },
+    { key: 'poi', label: 'At POIs', value: poi, color: 'var(--color-text-muted)' }
+  ];
+
+  return (
+    <div className="incidence_summary">
+      <p className="incidence_summary_caption">
+        Of {total.toLocaleString()} infection{total === 1 ? '' : 's'}, where
+        transmission actually happened:
+      </p>
+      {rows.map((row) => {
+        const pct = Math.round((row.value / total) * 100);
+        return (
+          <div key={row.key} className="incidence_summary_row">
+            <span className="incidence_summary_label">{row.label}</span>
+            <div
+              className="incidence_summary_track"
+              role="img"
+              aria-label={`${row.label}: ${pct} percent`}
+            >
+              <div
+                className="incidence_summary_fill"
+                style={{ width: `${pct}%`, backgroundColor: row.color }}
+              />
+            </div>
+            <span className="incidence_summary_value">
+              {pct}%{' '}
+              <span className="incidence_summary_count">
+                ({row.value.toLocaleString()})
+              </span>
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
 }
 
 function HotspotSwitch({
@@ -124,12 +173,14 @@ function RankingViewToggle({
 
 function RankingTable({
   rows,
+  valueLabel,
   isDisabled,
   onToggle,
   onSelectRow,
   getDetail
 }: {
   rows: RankRow[];
+  valueLabel: string;
   isDisabled: (row: RankRow) => boolean;
   onToggle?: (row: RankRow) => void;
   onSelectRow?: (row: RankRow) => void;
@@ -143,7 +194,7 @@ function RankingTable({
         <span>#</span>
         <span className="sr-only">Disable</span>
         <span>Hotspot</span>
-        <span className="hotspot_table_header_peak">Peak</span>
+        <span className="hotspot_table_header_peak">{valueLabel}</span>
       </div>
       {rows.length === 0 ? (
         <div className="hotspot_empty">No infections recorded.</div>
@@ -228,65 +279,78 @@ export default function PoiRankings({
   const simdata = useMapData((s) => s.simdata);
   const papdata = useMapData((s) => s.papdata);
   const poiPeaks = useMapData((s) => s.poiPeaks);
+  const incidence = useMapData((s) => s.incidence);
+
+  // Incidence = where infection actually happened (the honest hotspot metric).
+  // When present we rank by it; older runs without it fall back to peak
+  // infected-present.
+  const useIncidence = incidence != null;
 
   const poiStats = useMemo<PoiStat[]>(() => {
-    if (!papdata?.places?.length || (!poiPeaks && !simdata)) return [];
-    const places = papdata.places;
-
-    if (poiPeaks) {
-      return places.map((place) => {
-        const peak = poiPeaks[String(place.id)];
-        return {
-          id: String(place.id),
-          label: place.label || `Place #${place.id}`,
-          category: place.top_category || 'Uncategorized',
-          peakInfected: peak?.infected ?? 0,
-          popAtPeak: peak?.population ?? 0
-        };
-      });
+    if (!papdata?.places?.length || (!poiPeaks && !simdata && !incidence)) {
+      return [];
     }
+    const places = papdata.places;
+    const placeIncidence = incidence?.places ?? {};
 
-    if (!simdata) return [];
-
+    // Peak infected-present per place, from the precomputed peaks if available,
+    // else scanned from the frames the store currently holds.
     const count = places.length;
     const peak = new Array<number>(count).fill(0);
     const popAtPeak = new Array<number>(count).fill(0);
 
-    for (const frame of Object.values(simdata)) {
-      const placeStats = frame?.p;
-      if (!placeStats) continue;
-      for (let index = 0; index < count; index += 1) {
-        const infected = placeStats[index * 2 + 1] ?? 0;
-        if (infected > peak[index]) {
-          peak[index] = infected;
-          popAtPeak[index] = placeStats[index * 2] ?? 0;
+    if (poiPeaks) {
+      places.forEach((place, index) => {
+        const p = poiPeaks[String(place.id)];
+        peak[index] = p?.infected ?? 0;
+        popAtPeak[index] = p?.population ?? 0;
+      });
+    } else if (simdata) {
+      for (const frame of Object.values(simdata)) {
+        const placeStats = frame?.p;
+        if (!placeStats) continue;
+        for (let index = 0; index < count; index += 1) {
+          const infected = placeStats[index * 2 + 1] ?? 0;
+          if (infected > peak[index]) {
+            peak[index] = infected;
+            popAtPeak[index] = placeStats[index * 2] ?? 0;
+          }
         }
       }
     }
 
-    return places.map((place, index) => ({
-      id: String(place.id),
-      label: place.label || `Place #${place.id}`,
-      category: place.top_category || 'Uncategorized',
-      peakInfected: peak[index],
-      popAtPeak: popAtPeak[index]
-    }));
-  }, [simdata, papdata, poiPeaks]);
+    return places.map((place, index) => {
+      const id = String(place.id);
+      return {
+        id,
+        label: place.label || `Place #${place.id}`,
+        category: place.top_category || 'Uncategorized',
+        peakInfected: peak[index],
+        popAtPeak: popAtPeak[index],
+        incidence: placeIncidence[id] ?? 0
+      };
+    });
+  }, [simdata, papdata, poiPeaks, incidence]);
+
+  const rankValue = useMemo(
+    () => (stat: PoiStat) => (useIncidence ? stat.incidence : stat.peakInfected),
+    [useIncidence]
+  );
 
   const poiRows = useMemo<RankRow[]>(() => {
     return poiStats
-      .filter((stat) => stat.peakInfected > 0)
-      .sort((left, right) => right.peakInfected - left.peakInfected)
+      .filter((stat) => rankValue(stat) > 0)
+      .sort((left, right) => rankValue(right) - rankValue(left))
       .slice(0, TOP_N)
       .map((stat) => ({
         id: stat.id,
         fullLabel: stat.label,
         label: truncate(stat.label),
-        value: stat.peakInfected,
-        infected: stat.peakInfected,
+        value: rankValue(stat),
+        infected: rankValue(stat),
         population: stat.popAtPeak
       }));
-  }, [poiStats]);
+  }, [poiStats, rankValue]);
 
   const typeRows = useMemo<RankRow[]>(() => {
     const byCategory = new Map<
@@ -306,7 +370,7 @@ export default function PoiRankings({
         poiCount: 0,
         poiIds: []
       };
-      aggregate.infected += stat.peakInfected;
+      aggregate.infected += rankValue(stat);
       aggregate.population += stat.popAtPeak;
       aggregate.poiCount += 1;
       aggregate.poiIds.push(stat.id);
@@ -327,15 +391,28 @@ export default function PoiRankings({
       .filter((row) => row.infected > 0)
       .sort((left, right) => right.value - left.value)
       .slice(0, TOP_N);
-  }, [poiStats]);
+  }, [poiStats, rankValue]);
+
+  const poiIncidenceTotal = useMemo(() => {
+    if (!incidence) return 0;
+    let sum = 0;
+    for (const value of Object.values(incidence.places)) {
+      sum += value;
+    }
+    return sum;
+  }, [incidence]);
 
   if (poiStats.length === 0) return null;
 
   const activeRows = activeView === 'pois' ? poiRows : typeRows;
-  const activeTitle =
-    activeView === 'pois'
+  const activeTitle = useIncidence
+    ? activeView === 'pois'
+      ? 'Where infections happened (POIs)'
+      : 'Where infections happened (POI types)'
+    : activeView === 'pois'
       ? 'Most infectious POIs'
       : 'Most infectious POI types';
+  const valueLabel = useIncidence ? 'Caught' : 'Peak';
   const activeIsDisabled =
     activeView === 'pois'
       ? (row: RankRow) => disabledPoiIds.has(row.id)
@@ -357,8 +434,13 @@ export default function PoiRankings({
             type: 'places'
           })
       : undefined;
-  const activeDetail =
-    activeView === 'pois'
+  const activeDetail = useIncidence
+    ? activeView === 'pois'
+      ? (row: RankRow) =>
+          `${row.value.toLocaleString()} infected here · ${row.population.toLocaleString()} present at peak`
+      : (row: RankRow) =>
+          `${formatPoiCount(row.poiCount ?? 0)} · ${row.value.toLocaleString()} infected`
+    : activeView === 'pois'
       ? (row: RankRow) => `${row.population.toLocaleString()} present at peak`
       : (row: RankRow) =>
           `${formatPoiCount(row.poiCount ?? 0)}, ${row.population.toLocaleString()} present at peaks`;
@@ -378,9 +460,16 @@ export default function PoiRankings({
         />
       </div>
       <div className="poi_rankings_body">
+        {useIncidence && (
+          <HomeVsPoiSummary
+            home={incidence?.home ?? 0}
+            poi={poiIncidenceTotal}
+          />
+        )}
         <h3 className="poi_rankings_subtitle">{activeTitle}</h3>
         <RankingTable
           rows={activeRows}
+          valueLabel={valueLabel}
           isDisabled={activeIsDisabled}
           onToggle={activeToggle}
           onSelectRow={activeSelect}

--- a/src/features/cz-generation/helpers.ts
+++ b/src/features/cz-generation/helpers.ts
@@ -83,6 +83,10 @@ export function endDateFromMonth(month: string): string {
     .padStart(2, '0')}-01`;
 }
 
+export function dateOnlyToUtcIso(dateStr: string): string {
+  return `${dateStr}T00:00:00.000Z`;
+}
+
 export function monthFromEndDate(endDate: string): string {
   const [yStr, mStr] = endDate.split('-');
   const y = Number(yStr);
@@ -113,12 +117,12 @@ export function formatMonthLabel(month: string): string {
 }
 
 export function getLengthHours(startDate: string, endDate: string) {
-  const start = new Date(`${startDate}T00:00:00`);
-  const end = new Date(`${endDate}T00:00:00`);
-  if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) {
+  const start = Date.parse(dateOnlyToUtcIso(startDate));
+  const end = Date.parse(dateOnlyToUtcIso(endDate));
+  if (Number.isNaN(start) || Number.isNaN(end)) {
     return null;
   }
-  return Math.ceil((end.getTime() - start.getTime()) / (1000 * 60 * 60));
+  return Math.ceil((end - start) / (1000 * 60 * 60));
 }
 
 export function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/features/cz-generation/hooks/use-zone-finalization.ts
+++ b/src/features/cz-generation/hooks/use-zone-finalization.ts
@@ -9,7 +9,10 @@ import {
   GUIDED_HARD_EXPLICIT_POPULATION,
   type ClusterAlgorithm
 } from '@/features/cz-generation/constants';
-import { getLengthHours } from '@/features/cz-generation/helpers';
+import {
+  dateOnlyToUtcIso,
+  getLengthHours
+} from '@/features/cz-generation/helpers';
 import type {
   GuidedDestinationCandidate,
   GuidedSecondOrderMetadata,
@@ -293,7 +296,7 @@ export function useZoneFinalization({
         name: cityName,
         description: descriptionToSave,
         cbg_list: selectedCBGs,
-        start_date: new Date(`${startDate}T00:00:00`).toISOString(),
+        start_date: dateOnlyToUtcIso(startDate),
         length: lengthHours,
         latitude: mapCenter?.[0] || 0,
         longitude: mapCenter?.[1] || 0,

--- a/src/features/model-map/map-data.test.mjs
+++ b/src/features/model-map/map-data.test.mjs
@@ -24,6 +24,19 @@ const square = {
   ]
 };
 
+const shiftedSquare = {
+  type: 'Polygon',
+  coordinates: [
+    [
+      [2, 0],
+      [3, 0],
+      [3, 1],
+      [2, 1],
+      [2, 0]
+    ]
+  ]
+};
+
 test('summarizeGeometry returns area and centroid for a polygon footprint', () => {
   const summary = summarizeGeometry(square, 1);
 
@@ -256,6 +269,61 @@ test('makePeopleDotGeoJSON suppresses dots at disabled POIs', () => {
   assert.equal(data.features.length, 0);
 });
 
+test('makePeopleDotGeoJSON masks enabled dots inside disabled footprints', () => {
+  resetModelMapLayoutCaches();
+
+  const data = makePeopleDotGeoJSON(
+    [
+      {
+        type: 'places',
+        id: 'enabled-overlap',
+        latitude: 0.5,
+        longitude: 0.5,
+        label: 'Enabled Same Building',
+        footprint: square,
+        icon: '🏢',
+        population: 3,
+        infected: 0
+      },
+      {
+        type: 'places',
+        id: 'enabled-outside',
+        latitude: 0.5,
+        longitude: 2.5,
+        label: 'Enabled Outside',
+        footprint: shiftedSquare,
+        icon: '🏢',
+        population: 2,
+        infected: 0
+      },
+      {
+        type: 'places',
+        id: 'disabled',
+        latitude: 0.5,
+        longitude: 0.5,
+        label: 'Disabled',
+        footprint: square,
+        icon: '🏢',
+        population: 0,
+        infected: 0,
+        disabled: true
+      }
+    ],
+    'population'
+  );
+
+  assert.equal(data.features.length, 2);
+  assert.deepEqual(
+    [...new Set(data.features.map((feature) => feature.properties.loc_id))],
+    ['enabled-outside']
+  );
+  for (const feature of data.features) {
+    const [lng, lat] = feature.geometry.coordinates;
+    assert.equal(pointInGeometry(lng, lat, shiftedSquare), true);
+    assert.equal(pointInGeometry(lng, lat, square), false);
+  }
+});
+
 test('makePersonStatusDotGeoJSON suppresses dots at disabled POIs', () => {
   const pois = [
     {
@@ -294,6 +362,89 @@ test('makePersonStatusDotGeoJSON suppresses dots at disabled POIs', () => {
 
   // Disabled POI: no person dots emitted (visitors were rerouted away).
   assert.equal(result.features.length, 0);
+});
+
+test('makePersonStatusDotGeoJSON masks enabled dots inside disabled footprints', () => {
+  resetModelMapLayoutCaches();
+
+  const pois = [
+    {
+      type: 'places',
+      id: 'enabled-overlap',
+      latitude: 0.5,
+      longitude: 0.5,
+      label: 'Enabled Same Building',
+      footprint: square,
+      icon: '🏢',
+      population: 2,
+      infected: 1
+    },
+    {
+      type: 'places',
+      id: 'enabled-outside',
+      latitude: 0.5,
+      longitude: 2.5,
+      label: 'Enabled Outside',
+      footprint: shiftedSquare,
+      icon: '🏢',
+      population: 1,
+      infected: 0
+    },
+    {
+      type: 'places',
+      id: 'disabled',
+      latitude: 0.5,
+      longitude: 0.5,
+      label: 'Disabled',
+      footprint: square,
+      icon: '🏢',
+      population: 0,
+      infected: 0,
+      disabled: true
+    }
+  ];
+  const peopleMap = {
+    time: 60,
+    requested_time: 60,
+    total_people: 3,
+    returned_people: 3,
+    sample_rate: 1,
+    locations: [
+      {
+        type: 'places',
+        id: 'enabled-overlap',
+        people: [
+          {
+            id: 'a',
+            infected: false,
+            newly_infected: false,
+            recovered: false
+          },
+          { id: 'b', infected: true, newly_infected: true, recovered: false }
+        ]
+      },
+      {
+        type: 'places',
+        id: 'enabled-outside',
+        people: [
+          {
+            id: 'c',
+            infected: false,
+            newly_infected: false,
+            recovered: false
+          }
+        ]
+      }
+    ]
+  };
+
+  const result = makePersonStatusDotGeoJSON(pois, peopleMap);
+
+  assert.equal(result.features.length, 1);
+  assert.equal(result.features[0].properties.loc_id, 'enabled-outside');
+  const [lng, lat] = result.features[0].geometry.coordinates;
+  assert.equal(pointInGeometry(lng, lat, shiftedSquare), true);
+  assert.equal(pointInGeometry(lng, lat, square), false);
 });
 
 test('makePoiFootprintGeoJSON exposes only place footprints', () => {

--- a/src/features/model-map/map-dots.ts
+++ b/src/features/model-map/map-dots.ts
@@ -2,9 +2,11 @@
 // per-person status dots, POI footprints, and POI markers. Dot layouts are
 // memoized in the shared `layoutCaches` (place-dot and person-dot caches).
 import {
+  getGeometryPoints,
   halton,
   hashString,
   hashUnit,
+  pointInGeometry,
   samplePointsInFootprint
 } from './map-geometry.ts';
 import { layoutCaches } from './map-layout-caches.ts';
@@ -32,6 +34,68 @@ const NO_FOOTPRINT_DOT_JITTER_DEGREES = 0.00025;
 // Cap on how much the no-footprint disk grows with occupancy (radius scales with
 // sqrt(count)); keeps even busy footprint-less POIs from spraying too far.
 const NO_FOOTPRINT_DISK_MAX_GROWTH = 3;
+
+type DisabledFootprintMask = {
+  geometry: GeoJSONPolygonGeometry;
+  minLng: number;
+  maxLng: number;
+  minLat: number;
+  maxLat: number;
+};
+
+function buildDisabledFootprintMasks(pois: MapPoi[]) {
+  const masks: DisabledFootprintMask[] = [];
+
+  for (const poi of pois) {
+    const footprint = poi.footprint;
+    if (
+      poi.type !== 'places' ||
+      !poi.disabled ||
+      !isFootprintGeometry(footprint)
+    ) {
+      continue;
+    }
+
+    const points = getGeometryPoints(footprint);
+    if (!points.length) continue;
+
+    let minLng = Infinity;
+    let maxLng = -Infinity;
+    let minLat = Infinity;
+    let maxLat = -Infinity;
+    for (const [lng, lat] of points) {
+      minLng = Math.min(minLng, lng);
+      maxLng = Math.max(maxLng, lng);
+      minLat = Math.min(minLat, lat);
+      maxLat = Math.max(maxLat, lat);
+    }
+
+    masks.push({ geometry: footprint, minLng, maxLng, minLat, maxLat });
+  }
+
+  return masks;
+}
+
+function isInsideDisabledFootprint(
+  lng: number,
+  lat: number,
+  masks: DisabledFootprintMask[]
+) {
+  for (const mask of masks) {
+    if (
+      lng < mask.minLng ||
+      lng > mask.maxLng ||
+      lat < mask.minLat ||
+      lat > mask.maxLat
+    ) {
+      continue;
+    }
+    if (pointInGeometry(lng, lat, mask.geometry)) {
+      return true;
+    }
+  }
+  return false;
+}
 
 function computeDiskLayout(
   centerLat: number,
@@ -73,6 +137,7 @@ export function makePeopleDotGeoJSON(pois: MapPoi[], mode: string) {
   }, 0);
   const peoplePerDot = Math.max(1, Math.ceil(totalPeople / MAX_PERSON_DOTS));
 
+  const disabledFootprintMasks = buildDisabledFootprintMasks(pois);
   const features: PeopleDotFeature[] = [];
   let reachedCap = false;
 
@@ -139,6 +204,10 @@ export function makePeopleDotGeoJSON(pois: MapPoi[], mode: string) {
         lng = poi.longitude + Math.cos(angle) * radius;
       }
 
+      if (isInsideDisabledFootprint(lng, lat, disabledFootprintMasks)) {
+        continue;
+      }
+
       features.push({
         type: 'Feature',
         properties: {
@@ -180,6 +249,7 @@ export function makePersonStatusDotGeoJSON(
     poiByKey.set(`${poi.type}:${poi.id}`, poi);
   }
 
+  const disabledFootprintMasks = buildDisabledFootprintMasks(pois);
   const features: PersonStatusDotFeature[] = [];
   for (const location of peopleMapData.locations) {
     const poi = poiByKey.get(`${location.type}:${location.id}`);
@@ -235,6 +305,15 @@ export function makePersonStatusDotGeoJSON(
       const person = sortedPeople[index];
       const slot = positions[index];
       const coordinates: Coordinate = slot ?? [poi.longitude, poi.latitude];
+      if (
+        isInsideDisabledFootprint(
+          coordinates[0],
+          coordinates[1],
+          disabledFootprintMasks
+        )
+      ) {
+        continue;
+      }
 
       features.push({
         type: 'Feature',

--- a/src/lib/chartdata-client.test.mjs
+++ b/src/lib/chartdata-client.test.mjs
@@ -1,0 +1,48 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { computeOutcomeStats } from './chartdata-client.ts';
+
+test('computeOutcomeStats subtracts explicit seed ids from new infections', () => {
+  const stats = computeOutcomeStats({
+    iot: [
+      { time: 0, Delta: 10 },
+      { time: 24, Delta: 16 }
+    ],
+    states: [
+      { time: 0, Susceptible: 90 },
+      { time: 24, Susceptible: 84 }
+    ],
+    ages: [],
+    sexes: [],
+    metadata: {
+      initial_infected_ids: [' a ', 'b', '', 'c']
+    }
+  });
+
+  assert.equal(stats.totalInfected, 16);
+  assert.equal(stats.seededInfected, 3);
+  assert.equal(stats.newInfections, 13);
+});
+
+test('computeOutcomeStats falls back to initial infected count for older runs', () => {
+  const stats = computeOutcomeStats({
+    iot: [
+      { time: 0, Delta: 5 },
+      { time: 24, Delta: 8 }
+    ],
+    states: [
+      { time: 0, Susceptible: 95 },
+      { time: 24, Susceptible: 92 }
+    ],
+    ages: [],
+    sexes: [],
+    metadata: {
+      initial_infected_count: 5
+    }
+  });
+
+  assert.equal(stats.totalInfected, 8);
+  assert.equal(stats.seededInfected, 5);
+  assert.equal(stats.newInfections, 3);
+});

--- a/src/lib/chartdata-client.ts
+++ b/src/lib/chartdata-client.ts
@@ -34,7 +34,10 @@ export async function fetchChartData(
   signal?: AbortSignal,
   onProcessing?: () => void
 ): Promise<ChartData> {
-  const url = new URL(`/api/simdata/${simId}/chartdata`, window.location.origin);
+  const url = new URL(
+    `/api/simdata/${simId}/chartdata`,
+    window.location.origin
+  );
   if (loc) {
     url.searchParams.append('loc_type', loc.type);
     url.searchParams.append('loc_id', loc.id);
@@ -49,7 +52,9 @@ export async function fetchChartData(
     }
     const json = await res.json();
     if (!res.ok) {
-      throw new Error(json?.message || `Failed to fetch chart data (${res.status})`);
+      throw new Error(
+        json?.message || `Failed to fetch chart data (${res.status})`
+      );
     }
     return json.data as ChartData;
   }
@@ -62,6 +67,10 @@ export type OutcomeStats = {
   peakTimeHours: number;
   /** Cumulative people ever infected (attack count) by the end of the run. */
   totalInfected: number;
+  /** Number of people infected at initialization. */
+  seededInfected: number;
+  /** Cumulative infections after subtracting the initial seed cohort. */
+  newInfections: number;
 };
 
 /** Active infected at a timestep = sum of the per-disease counts in `iot`. */
@@ -72,6 +81,25 @@ function activeInfected(point: DataPoint | undefined): number {
     if (key !== 'time' && typeof value === 'number') total += value;
   }
   return total;
+}
+
+function getMetadataRecord(metadata: unknown): Record<string, unknown> | null {
+  return metadata && typeof metadata === 'object'
+    ? (metadata as Record<string, unknown>)
+    : null;
+}
+
+function getSeededInfectedCount(metadata: unknown) {
+  const record = getMetadataRecord(metadata);
+  if (!record) return 0;
+
+  const ids = record.initial_infected_ids;
+  if (Array.isArray(ids)) {
+    return ids.map((id) => String(id).trim()).filter(Boolean).length;
+  }
+
+  const count = Number(record.initial_infected_count);
+  return Number.isFinite(count) ? Math.max(0, count) : 0;
 }
 
 /**
@@ -105,5 +133,14 @@ export function computeOutcomeStats(stats: ChartData): OutcomeStats {
     totalInfected = Math.max(0, population - lastSusceptible);
   }
 
-  return { peakInfected, peakTimeHours, totalInfected };
+  const seededInfected = getSeededInfectedCount(stats.metadata);
+  const newInfections = Math.max(0, totalInfected - seededInfected);
+
+  return {
+    peakInfected,
+    peakTimeHours,
+    totalInfected,
+    seededInfected,
+    newInfections
+  };
 }

--- a/src/lib/map-cache.ts
+++ b/src/lib/map-cache.ts
@@ -8,6 +8,10 @@ const CACHE_LIMIT = 4;
 export type MapCacheFrame = {
   h: number[];
   p: number[];
+  // Cumulative infection incidence emitted by the engine: home total (hinc)
+  // and per-place counts (pinc, places order). Absent on older/non-engine runs.
+  hinc?: number;
+  pinc?: number[];
 };
 
 export type PoiPeak = {
@@ -16,6 +20,12 @@ export type PoiPeak = {
 };
 
 export type PoiPeaks = Record<string, PoiPeak>;
+
+// Run-level incidence: where infection actually happened (home vs each POI).
+export type RunIncidence = {
+  home: number;
+  places: Record<string, number>;
+};
 
 type FrameIndex = {
   key: string;
@@ -29,6 +39,7 @@ export type MapCacheManifest = {
   hotspots: Record<string, number[]>;
   timesteps: number[];
   poiPeaks: PoiPeaks;
+  incidence: RunIncidence | null;
 };
 
 type CachedManifest = MapCacheManifest & {
@@ -151,6 +162,42 @@ function updatePoiPeaks(
   }
 }
 
+type IncidenceAccumulator = {
+  home: number;
+  places: Record<string, number>;
+  seen: boolean;
+};
+
+// Incidence is cumulative and monotonic, so the final frame holds the totals;
+// element-wise max across frames is robust to any frame gaps or ordering.
+function updateIncidence(
+  acc: IncidenceAccumulator,
+  places: unknown[],
+  frame: MapCacheFrame
+) {
+  const hasHome = typeof frame.hinc === 'number';
+  const pinc = frame.pinc;
+  if (!hasHome && !Array.isArray(pinc)) {
+    return;
+  }
+  acc.seen = true;
+  if (hasHome && (frame.hinc as number) > acc.home) {
+    acc.home = frame.hinc as number;
+  }
+  if (Array.isArray(pinc)) {
+    for (let index = 0; index < places.length; index += 1) {
+      const value = toNonNegativeCount(pinc[index]);
+      if (value === 0) {
+        continue;
+      }
+      const placeId = getPlaceId(places[index], index);
+      if (value > (acc.places[placeId] ?? 0)) {
+        acc.places[placeId] = value;
+      }
+    }
+  }
+}
+
 async function buildManifest(filePath: string, mtimeMs: number, size: number) {
   const raw = await readFile(filePath, 'utf8');
   const papdataIndex = raw.indexOf(PAPDATA_MARKER);
@@ -180,6 +227,11 @@ async function buildManifest(filePath: string, mtimeMs: number, size: number) {
   const frames: FrameIndex[] = [];
   const timesteps: number[] = [];
   const poiPeaks: PoiPeaks = {};
+  const incidenceAcc: IncidenceAccumulator = {
+    home: 0,
+    places: {},
+    seen: false
+  };
   const simdataContentByteStart = Buffer.byteLength(
     raw.slice(0, simdataContentStart),
     'utf8'
@@ -212,21 +264,26 @@ async function buildManifest(filePath: string, mtimeMs: number, size: number) {
       const byteLength = valueEnd - valueStart;
       frames.push({ key, time, byteStart, byteLength });
       timesteps.push(time);
-      updatePoiPeaks(
-        poiPeaks,
-        places,
-        JSON.parse(raw.slice(valueStart, valueEnd)) as MapCacheFrame
-      );
+      const parsedFrame = JSON.parse(
+        raw.slice(valueStart, valueEnd)
+      ) as MapCacheFrame;
+      updatePoiPeaks(poiPeaks, places, parsedFrame);
+      updateIncidence(incidenceAcc, places, parsedFrame);
     }
 
     position = valueEnd;
   }
+
+  const incidence: RunIncidence | null = incidenceAcc.seen
+    ? { home: incidenceAcc.home, places: incidenceAcc.places }
+    : null;
 
   const manifest = {
     papdata,
     hotspots,
     timesteps,
     poiPeaks,
+    incidence,
     frames,
     mtimeMs,
     size,
@@ -276,9 +333,9 @@ function findNearestFrame(frames: FrameIndex[], requestedTime: number) {
 export async function loadMapCacheManifest(
   filePath: string
 ): Promise<MapCacheManifest> {
-  const { papdata, hotspots, timesteps, poiPeaks } =
+  const { papdata, hotspots, timesteps, poiPeaks, incidence } =
     await getCachedManifest(filePath);
-  return { papdata, hotspots, timesteps, poiPeaks };
+  return { papdata, hotspots, timesteps, poiPeaks, incidence };
 }
 
 export async function loadMapCacheFrame(

--- a/src/lib/sim-processor.ts
+++ b/src/lib/sim-processor.ts
@@ -210,14 +210,25 @@ export async function processSimulation(opts: ProcessOpts): Promise<ChartData> {
     let tStage = nowMs();
     let homesArray: number[];
     let placesArray: number[];
+    // Engine-only cumulative incidence (home total + per-place); carried
+    // through to the map cache so the frontend can split home vs POI.
+    let homeIncidence: number | undefined;
+    let placeIncidence: number[] | undefined;
     const numericPattern = Array.isArray(
       (pvalue as unknown as { h?: unknown }).h
     );
 
     if (numericPattern) {
-      const np = pvalue as unknown as { h: number[]; p: number[] };
+      const np = pvalue as unknown as {
+        h: number[];
+        p: number[];
+        hinc?: number;
+        pinc?: number[];
+      };
       homesArray = np.h;
       placesArray = np.p;
+      homeIncidence = np.hinc;
+      placeIncidence = np.pinc;
       // Hotspot tracking from the numeric places array (inf at index 2*i+1).
       for (let i = 0; i < placeIds.length; i++) {
         const id = placeIds[i];
@@ -282,9 +293,16 @@ export async function processSimulation(opts: ProcessOpts): Promise<ChartData> {
     tStage = nowMs();
     if (!first) cacheParts.push(',');
     first = false;
-    cacheParts.push(
-      `"${skey}":${JSON.stringify({ h: homesArray, p: placesArray })}`
-    );
+    const framePayload =
+      homeIncidence !== undefined || placeIncidence !== undefined
+        ? {
+            h: homesArray,
+            p: placesArray,
+            hinc: homeIncidence ?? 0,
+            pinc: placeIncidence ?? []
+          }
+        : { h: homesArray, p: placesArray };
+    cacheParts.push(`"${skey}":${JSON.stringify(framePayload)}`);
     accum('processSimulation/cache_parts_push', tStage);
 
     // === GLOBAL STATS: per-timestep aggregation ===

--- a/src/lib/simulation-request.ts
+++ b/src/lib/simulation-request.ts
@@ -17,6 +17,7 @@ export type SimulationRequestBody = Omit<SimSettings, 'compareBaseline'> & {
   state: string;
   location: string;
   initial_infected_count: number;
+  initial_infected_ids: string[];
   disease_name: string;
   variants: string[];
   dmp_mode: DmpMode;
@@ -77,7 +78,9 @@ export async function buildSimulationRequest(
     .map((variant) => variant.trim())
     .filter(Boolean);
 
-  const matrixCsvByVariant = await fetchMatrixCsvByVariant(settings.matrix_by_variant);
+  const matrixCsvByVariant = await fetchMatrixCsvByVariant(
+    settings.matrix_by_variant
+  );
 
   // compareBaseline is a client-only UI flag; keep it out of the sim payload.
   const { compareBaseline: _compareBaseline, ...settingsForBody } = settings;

--- a/src/stores/mapdata.ts
+++ b/src/stores/mapdata.ts
@@ -38,6 +38,15 @@ export type PoiPeaks = Record<
   }
 >;
 
+// Cumulative infection incidence attributed to WHERE transmission happened
+// (from the engine): a home total plus per-place counts (keyed by place id).
+// Distinct from PoiPeaks, which is peak infected *present*. Null for old or
+// non-engine runs that never emitted it.
+export type RunIncidence = {
+  home: number;
+  places: Record<string, number>;
+};
+
 interface MapDataStore {
   name: string;
   simdata: SimData | null;
@@ -45,6 +54,7 @@ interface MapDataStore {
   hotspots: { [key: string]: number[] } | null;
   timesteps: number[] | null;
   poiPeaks: PoiPeaks | null;
+  incidence: RunIncidence | null;
 
   setName: (name: string) => void;
   setSimData: (simdata: SimData | null) => void;
@@ -52,6 +62,7 @@ interface MapDataStore {
   setHotspots: (hotspots: { [key: string]: number[] }) => void;
   setTimesteps: (timesteps: number[] | null) => void;
   setPoiPeaks: (poiPeaks: PoiPeaks | null) => void;
+  setIncidence: (incidence: RunIncidence | null) => void;
 }
 
 // Cap how many on-demand map frames the store retains. Frames stream in during
@@ -68,6 +79,7 @@ const useMapData = create<MapDataStore>((set) => ({
   hotspots: null,
   timesteps: null,
   poiPeaks: null,
+  incidence: null,
 
   setName: (name) => {
     set({ name });
@@ -75,7 +87,13 @@ const useMapData = create<MapDataStore>((set) => ({
 
   setSimData: (newSimData) => {
     if (newSimData === null) {
-      set({ simdata: null, hotspots: null, timesteps: null, poiPeaks: null });
+      set({
+        simdata: null,
+        hotspots: null,
+        timesteps: null,
+        poiPeaks: null,
+        incidence: null
+      });
       return;
     }
     set((state) => {
@@ -129,6 +147,10 @@ const useMapData = create<MapDataStore>((set) => ({
 
   setPoiPeaks: (poiPeaks) => {
     set({ poiPeaks });
+  },
+
+  setIncidence: (incidence) => {
+    set({ incidence });
   }
 }));
 

--- a/src/stores/simsettings.ts
+++ b/src/stores/simsettings.ts
@@ -37,6 +37,7 @@ export type SimSettings = {
   randseed: boolean;
   usecache: boolean;
   initial_infected_count: number;
+  initial_infected_ids: string[];
   disease_name: string;
   variants: string[];
   dmp_mode: DmpMode;
@@ -78,6 +79,7 @@ const default_settings: SimSettings = {
   randseed: true,
   usecache: true,
   initial_infected_count: 1,
+  initial_infected_ids: [],
   disease_name: 'COVID-19',
   variants: ['Delta'],
   dmp_mode: 'auto',

--- a/src/styles/simulator.css
+++ b/src/styles/simulator.css
@@ -1170,6 +1170,62 @@ div.sim_output {
   font-weight: 700;
 }
 
+.incidence_summary {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px 14px;
+  border: 1px solid rgba(61, 136, 173, 0.18);
+  border-radius: 10px;
+  background: rgba(61, 136, 173, 0.05);
+}
+
+.incidence_summary_caption {
+  margin: 0 0 2px;
+  color: var(--color-text-muted);
+  font-size: 12px;
+  line-height: 1.35;
+}
+
+.incidence_summary_row {
+  display: grid;
+  grid-template-columns: 64px 1fr auto;
+  align-items: center;
+  gap: 10px;
+}
+
+.incidence_summary_label {
+  color: var(--color-text-main);
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.incidence_summary_track {
+  height: 8px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.08);
+}
+
+.incidence_summary_fill {
+  height: 100%;
+  border-radius: 999px;
+  transition: width 0.3s ease;
+}
+
+.incidence_summary_value {
+  color: var(--color-text-main);
+  font-size: 13px;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.incidence_summary_count {
+  color: var(--color-text-muted);
+  font-weight: 500;
+}
+
 .hotspot_view_toggle {
   display: inline-flex;
   overflow: hidden;


### PR DESCRIPTION
## Summary
- switch hotspot rankings to incidence when backend incidence data is available
- show home-vs-POI transmission summary in the hotspots panel
- carry incidence through map-cache processing and simulator run loading
- add seeded-vs-new infection outcome stats, UTC date handling, and disabled-POI dot masking updates

## Validation
- pnpm test
- pnpm lint (passes with one informational existing Biome suggestion in src/lib/db-files.test.mjs)
- pnpm typecheck