### PR TITLE
Improve simulator output maps and charts

### DIFF
--- a/src/app/api/simdata/[id]/chartdata/route.ts
+++ b/src/app/api/simdata/[id]/chartdata/route.ts
@@ -1,6 +1,7 @@
 import type { NextRequest } from 'next/server';
-import { resolveDbDataPath } from '@/lib/db-files';
+import { DB_FOLDER, resolveDbDataPath } from '@/lib/db-files';
 import { streamJsonObjectEntries } from '@/lib/json-stream';
+import { loadPlaceIncidenceSeries } from '@/lib/map-cache';
 import { getCachedPapdata } from '@/lib/papdata-cache';
 import { loadDots } from '@/lib/people-map-cache';
 import { prisma } from '@/lib/prisma';
@@ -20,6 +21,7 @@ import { jsonMessage } from '@/server/api/responses';
 import { parseNonNegativeRouteNumber } from '@/server/api/route-params';
 
 const LOC_CACHE_MAX = 30;
+const POI_INCIDENCE_SERIES_KEY = 'New infections';
 interface LocCacheEntry {
   data: ChartData;
   lastAccess: number;
@@ -198,7 +200,8 @@ function buildChartFromDots(
     sortedTimes: number[];
   },
   locId: string,
-  diseaseKey: string
+  diseaseKey: string,
+  incidenceSeries?: DataPoint[] | null
 ): ChartData | null {
   const idx = dots.placeIds.indexOf(locId);
   if (idx < 0) {
@@ -226,6 +229,9 @@ function buildChartFromDots(
       Infected: infected,
       Recovered: recovered
     });
+  }
+  if (incidenceSeries && incidenceSeries.length > 0) {
+    chartData.incidence = incidenceSeries;
   }
   return chartData;
 }
@@ -289,16 +295,40 @@ export async function GET(
     // numeric SoA runs the slow streamer returns empty for). Fall back to the
     // full stream for a homes scope or runs baked without a dots file.
     if (loc_type === 'places') {
+      let incidenceSeries: DataPoint[] | null = null;
+      try {
+        incidenceSeries = await loadPlaceIncidenceSeries(
+          `${DB_FOLDER}${simdata.file_id}.map.json`,
+          loc_id,
+          POI_INCIDENCE_SERIES_KEY
+        );
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException)?.code !== 'ENOENT') {
+          console.error('POI incidence chart series failed:', error);
+        }
+      }
+
       const dots = await loadDots(simdata.file_id);
       const fast = dots
         ? buildChartFromDots(
             dots,
             loc_id,
-            diseaseKeyFromStats(simdata.global_stats)
+            diseaseKeyFromStats(simdata.global_stats),
+            incidenceSeries
           )
         : null;
       if (fast) {
         return Response.json({ data: fast });
+      }
+      if (incidenceSeries && incidenceSeries.length > 0) {
+        const chartData: ChartData = {
+          iot: [],
+          ages: [],
+          sexes: [],
+          states: [],
+          incidence: incidenceSeries
+        };
+        return Response.json({ data: chartData });
       }
     }
 

--- a/src/app/cz-generation/page.tsx
+++ b/src/app/cz-generation/page.tsx
@@ -22,11 +22,9 @@ import {
 } from '@/features/cz-generation/constants';
 import {
   clampIndex,
+  coerceDateRangeToAvailableMonths,
   dedupeCbgList,
-  endDateFromMonth,
-  monthFromDate,
-  monthFromEndDate,
-  startDateFromMonth
+  getMapSeedCbgIds
 } from '@/features/cz-generation/helpers';
 import { useCandidatePois } from '@/features/cz-generation/hooks/use-candidate-pois';
 import { useCzMetrics } from '@/features/cz-generation/hooks/use-cz-metrics';
@@ -161,18 +159,23 @@ export default function CZGeneration() {
     algorithmMetadata?.bounded_envelope
       ? algorithmMetadata
       : null;
-  const mapSeedCbgIds = useMemo(() => {
-    const source = algorithmMetadata?.seed_cbgs?.length
-      ? algorithmMetadata.seed_cbgs
-      : guidedSeedCbgs.length
-        ? guidedSeedCbgs
-        : seedCBG
-          ? [seedCBG]
-          : [];
-    return Array.from(
-      new Set(source.map((cbg) => normalizeCbgId(cbg)).filter(Boolean))
-    );
-  }, [algorithmMetadata, guidedSeedCbgs, seedCBG]);
+  const mapSeedCbgIds = useMemo(
+    () =>
+      getMapSeedCbgIds({
+        algorithmSeedCbgs: algorithmMetadata?.seed_cbgs,
+        guidedSeedCbgs,
+        resolvedSeedCbgs: resolvedSeedLookup?.seedCbgs,
+        seedCbg: seedCBG,
+        setupSeedCbgs
+      }),
+    [
+      algorithmMetadata?.seed_cbgs,
+      guidedSeedCbgs,
+      resolvedSeedLookup?.seedCbgs,
+      seedCBG,
+      setupSeedCbgs
+    ]
+  );
   const maxTraceStep = traceSteps.length > 0 ? traceSteps.length - 1 : 0;
   const activeTraceStep =
     traceSteps[clampIndex(traceStepIndex, 0, maxTraceStep)] ?? null;
@@ -441,23 +444,25 @@ export default function CZGeneration() {
   const detectedStateAbbr = getStateFromCBG(
     seedStateCbg ? [seedStateCbg] : null
   );
-  const { availableMonths, availableMonthsLoading, monthOptions } =
+  const { availableMonthsLoading, monthOptions } =
     usePatternAvailability(detectedStateAbbr);
+  const availableDateRange = useMemo(
+    () =>
+      coerceDateRangeToAvailableMonths(startDate, endDate, monthOptions),
+    [endDate, monthOptions, startDate]
+  );
 
   useEffect(() => {
-    if (availableMonths.length === 0) return;
-    const currentStart = monthFromDate(startDate);
-    const currentEnd = monthFromEndDate(endDate);
-    if (!availableMonths.includes(currentStart)) {
-      const nextStart = availableMonths[0];
-      setStartDate(startDateFromMonth(nextStart));
-      if (!availableMonths.includes(currentEnd) || currentEnd < nextStart) {
-        setEndDate(endDateFromMonth(nextStart));
-      }
-    } else if (!availableMonths.includes(currentEnd)) {
-      setEndDate(endDateFromMonth(currentStart));
+    if (!availableDateRange.changed) {
+      return;
     }
-  }, [availableMonths, startDate, endDate]);
+    setStartDate(availableDateRange.startDate);
+    setEndDate(availableDateRange.endDate);
+  }, [
+    availableDateRange.changed,
+    availableDateRange.endDate,
+    availableDateRange.startDate
+  ]);
 
   useEffect(() => {
     if (phase !== 'input') {
@@ -738,7 +743,12 @@ export default function CZGeneration() {
     setGuidedDestinationError,
     isGuidedSecondOrderAlgorithm,
     setGuidedDestinationLoading,
-    startDate,
+    startDate: availableDateRange.startDate,
+    endDate: availableDateRange.endDate,
+    availableMonths: monthOptions,
+    detectedStateAbbr,
+    setStartDate,
+    setEndDate,
     setupSeedGeoJSON,
     loadSeedGeoJson,
     setSetupSeedGeoJSON,
@@ -773,8 +783,8 @@ export default function CZGeneration() {
     saveCZHtmlMap
   } = useZoneFinalization({
     selectedCBGs,
-    startDate,
-    endDate,
+    startDate: availableDateRange.startDate,
+    endDate: availableDateRange.endDate,
     guidedSelectionMode,
     guidedSelectionSummary,
     description,
@@ -782,6 +792,7 @@ export default function CZGeneration() {
     cityName,
     location,
     seedCBG,
+    seedCbgIds: mapSeedCbgIds,
     clusterAlgorithm,
     mobilityPruneMinSeedCapturePct,
     isGuidedSecondOrderAlgorithm,
@@ -951,8 +962,8 @@ export default function CZGeneration() {
               monthOptions={monthOptions}
               availableMonthsLoading={availableMonthsLoading}
               detectedStateAbbr={detectedStateAbbr}
-              startDate={startDate}
-              endDate={endDate}
+              startDate={availableDateRange.startDate}
+              endDate={availableDateRange.endDate}
               onStartDateChange={setStartDate}
               onEndDateChange={setEndDate}
               description={description}

--- a/src/app/simulator/[run_id]/page.tsx
+++ b/src/app/simulator/[run_id]/page.tsx
@@ -27,6 +27,8 @@ import {
   formatRunDate,
   getDisabledPoiIdsFromMetadata,
   getRunSettingsFromMetadata,
+  getSeedCbgIdsForRun,
+  getSeedRegionLookupQueryForRun,
   RUN_VIEW_LABELS,
   type RunView,
   type SelectedLoc,
@@ -102,6 +104,9 @@ export default function SimulatorRun() {
     null
   );
   const [disabledRunError, setDisabledRunError] = useState<string | null>(null);
+  const [resolvedSeedRegionCbgIds, setResolvedSeedRegionCbgIds] = useState<
+    string[]
+  >([]);
   // Set when the user kicks off a disabled rerun, so the page auto-switches to
   // the rerouted run once its payload loads instead of leaving them on the
   // original (un-rerouted) run with a stale view.
@@ -115,6 +120,27 @@ export default function SimulatorRun() {
         : interventionSimId;
   const hasComparisonRuns = baselineId != null || disabledSimId != null;
   const activeViewLabel = RUN_VIEW_LABELS[activeView];
+  const activeRunMetadata =
+    activeView === 'disabled'
+      ? disabledPayload?.metadata
+      : activeView === 'baseline'
+        ? baselinePayload?.metadata
+        : interventionPayload?.metadata;
+  const seedCbgIds = useMemo(
+    () => getSeedCbgIdsForRun(selectedZone, activeRunMetadata),
+    [activeRunMetadata, selectedZone]
+  );
+  const seedRegionLookupQuery = useMemo(
+    () => getSeedRegionLookupQueryForRun(selectedZone, activeRunMetadata),
+    [activeRunMetadata, selectedZone]
+  );
+  const effectiveSeedCbgIds = useMemo(
+    () =>
+      resolvedSeedRegionCbgIds.length > seedCbgIds.length
+        ? resolvedSeedRegionCbgIds
+        : seedCbgIds,
+    [resolvedSeedRegionCbgIds, seedCbgIds]
+  );
 
   // Keep this run (and its baseline/disabled companions, so the comparison
   // survives) by marking them saved.
@@ -227,6 +253,42 @@ export default function SimulatorRun() {
     setDisabledCategories(new Set());
     setDisabledPoiIds(new Set(metadataDisabledIds));
   }, [disabledPayload?.metadata]);
+
+  useEffect(() => {
+    setResolvedSeedRegionCbgIds([]);
+    if (!seedRegionLookupQuery || seedCbgIds.length > 1) {
+      return;
+    }
+
+    const controller = new AbortController();
+    fetch('/api/lookup-location', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ location: seedRegionLookupQuery }),
+      signal: controller.signal
+    })
+      .then((response) => (response.ok ? response.json() : null))
+      .then((data) => {
+        if (controller.signal.aborted) {
+          return;
+        }
+        const seedCbgs = Array.isArray(data?.seed_cbgs)
+          ? data.seed_cbgs.filter((cbg: unknown): cbg is string => {
+              return typeof cbg === 'string' && cbg.trim().length > 0;
+            })
+          : [];
+        setResolvedSeedRegionCbgIds(seedCbgs);
+      })
+      .catch((error) => {
+        if ((error as Error)?.name !== 'AbortError') {
+          console.warn('Failed to resolve seed region CBGs:', error);
+        }
+      });
+
+    return () => {
+      controller.abort();
+    };
+  }, [seedCbgIds.length, seedRegionLookupQuery]);
 
   // After a disabled rerun completes and its payload loads, switch the map to
   // the rerouted run so the user sees the actual effect of disabling rather
@@ -737,6 +799,7 @@ export default function SimulatorRun() {
             key={activeSimId}
             selectedZone={selectedZone}
             simId={activeSimId}
+            seedCbgIds={effectiveSeedCbgIds}
             // Only paint POIs as disabled on the run that actually rerouted
             // them; the intervention/baseline runs still placed people there.
             disabledPoiIds={

--- a/src/app/simulator/[run_id]/run-metadata.test.mjs
+++ b/src/app/simulator/[run_id]/run-metadata.test.mjs
@@ -4,6 +4,8 @@ import {
   getDisabledPoiIdsFromMetadata,
   getInterventions,
   getModelPaths,
+  getSeedCbgIdsForRun,
+  getSeedRegionLookupQueryForRun,
   getRunSettingsFromMetadata,
   getStringArray
 } from './run-metadata.ts';
@@ -22,6 +24,82 @@ test('getDisabledPoiIdsFromMetadata is empty for non-objects / missing / non-arr
   assert.deepEqual(
     getDisabledPoiIdsFromMetadata({ disabled_poi_ids: 'a' }),
     []
+  );
+});
+
+test('getSeedCbgIdsForRun reads explicit seed CBG metadata', () => {
+  assert.deepEqual(
+    getSeedCbgIdsForRun(null, {
+      algorithm_metadata: {
+        seed_cbgs: ['401139400081', '401139400082', '401139400083']
+      }
+    }),
+    ['401139400081', '401139400082', '401139400083']
+  );
+});
+
+test('getSeedCbgIdsForRun reads saved explicit seed CBG description line', () => {
+  assert.deepEqual(
+    getSeedCbgIdsForRun(
+      {
+        description:
+          'Auto-generated\nSeed CBGs: 401139400081, 401139400082, 401139400083',
+        cbg_list: ['401139400084']
+      },
+      null
+    ),
+    ['401139400081', '401139400082', '401139400083']
+  );
+});
+
+test('getSeedCbgIdsForRun falls back to old guided seed count descriptions', () => {
+  assert.deepEqual(
+    getSeedCbgIdsForRun(
+      {
+        description: 'Seed CBG: 401139400081\nSeed region: 3 seed CBGs',
+        cbg_list: [
+          '401139400081',
+          '401139400082',
+          '401139400083',
+          '401139400084'
+        ]
+      },
+      null
+    ),
+    ['401139400081', '401139400082', '401139400083']
+  );
+});
+
+test('getSeedRegionLookupQueryForRun reads old guided seed labels', () => {
+  assert.equal(
+    getSeedRegionLookupQueryForRun(
+      {
+        description: 'Seed CBG: 401139400081\nSeed region: Pawhuska, OK'
+      },
+      null
+    ),
+    'Pawhuska, OK'
+  );
+  assert.equal(
+    getSeedRegionLookupQueryForRun(
+      {
+        description: 'Seed region: 3 seed CBGs'
+      },
+      null
+    ),
+    ''
+  );
+});
+
+test('getSeedRegionLookupQueryForRun falls back to generated location labels', () => {
+  assert.equal(
+    getSeedRegionLookupQueryForRun(
+      {
+        description: 'Location: Pawhuska, OK\nSeed CBG: 401139400081'
+      },
+      null
+    ),
+    'Pawhuska, OK'
   );
 });
 

--- a/src/app/simulator/[run_id]/run-metadata.ts
+++ b/src/app/simulator/[run_id]/run-metadata.ts
@@ -64,6 +64,176 @@ function asRecord(value: unknown): Record<string, unknown> | null {
     : null;
 }
 
+function normalizeCbgId(value: unknown) {
+  if (value === null || value === undefined) {
+    return '';
+  }
+
+  const raw = String(value).trim();
+  if (!/^\d+$/.test(raw)) {
+    return '';
+  }
+
+  return raw.length === 11 ? raw.padStart(12, '0') : raw;
+}
+
+function addSeedCbgIds(target: Set<string>, value: unknown) {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      addSeedCbgIds(target, item);
+    }
+    return;
+  }
+
+  const cbgId = normalizeCbgId(value);
+  if (cbgId) {
+    target.add(cbgId);
+  }
+}
+
+function addSeedCbgIdsFromDescription(target: Set<string>, value: unknown) {
+  if (typeof value !== 'string') {
+    return;
+  }
+
+  const match = value.match(/^Seed CBGs?:\s*([0-9][0-9,\s]*)\s*$/im);
+  if (match) {
+    for (const cbgId of match[1].split(/[,\s]+/)) {
+      addSeedCbgIds(target, cbgId);
+    }
+  }
+}
+
+function getSeedCbgCountFromDescription(value: unknown) {
+  if (typeof value !== 'string') {
+    return 0;
+  }
+
+  const match = value.match(/^Seed region:\s*(\d+)\s+seed CBGs?\b/im);
+  const count = Number(match?.[1]);
+  return Number.isInteger(count) && count > 0 ? count : 0;
+}
+
+function getSeedRegionLabelFromDescription(value: unknown) {
+  if (typeof value !== 'string') {
+    return '';
+  }
+
+  const match = value.match(/^Seed region:\s*(.+?)\s*$/im);
+  const label = String(match?.[1] ?? '').trim();
+  if (!label || /^\d+\s+seed CBGs?$/i.test(label)) {
+    return '';
+  }
+  return label;
+}
+
+function getLocationLabelFromDescription(value: unknown) {
+  if (typeof value !== 'string') {
+    return '';
+  }
+
+  const match = value.match(/^Location:\s*(.+?)\s*$/im);
+  const label = String(match?.[1] ?? '').trim();
+  return label && label !== 'N/A' && label.toUpperCase() !== 'TEST'
+    ? label
+    : '';
+}
+
+function addSeedCbgIdsFromRecord(
+  target: Set<string>,
+  record: Record<string, unknown> | null
+) {
+  if (!record) {
+    return;
+  }
+
+  addSeedCbgIds(target, record.seed_cbg);
+  addSeedCbgIds(target, record.seed_cbgs);
+  addSeedCbgIds(target, record.seed_cbg_id);
+  addSeedCbgIds(target, record.seed_cbg_ids);
+  addSeedCbgIdsFromDescription(target, record.description);
+
+  for (const key of [
+    'algorithm_metadata',
+    'guided_metadata',
+    'zone',
+    'czone',
+    'convenience_zone'
+  ]) {
+    addSeedCbgIdsFromRecord(target, asRecord(record[key]));
+  }
+}
+
+export function getSeedCbgIdsForRun(
+  zone:
+    | {
+        description?: string | null;
+        cbg_list?: unknown[] | null;
+      }
+    | null
+    | undefined,
+  metadata: unknown
+) {
+  const seedCbgIds = new Set<string>();
+  const seedCbgCount = getSeedCbgCountFromDescription(zone?.description);
+  const addCountedZoneSeedCbgs = () => {
+    if (seedCbgCount <= 0 || seedCbgIds.size >= seedCbgCount) {
+      return;
+    }
+    for (const cbgId of zone?.cbg_list?.slice(0, seedCbgCount) ?? []) {
+      addSeedCbgIds(seedCbgIds, cbgId);
+    }
+  };
+
+  addSeedCbgIdsFromRecord(seedCbgIds, asRecord(metadata));
+  addCountedZoneSeedCbgs();
+  if (seedCbgIds.size > 0) {
+    return [...seedCbgIds];
+  }
+
+  addSeedCbgIdsFromDescription(seedCbgIds, zone?.description);
+  addCountedZoneSeedCbgs();
+  if (seedCbgIds.size > 0) {
+    return [...seedCbgIds];
+  }
+
+  addSeedCbgIds(seedCbgIds, zone?.cbg_list?.[0]);
+  return [...seedCbgIds];
+}
+
+export function getSeedRegionLookupQueryForRun(
+  zone:
+    | {
+        description?: string | null;
+      }
+    | null
+    | undefined,
+  metadata: unknown
+) {
+  const zoneLabel = getSeedRegionLabelFromDescription(zone?.description);
+  if (zoneLabel) {
+    return zoneLabel;
+  }
+
+  const zoneLocation = getLocationLabelFromDescription(zone?.description);
+  if (zoneLocation) {
+    return zoneLocation;
+  }
+
+  const metadataRecord = asRecord(metadata);
+  for (const key of ['zone', 'czone', 'convenience_zone']) {
+    const description = asRecord(metadataRecord?.[key])?.description;
+    const label =
+      getSeedRegionLabelFromDescription(description) ||
+      getLocationLabelFromDescription(description);
+    if (label) {
+      return label;
+    }
+  }
+
+  return '';
+}
+
 export function getStringArray(value: unknown) {
   if (!Array.isArray(value)) {
     return null;

--- a/src/components/modelmap.tsx
+++ b/src/components/modelmap.tsx
@@ -16,9 +16,11 @@ import {
 } from '@/features/model-map/map-constants';
 import {
   type GeoJSONData,
+  getFeatureCbgId,
   iconLookup,
   makePeopleDotGeoJSON,
   makePersonStatusDotGeoJSON,
+  normalizeCbgId,
   type PeopleDotFeatureCollection,
   type PeopleMapData,
   type PersonStatusDotFeatureCollection,
@@ -52,10 +54,22 @@ const EMPTY_HOTSPOTS: Record<string, number[]> = {};
 // ~4.5s.
 const MAX_BUFFER_HOLDS = 6;
 
+function getSeedCbgIdsKey(seedCbgIds: readonly string[] | undefined) {
+  const normalized = new Set<string>();
+  for (const cbgId of seedCbgIds ?? []) {
+    const normalizedCbgId = normalizeCbgId(cbgId);
+    if (normalizedCbgId) {
+      normalized.add(normalizedCbgId);
+    }
+  }
+  return [...normalized].sort().join(',');
+}
+
 interface ModelMapProps {
   onMarkerClick: (info: { id: string; label: string; type: string }) => void;
   simId?: number | null;
   disabledPoiIds?: ReadonlySet<string>;
+  seedCbgIds?: string[];
   // A POI to fly the Cases map to (e.g. clicked in the hotspot rankings). The
   // `nonce` changes on every request so repeat clicks on the same POI re-fly.
   focusPoi?: { id: string; nonce: number } | null;
@@ -73,6 +87,7 @@ export default function ModelMap({
   disabledPoiIds,
   focusPoi,
   simId,
+  seedCbgIds,
   selectedZone
 }: ModelMapProps) {
   const sim_data = useMapData((state) => state.simdata);
@@ -80,7 +95,9 @@ export default function ModelMap({
   const hotspots = useMapData((state) => state.hotspots) ?? EMPTY_HOTSPOTS;
   const timesteps = useMapData((state) => state.timesteps);
   const setSimData = useMapData((state) => state.setSimData);
-  const [zoneGeoJSON, setZoneGeoJSON] = useState<GeoJSONData | null>(null);
+  const [baseZoneGeoJSON, setBaseZoneGeoJSON] = useState<GeoJSONData | null>(
+    null
+  );
 
   const [maxHours, setMaxHours] = useState(1);
   const [currentTime, setCurrentTime] = useState(() =>
@@ -110,6 +127,34 @@ export default function ModelMap({
   const [dotsBundleReady, setDotsBundleReady] = useState(false);
   const panelRef = useRef<HTMLDivElement>(null);
   const [mapFrameError, setMapFrameError] = useState<string | null>(null);
+  const seedCbgIdsKey = useMemo(
+    () => getSeedCbgIdsKey(seedCbgIds),
+    [seedCbgIds]
+  );
+  const seedCbgSet = useMemo(
+    () => new Set(seedCbgIdsKey ? seedCbgIdsKey.split(',') : []),
+    [seedCbgIdsKey]
+  );
+  const zoneGeoJSON = useMemo(() => {
+    if (!baseZoneGeoJSON?.features?.length) {
+      return null;
+    }
+
+    return {
+      ...baseZoneGeoJSON,
+      features: baseZoneGeoJSON.features.map((feature) => {
+        const cbgId = getFeatureCbgId(feature);
+        return {
+          ...feature,
+          properties: {
+            ...feature.properties,
+            _cbg_id: cbgId,
+            _is_seed_cbg: seedCbgSet.has(cbgId)
+          }
+        };
+      })
+    } satisfies GeoJSONData;
+  }, [baseZoneGeoJSON, seedCbgSet]);
 
   useEffect(() => {
     resetModelMapLayoutCaches();
@@ -156,7 +201,7 @@ export default function ModelMap({
   useEffect(() => {
     const cbgList = selectedZone?.cbg_list?.filter(Boolean) ?? [];
     if (cbgList.length === 0) {
-      setZoneGeoJSON(null);
+      setBaseZoneGeoJSON(null);
       return;
     }
 
@@ -170,7 +215,7 @@ export default function ModelMap({
       .then((resp) => (resp.ok ? resp.json() : null))
       .then((data) => {
         if (!controller.signal.aborted) {
-          setZoneGeoJSON(data?.features?.length ? data : null);
+          setBaseZoneGeoJSON(data?.features?.length ? data : null);
         }
       })
       .catch((err) => {

--- a/src/components/outputgraphs.tsx
+++ b/src/components/outputgraphs.tsx
@@ -16,6 +16,7 @@ import {
   XAxis,
   YAxis
 } from 'recharts';
+import { ArrowLeft } from 'lucide-react';
 import {
   currentInfectionsAtPoint,
   fetchChartData
@@ -40,6 +41,7 @@ const COLORS = [
 const BASELINE_SUFFIX = ' (baseline)';
 const DISABLED_POI_SUFFIX = ' (disabled POIs)';
 const ACTIVE_INFECTIONS_KEY = 'Active infections';
+const POI_INCIDENCE_SERIES_KEY = 'New infections';
 const DEFAULT_HIDDEN_STATE_METRICS = new Set([
   'Infected',
   'Infectious',
@@ -48,6 +50,7 @@ const DEFAULT_HIDDEN_STATE_METRICS = new Set([
 ]);
 
 const SERIES_COLORS: Record<string, string> = {
+  [POI_INCIDENCE_SERIES_KEY]: '#e8485a',
   [ACTIVE_INFECTIONS_KEY]: '#3d88ad',
   Removed: '#e8485a',
   Infected: '#64748b',
@@ -63,6 +66,15 @@ const CHART_TYPE_OPTIONS = [
     value: 'iot',
     label: 'Infectiousness',
     heading: 'Infectiousness over time'
+  },
+  { value: 'states', label: 'States', heading: 'Disease states' }
+] as const;
+
+const POI_CHART_TYPE_OPTIONS = [
+  {
+    value: 'iot',
+    label: 'Incidence',
+    heading: 'Infection incidence over time'
   },
   { value: 'states', label: 'States', heading: 'Disease states' }
 ] as const;
@@ -144,11 +156,13 @@ const SCENARIOS: Record<
 function ChartLines({
   data,
   seriesDefs,
-  hiddenLines
+  hiddenLines,
+  yAxisLabel = 'People'
 }: {
   data: DataPoint[];
   seriesDefs: SeriesDef[];
   hiddenLines: Set<string>;
+  yAxisLabel?: string;
 }) {
   return (
     <ResponsiveContainer width="100%" height="100%">
@@ -172,7 +186,7 @@ function ChartLines({
         />
         <YAxis
           label={{
-            value: 'People',
+            value: yAxisLabel,
             angle: -90,
             position: 'insideLeft'
           }}
@@ -293,14 +307,32 @@ function withActiveInfectionsSeries(
   });
 }
 
-function getChartSeries(data: ChartData | null, chartType: ChartType) {
+function getDataSeries(data: ChartData, key: string): DataPoint[] {
+  const series = data[key];
+  return Array.isArray(series) ? (series as DataPoint[]) : [];
+}
+
+function getChartSeries(
+  data: ChartData | null,
+  chartType: ChartType,
+  preferIncidence = false
+) {
   if (!data) {
     return [];
   }
-  if (chartType !== 'states') {
-    return data[chartType] ?? [];
+  if (preferIncidence && chartType === 'iot') {
+    const incidence = getDataSeries(data, 'incidence');
+    if (incidence.length > 0) {
+      return incidence;
+    }
   }
-  return withActiveInfectionsSeries(data.states ?? [], data.iot ?? []);
+  if (chartType !== 'states') {
+    return getDataSeries(data, chartType);
+  }
+  return withActiveInfectionsSeries(
+    getDataSeries(data, 'states'),
+    getDataSeries(data, 'iot')
+  );
 }
 
 function hasSeriesData(data: DataPoint[], key: string) {
@@ -478,7 +510,13 @@ export default function OutputGraphs({
   const hasBaseline = baselineSimId != null && baselineData != null;
   const hasDisabledPoi = disabledPoiSimId != null && disabledPoiData != null;
   const hasComparisons = hasBaseline || hasDisabledPoi;
-  const activeChart = CHART_TYPE_OPTIONS.find(
+  const selectedPoi = selected_loc?.type === 'places';
+  const chartTypeOptions = selectedPoi
+    ? POI_CHART_TYPE_OPTIONS
+    : CHART_TYPE_OPTIONS;
+  const prefersIncidenceSeries = selectedPoi && chartType === 'iot';
+  const yAxisLabel = prefersIncidenceSeries ? 'New infections' : 'People';
+  const activeChart = chartTypeOptions.find(
     (option) => option.value === chartType
   );
 
@@ -487,12 +525,16 @@ export default function OutputGraphs({
     seriesDefs: SeriesDef[];
     splitCharts: SplitChart[];
   }>(() => {
-    const primarySeries = getChartSeries(chartData, chartType);
+    const primarySeries = getChartSeries(
+      chartData,
+      chartType,
+      prefersIncidenceSeries
+    );
     const baselineSeries = hasBaseline
-      ? getChartSeries(baselineData, chartType)
+      ? getChartSeries(baselineData, chartType, prefersIncidenceSeries)
       : [];
     const disabledPoiSeries = hasDisabledPoi
-      ? getChartSeries(disabledPoiData, chartType)
+      ? getChartSeries(disabledPoiData, chartType, prefersIncidenceSeries)
       : [];
     const baseKeys = getOrderedSeriesKeys(
       [...primarySeries, ...baselineSeries, ...disabledPoiSeries],
@@ -571,7 +613,9 @@ export default function OutputGraphs({
     ];
 
     for (const comparison of comparisons) {
-      const comparisonSeries = comparison.data?.[chartType] ?? [];
+      const comparisonSeries = comparison.data
+        ? getChartSeries(comparison.data, chartType, prefersIncidenceSeries)
+        : [];
       const scenario = SCENARIOS[comparison.scenario];
       for (const point of comparisonSeries) {
         const merged = byTime.get(point.time) ?? { time: point.time };
@@ -587,7 +631,7 @@ export default function OutputGraphs({
       ...baseKeys.map((key) => ({
         key,
         metricKey: key,
-        label: key,
+        label: getMetricLabel(chartType, key),
         scenario: 'selected' as const,
         color: colorOf(key),
         strokeWidth: SCENARIOS.selected.strokeWidth
@@ -621,7 +665,8 @@ export default function OutputGraphs({
     disabledPoiData,
     hasBaseline,
     hasComparisons,
-    hasDisabledPoi
+    hasDisabledPoi,
+    prefersIncidenceSeries
   ]);
 
   const legendSeriesDefs = useMemo(() => {
@@ -680,30 +725,42 @@ export default function OutputGraphs({
               )}
             </div>
           </div>
-          <div
-            className="outputgraph_segmented"
-            role="tablist"
-            aria-label="Chart type"
-          >
-            {CHART_TYPE_OPTIONS.map((option) => (
-              <button
-                type="button"
-                role="tab"
-                aria-selected={chartType === option.value}
-                className={
-                  chartType === option.value
-                    ? 'outputgraph_segment is-active'
-                    : 'outputgraph_segment'
-                }
-                key={option.value}
-                onClick={() => {
-                  setChartType(option.value);
-                  setLineVisibilityOverrides(new Map());
-                }}
+          <div className="outputgraph_header_actions">
+            {selected_loc && (
+              <Button
+                variant="secondary"
+                className="outputgraph_back_button"
+                onClick={onReset}
               >
-                {option.label}
-              </button>
-            ))}
+                <ArrowLeft size={16} aria-hidden="true" />
+                <span>All infection graphs</span>
+              </Button>
+            )}
+            <div
+              className="outputgraph_segmented"
+              role="tablist"
+              aria-label="Chart type"
+            >
+              {chartTypeOptions.map((option) => (
+                <button
+                  type="button"
+                  role="tab"
+                  aria-selected={chartType === option.value}
+                  className={
+                    chartType === option.value
+                      ? 'outputgraph_segment is-active'
+                      : 'outputgraph_segment'
+                  }
+                  key={option.value}
+                  onClick={() => {
+                    setChartType(option.value);
+                    setLineVisibilityOverrides(new Map());
+                  }}
+                >
+                  {option.label}
+                </button>
+              ))}
+            </div>
           </div>
         </div>
         {chartError ? (
@@ -744,6 +801,7 @@ export default function OutputGraphs({
                           data={chart.data}
                           seriesDefs={chartSeriesDefs}
                           hiddenLines={hiddenLines}
+                          yAxisLabel={yAxisLabel}
                         />
                       </div>
                     </section>
@@ -756,6 +814,7 @@ export default function OutputGraphs({
                   data={mergedData}
                   seriesDefs={legendSeriesDefs}
                   hiddenLines={hiddenLines}
+                  yAxisLabel={yAxisLabel}
                 />
               </div>
             )}
@@ -767,17 +826,6 @@ export default function OutputGraphs({
           </>
         )}
       </section>
-      {selected_loc && (
-        <div className="outputgraph_reset">
-          <Button
-            variant="destructive"
-            className="px-4! py-2!"
-            onClick={onReset}
-          >
-            Reset Selection
-          </Button>
-        </div>
-      )}
     </div>
   );
 }

--- a/src/features/cz-generation/constants.ts
+++ b/src/features/cz-generation/constants.ts
@@ -43,6 +43,8 @@ export const EMPTY_LIST: TraceCandidate[] = [];
 
 export const CBG_GEOJSON_REQUEST_CHUNK_SIZE = 75;
 export const INITIAL_SEED_EDIT_NEIGHBOR_RINGS = 2;
+export const PATTERN_AVAILABILITY_START_DATE = '2018-01-01';
+export const PATTERN_AVAILABILITY_END_DATE = '2025-12-31';
 
 export const GUIDED_REGION_PALETTE: GuidedSelectionStyle[] = [
   { fillColor: '#f59e0b', lineColor: '#b45309' },

--- a/src/features/cz-generation/helpers.test.mjs
+++ b/src/features/cz-generation/helpers.test.mjs
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { getMapSeedCbgIds } from './helpers.ts';
+
+test('getMapSeedCbgIds uses resolved seed region before single core seed', () => {
+  assert.deepEqual(
+    getMapSeedCbgIds({
+      resolvedSeedCbgs: ['401139400081', '401139400082', '401139400083'],
+      seedCbg: '401139400081'
+    }),
+    ['401139400081', '401139400082', '401139400083']
+  );
+});
+
+test('getMapSeedCbgIds uses edited setup seed region before resolved lookup', () => {
+  assert.deepEqual(
+    getMapSeedCbgIds({
+      resolvedSeedCbgs: ['401139400081', '401139400082', '401139400083'],
+      setupSeedCbgs: ['401139400082', '401139400084'],
+      seedCbg: '401139400081'
+    }),
+    ['401139400082', '401139400084']
+  );
+});
+
+test('getMapSeedCbgIds uses guided seed region before setup seed region', () => {
+  assert.deepEqual(
+    getMapSeedCbgIds({
+      guidedSeedCbgs: ['401139400085', '401139400086'],
+      setupSeedCbgs: ['401139400081', '401139400082'],
+      seedCbg: '401139400081'
+    }),
+    ['401139400085', '401139400086']
+  );
+});

--- a/src/features/cz-generation/helpers.ts
+++ b/src/features/cz-generation/helpers.ts
@@ -2,11 +2,11 @@ import {
   type GeoJSONData,
   getFeatureCbgId,
   normalizeCbgId
-} from '@/lib/cz-geo';
+} from '../../lib/cz-geo.ts';
 import {
   CLUSTER_ALGORITHM_OPTIONS,
   type ClusterAlgorithm
-} from './constants';
+} from './constants.ts';
 
 export function isClusterAlgorithm(
   value: unknown
@@ -22,6 +22,29 @@ export function dedupeCbgList(values: string[]) {
   return Array.from(
     new Set(values.map((value) => normalizeCbgId(value)).filter(Boolean))
   );
+}
+
+export function getMapSeedCbgIds({
+  algorithmSeedCbgs,
+  guidedSeedCbgs,
+  resolvedSeedCbgs,
+  seedCbg,
+  setupSeedCbgs
+}: {
+  algorithmSeedCbgs?: string[] | null;
+  guidedSeedCbgs?: string[] | null;
+  resolvedSeedCbgs?: string[] | null;
+  seedCbg?: string | null;
+  setupSeedCbgs?: string[] | null;
+}) {
+  const source =
+    (guidedSeedCbgs?.length ? guidedSeedCbgs : null) ??
+    (setupSeedCbgs?.length ? setupSeedCbgs : null) ??
+    (resolvedSeedCbgs?.length ? resolvedSeedCbgs : null) ??
+    (algorithmSeedCbgs?.length ? algorithmSeedCbgs : null) ??
+    (seedCbg ? [seedCbg] : []);
+
+  return dedupeCbgList(source);
 }
 
 export function sameStringArray(a: string[], b: string[]) {
@@ -99,6 +122,48 @@ export function monthFromEndDate(endDate: string): string {
   return `${prevYear.toString().padStart(4, '0')}-${prevMonth
     .toString()
     .padStart(2, '0')}`;
+}
+
+export function normalizeAvailableMonths(availableMonths: string[]) {
+  return Array.from(
+    new Set(
+      availableMonths.filter((month) => /^\d{4}-\d{2}$/.test(month))
+    )
+  ).sort();
+}
+
+export function coerceDateRangeToAvailableMonths(
+  startDate: string,
+  endDate: string,
+  availableMonths: string[]
+) {
+  const months = normalizeAvailableMonths(availableMonths);
+  if (months.length === 0) {
+    return {
+      startDate,
+      endDate,
+      changed: false
+    };
+  }
+
+  let nextStartMonth = monthFromDate(startDate);
+  if (!months.includes(nextStartMonth)) {
+    nextStartMonth = months[0];
+  }
+
+  let nextEndMonth = monthFromEndDate(endDate);
+  if (!months.includes(nextEndMonth) || nextEndMonth < nextStartMonth) {
+    nextEndMonth = nextStartMonth;
+  }
+
+  const nextStartDate = startDateFromMonth(nextStartMonth);
+  const nextEndDate = endDateFromMonth(nextEndMonth);
+
+  return {
+    startDate: nextStartDate,
+    endDate: nextEndDate,
+    changed: nextStartDate !== startDate || nextEndDate !== endDate
+  };
 }
 
 export function formatMonthLabel(month: string): string {

--- a/src/features/cz-generation/hooks/use-generation-preview-submit.ts
+++ b/src/features/cz-generation/hooks/use-generation-preview-submit.ts
@@ -1,15 +1,22 @@
 import { useCallback, type FormEvent } from 'react';
 import {
+  fetchPatternAvailability,
   fetchSecondOrderDestinations,
   getClusteringProgressUrl,
   lookupLocation,
   startClusteringPreview
 } from '@/features/cz-generation/api';
-import type { ClusterAlgorithm } from '@/features/cz-generation/constants';
 import {
+  PATTERN_AVAILABILITY_END_DATE,
+  PATTERN_AVAILABILITY_START_DATE,
+  type ClusterAlgorithm
+} from '@/features/cz-generation/constants';
+import {
+  coerceDateRangeToAvailableMonths,
   dedupeCbgList,
   getPayloadErrorMessage,
   isClusterAlgorithm,
+  normalizeAvailableMonths,
   isRecord
 } from '@/features/cz-generation/helpers';
 import type {
@@ -25,6 +32,7 @@ import {
   getBoundsForGeoJson,
   mergeGeoJsonFeatures
 } from '@/lib/cz-geo';
+import { getStateFromCBG } from '@/lib/simulation-zone';
 
 type Phase = 'input' | 'edit' | 'finalizing';
 
@@ -50,6 +58,11 @@ type UseGenerationPreviewSubmitParams = {
   isGuidedSecondOrderAlgorithm: boolean;
   setGuidedDestinationLoading: (value: boolean) => void;
   startDate: string;
+  endDate: string;
+  availableMonths: string[];
+  detectedStateAbbr: string | null;
+  setStartDate: (value: string) => void;
+  setEndDate: (value: string) => void;
   setupSeedGeoJSON: GeoJSONData | null;
   loadSeedGeoJson: (
     seedCbgs: string[],
@@ -100,6 +113,11 @@ export function useGenerationPreviewSubmit({
   isGuidedSecondOrderAlgorithm,
   setGuidedDestinationLoading,
   startDate,
+  endDate,
+  availableMonths,
+  detectedStateAbbr,
+  setStartDate,
+  setEndDate,
   setupSeedGeoJSON,
   loadSeedGeoJson,
   setSetupSeedGeoJSON,
@@ -219,6 +237,20 @@ export function useGenerationPreviewSubmit({
     []
   );
 
+  const loadAvailableMonthsForState = useCallback(async (stateAbbr: string) => {
+    const resp = await fetchPatternAvailability({
+      state: stateAbbr,
+      startDate: PATTERN_AVAILABILITY_START_DATE,
+      endDate: PATTERN_AVAILABILITY_END_DATE
+    });
+    const months = Array.isArray(resp?.data?.available_months)
+      ? resp.data.available_months.filter(
+          (month): month is string => typeof month === 'string'
+        )
+      : [];
+    return normalizeAvailableMonths(months);
+  }, []);
+
   return useCallback(
     async (event: FormEvent<HTMLFormElement>) => {
       event.preventDefault();
@@ -302,13 +334,38 @@ export function useGenerationPreviewSubmit({
       setSelectedGuidedDestinationIds([]);
       setGuidedDestinationError('');
 
+      let submissionStartDate = startDate;
+
       try {
+        if (!isTestMode && coreCbg) {
+          const seedStateAbbr = getStateFromCBG([coreCbg]);
+          let monthsForSeed =
+            seedStateAbbr && seedStateAbbr === detectedStateAbbr
+              ? availableMonths
+              : [];
+
+          if (seedStateAbbr && monthsForSeed.length === 0) {
+            monthsForSeed = await loadAvailableMonthsForState(seedStateAbbr);
+          }
+
+          const coercedRange = coerceDateRangeToAvailableMonths(
+            startDate,
+            endDate,
+            monthsForSeed
+          );
+          submissionStartDate = coercedRange.startDate;
+          if (coercedRange.changed) {
+            setStartDate(coercedRange.startDate);
+            setEndDate(coercedRange.endDate);
+          }
+        }
+
         if (isGuidedSecondOrderAlgorithm) {
           setGuidedDestinationLoading(true);
           const data = await fetchSecondOrderDestinations({
             cbg: coreCbg,
             seed_cbgs: resolvedSeedCbgs,
-            start_date: startDate,
+            start_date: submissionStartDate,
             use_test_data: isTestMode,
             limit: 12
           });
@@ -401,7 +458,7 @@ export function useGenerationPreviewSubmit({
         const clusterReq: Record<string, unknown> = {
           min_pop: Number(minPop),
           algorithm: clusterAlgorithm,
-          start_date: startDate,
+          start_date: submissionStartDate,
           use_test_data: isTestMode,
           include_trace: true
         };
@@ -529,8 +586,12 @@ export function useGenerationPreviewSubmit({
       }
     },
     [
+      availableMonths,
       clusterAlgorithm,
+      detectedStateAbbr,
+      endDate,
       isGuidedSecondOrderAlgorithm,
+      loadAvailableMonthsForState,
       loadSeedGeoJson,
       loading,
       location,
@@ -558,11 +619,13 @@ export function useGenerationPreviewSubmit({
       setResolvedSeedLookup,
       setSeedCBG,
       setSeedEditMode,
+      setEndDate,
       setSeedGuardDistanceKm,
       setSelectedCBGs,
       setSelectedGuidedDestinationIds,
       setSelectedTraceCandidateCbg,
       setSetupSeedGeoJSON,
+      setStartDate,
       setTotalPopulation,
       setTraceEnabled,
       setTraceStepIndex,

--- a/src/features/cz-generation/hooks/use-pattern-availability.ts
+++ b/src/features/cz-generation/hooks/use-pattern-availability.ts
@@ -1,5 +1,10 @@
 import { useEffect, useMemo, useState } from 'react';
 import { fetchPatternAvailability } from '@/features/cz-generation/api';
+import {
+  PATTERN_AVAILABILITY_END_DATE,
+  PATTERN_AVAILABILITY_START_DATE
+} from '@/features/cz-generation/constants';
+import { normalizeAvailableMonths } from '@/features/cz-generation/helpers';
 
 export function usePatternAvailability(detectedStateAbbr: string | null) {
   const [availableMonths, setAvailableMonths] = useState<string[]>([]);
@@ -19,8 +24,8 @@ export function usePatternAvailability(detectedStateAbbr: string | null) {
     fetchPatternAvailability(
       {
         state: detectedStateAbbr,
-        startDate: '2018-01-01',
-        endDate: '2025-12-31'
+        startDate: PATTERN_AVAILABILITY_START_DATE,
+        endDate: PATTERN_AVAILABILITY_END_DATE
       },
       controller.signal
     )
@@ -29,8 +34,10 @@ export function usePatternAvailability(detectedStateAbbr: string | null) {
           return;
         }
         const months = Array.isArray(resp?.data?.available_months)
-          ? resp.data.available_months.filter(
-              (month): month is string => typeof month === 'string'
+          ? normalizeAvailableMonths(
+              resp.data.available_months.filter(
+                (month): month is string => typeof month === 'string'
+              )
             )
           : [];
         setAvailableMonths(months);

--- a/src/features/cz-generation/hooks/use-zone-finalization.ts
+++ b/src/features/cz-generation/hooks/use-zone-finalization.ts
@@ -19,6 +19,7 @@ import type {
   GuidedSelectionSummary
 } from '@/features/cz-generation/types';
 import { useSession } from '@/lib/auth-client';
+import { normalizeCbgId } from '@/lib/cz-geo';
 import {
   createGuestZoneClaimToken,
   rememberGuestZoneClaim
@@ -38,6 +39,7 @@ type UseZoneFinalizationParams = {
   cityName: string;
   location: string;
   seedCBG: string;
+  seedCbgIds: string[];
   clusterAlgorithm: ClusterAlgorithm;
   mobilityPruneMinSeedCapturePct: number;
   isGuidedSecondOrderAlgorithm: boolean;
@@ -156,6 +158,7 @@ export function useZoneFinalization({
   cityName,
   location,
   seedCBG,
+  seedCbgIds,
   clusterAlgorithm,
   mobilityPruneMinSeedCapturePct,
   isGuidedSecondOrderAlgorithm,
@@ -220,11 +223,17 @@ export function useZoneFinalization({
         CLUSTER_ALGORITHM_OPTIONS.find(
           (option) => option.value === clusterAlgorithm
         )?.label || clusterAlgorithm;
+      const normalizedSeedCbgIds = Array.from(
+        new Set(seedCbgIds.map((cbg) => normalizeCbgId(cbg)).filter(Boolean))
+      );
 
       const generatedDescription = [
         `Auto-generated on ${now.toLocaleString()}`,
         `Location: ${cityName || location || 'N/A'}`,
-        `Seed CBG: ${seedCBG || 'N/A'}`,
+        `Seed CBG: ${seedCBG || normalizedSeedCbgIds[0] || 'N/A'}`,
+        ...(normalizedSeedCbgIds.length > 1
+          ? [`Seed CBGs: ${normalizedSeedCbgIds.join(', ')}`]
+          : []),
         `Algorithm: ${algorithmLabel}`,
         clusterAlgorithm === 'mobility_prune'
           ? `Minimum seed movement captured: ${Number(

--- a/src/features/model-map/clustered-map.tsx
+++ b/src/features/model-map/clustered-map.tsx
@@ -37,6 +37,10 @@ import type {
 } from '@/features/model-map/map-types';
 
 const DISABLED_POI_COLOR = '#111827';
+const ZONE_CBG_FILL_COLOR = '#2563eb';
+const ZONE_CBG_LINE_COLOR = '#1d4ed8';
+const SEED_CBG_FILL_COLOR = '#10b981';
+const SEED_CBG_LINE_COLOR = '#065f46';
 
 interface ClusteredMapProps {
   currentTime: number;
@@ -417,15 +421,30 @@ export default function ClusteredMap({
               id="zone-cbgs-fill"
               type="fill"
               paint={{
-                'fill-color': '#2563eb',
-                'fill-opacity': 0.08
+                'fill-color': [
+                  'case',
+                  ['boolean', ['get', '_is_seed_cbg'], false],
+                  SEED_CBG_FILL_COLOR,
+                  ZONE_CBG_FILL_COLOR
+                ] as const,
+                'fill-opacity': [
+                  'case',
+                  ['boolean', ['get', '_is_seed_cbg'], false],
+                  0.16,
+                  0.08
+                ] as const
               }}
             />
             <Layer
               id="zone-cbgs-outline"
               type="line"
               paint={{
-                'line-color': '#1d4ed8',
+                'line-color': [
+                  'case',
+                  ['boolean', ['get', '_is_seed_cbg'], false],
+                  SEED_CBG_LINE_COLOR,
+                  ZONE_CBG_LINE_COLOR
+                ] as const,
                 'line-width': [
                   'interpolate',
                   ['linear'],
@@ -801,7 +820,12 @@ export default function ClusteredMap({
               id="zone-cbgs-top-outline"
               type="line"
               paint={{
-                'line-color': '#1d4ed8',
+                'line-color': [
+                  'case',
+                  ['boolean', ['get', '_is_seed_cbg'], false],
+                  SEED_CBG_LINE_COLOR,
+                  ZONE_CBG_LINE_COLOR
+                ] as const,
                 'line-width': [
                   'interpolate',
                   ['linear'],

--- a/src/lib/map-cache.ts
+++ b/src/lib/map-cache.ts
@@ -1,4 +1,5 @@
 import { open, readFile, stat } from 'node:fs/promises';
+import type { DataPoint } from './simulation-data';
 
 const PAPDATA_MARKER = ',"papdata":';
 const SIMDATA_MARKER = ',"simdata":';
@@ -336,6 +337,63 @@ export async function loadMapCacheManifest(
   const { papdata, hotspots, timesteps, poiPeaks, incidence } =
     await getCachedManifest(filePath);
   return { papdata, hotspots, timesteps, poiPeaks, incidence };
+}
+
+export async function loadPlaceIncidenceSeries(
+  filePath: string,
+  locId: string,
+  seriesKey = 'New infections'
+): Promise<DataPoint[] | null> {
+  const manifest = await getCachedManifest(filePath);
+  const places = getPapdataPlaces(manifest.papdata);
+  const placeIndex = places.findIndex(
+    (place, index) => getPlaceId(place, index) === locId
+  );
+
+  if (placeIndex < 0) {
+    return null;
+  }
+
+  const file = await open(filePath, 'r');
+  const series: DataPoint[] = [];
+  let previousCumulative = 0;
+  let sawIncidence = false;
+
+  try {
+    for (const frameIndex of manifest.frames) {
+      const buffer = Buffer.alloc(frameIndex.byteLength);
+      let bytesRead = 0;
+      while (bytesRead < frameIndex.byteLength) {
+        const result = await file.read(
+          buffer,
+          bytesRead,
+          frameIndex.byteLength - bytesRead,
+          frameIndex.byteStart + bytesRead
+        );
+        if (result.bytesRead === 0) {
+          throw new Error('Unexpected end of map cache frame.');
+        }
+        bytesRead += result.bytesRead;
+      }
+
+      const frame = JSON.parse(buffer.toString('utf8')) as MapCacheFrame;
+      if (!Array.isArray(frame.pinc)) {
+        continue;
+      }
+
+      sawIncidence = true;
+      const cumulative = toNonNegativeCount(frame.pinc[placeIndex]);
+      series.push({
+        time: frameIndex.time / 60,
+        [seriesKey]: Math.max(0, cumulative - previousCumulative)
+      });
+      previousCumulative = cumulative;
+    }
+  } finally {
+    await file.close();
+  }
+
+  return sawIncidence ? series : null;
 }
 
 export async function loadMapCacheFrame(

--- a/src/styles/outputgraphs.css
+++ b/src/styles/outputgraphs.css
@@ -52,6 +52,21 @@ div.outputgraph_chart {
   white-space: nowrap;
 }
 
+.outputgraph_header_actions {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: flex-start;
+  gap: 10px;
+}
+
+.outputgraph_back_button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 34px;
+  white-space: nowrap;
+}
+
 .outputgraph_segmented {
   display: inline-flex;
   flex: 0 0 auto;
@@ -196,12 +211,6 @@ div.outputgraph_chart {
   text-align: center;
 }
 
-.outputgraph_reset {
-  display: flex;
-  justify-content: center;
-  margin-top: 12px;
-}
-
 @media (max-width: 768px) {
   div.outputgraphs_container {
     width: 100%;
@@ -216,8 +225,18 @@ div.outputgraph_chart {
     gap: 12px;
   }
 
-  .outputgraph_segmented {
+  .outputgraph_header_actions {
     width: 100%;
+    flex-wrap: wrap;
+  }
+
+  .outputgraph_back_button {
+    flex: 1 1 180px;
+    justify-content: center;
+  }
+
+  .outputgraph_segmented {
+    flex: 1 1 220px;
     overflow-x: auto;
   }
 


### PR DESCRIPTION
## Summary
- Preserve multi-CBG seed regions from convenience-zone generation and render seed CBGs green in simulator and infection maps.
- Recover seed CBG ids from run metadata, descriptions, and legacy location labels so old and new runs display consistently.
- Add POI incidence chart support from map-cache data and refine output graph controls.
- Normalize CZ pattern availability dates and months during generation.

## Testing
- pnpm typecheck
- pnpm test
- pnpm lint (passes with existing style note in src/lib/db-files.test.mjs)
- git diff --check